### PR TITLE
ci: drop redundant push-to-main trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
+  # CI runs on PRs only.  The merge commit on main is byte-for-byte
+  # identical to the PR's last-tested commit, so re-testing on push to
+  # main catches nothing new -- but doubles CI usage per merge, and
+  # quadruples it across a feature-PR -> release-PR cycle.  Branch
+  # protection requires PR review, so direct pushes to main are not a
+  # supported flow.  release-please still fires on push to main via
+  # release.yml; that workflow is unaffected.
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

CI was firing twice per merge — once on the PR and again on the merge commit pushed to main. The merge commit is byte-for-byte identical to the PR's last-tested commit, so the post-merge run catches nothing new but doubles CI usage.

Across a typical feature-PR → release-PR cycle this was **4 full CI runs × 3 jobs = 12 job executions** for code that did not meaningfully change between them. Removing the `push` trigger from `ci.yml` cuts that in half.

## Trade-off

Direct pushes to main no longer get tested. This repo's CLAUDE.md documents a PR-only workflow and branch protection enforces it, so direct pushes aren't a supported flow.

`release.yml` still triggers on push to main — release-please needs that to open release PRs. Unaffected.

## Test plan

- [ ] CI passes on this PR (verifies `pull_request` trigger still works)
- [ ] After merge, no second CI run fires on the merge commit
- [ ] Next release-please PR opens normally and gets its own CI run