### PR TITLE
feat: faster + more visual target-type picking across avy/embark/tap

### DIFF
--- a/modules/completion/embark.el
+++ b/modules/completion/embark.el
@@ -807,6 +807,85 @@ after embark-act's prompt exits."
 
   (define-key embark-general-map (kbd "C-l") #'zetta-embark-pick-target-type)
 
+  (defun zetta-embark--assign-type-keys (types)
+    "Assign unique single-char keys to TYPES (list of symbols).
+
+For each TYPE, try each char of its symbol-name in order; pick the
+first alphanumeric char not already taken.  When all chars of a name
+are taken, fall back to the next free char from a-z.  Returns an
+alist of (CHAR . TYPE) preserving TYPES order."
+    (let ((used (make-hash-table))
+          result)
+      (dolist (type types)
+        (let* ((name (symbol-name type))
+               (key (or (cl-some
+                         (lambda (c)
+                           (and (or (and (>= c ?a) (<= c ?z))
+                                    (and (>= c ?0) (<= c ?9)))
+                                (not (gethash c used))
+                                c))
+                         (string-to-list name))
+                        (cl-some
+                         (lambda (c)
+                           (unless (gethash c used) c))
+                         (number-sequence ?a ?z)))))
+          (when key
+            (puthash key t used)
+            (push (cons key type) result))))
+      (nreverse result)))
+
+  (defun zetta-embark-pick-target-type-key ()
+    "Pick a target type at point via a single-key transient menu.
+
+Like `zetta-embark-pick-target-type' but uses `read-multiple-choice'
+to read a single key instead of opening a `consult--read' UI.  Fast
+when you already know the type you want and don't need a preview.
+
+Keys are inferred dynamically from the available types: for each
+type, the first free char of its symbol-name wins (so `url' is `u',
+`org-url-link' falls through to `o', `line' is `l', `defun' is `d')."
+    (interactive)
+    (let* ((targets (cl-remove-if-not
+                     (lambda (tgt) (plist-get tgt :bounds))
+                     (embark--targets)))
+           (types (mapcar (lambda (tgt) (plist-get tgt :type)) targets))
+           (key->type (zetta-embark--assign-type-keys types))
+           (choices (mapcar
+                     (lambda (entry)
+                       (let* ((c (car entry))
+                              (type (cdr entry))
+                              (tgt (cl-find type targets
+                                            :key (lambda (tgt)
+                                                   (plist-get tgt :type))))
+                              (text (truncate-string-to-width
+                                     (or (plist-get tgt :target) "")
+                                     30 nil nil "…")))
+                         (list c (format "%s %s" type text))))
+                     key->type)))
+      (cond
+       ((null targets)
+        (message "No bounded targets at point"))
+       ((null choices)
+        (message "No key could be assigned to any target type"))
+       (t
+        (let* ((picked (read-multiple-choice "Pick: " choices))
+               (key (car picked))
+               (type (alist-get key key->type))
+               (tgt (cl-find type targets
+                             :key (lambda (tgt) (plist-get tgt :type)))))
+          (when tgt
+            (let* ((sym (plist-get tgt :type))
+                   (text (plist-get tgt :target))
+                   (b (plist-get tgt :bounds))
+                   (beg (car b))
+                   (end (cdr b))
+                   (embark-target-finders
+                    (list (lambda ()
+                            (cons sym (cons text (cons beg end)))))))
+              (call-interactively #'embark-act))))))))
+
+  (define-key embark-general-map (kbd ",") #'zetta-embark-pick-target-type-key)
+
   (defun zetta-embark--pick-instance-do (type thing candidates start)
     "Open consult to pick one of CANDIDATES. Called *after* the
 outer embark-act exits, so we have a clean minibuffer context.

--- a/modules/completion/embark.el
+++ b/modules/completion/embark.el
@@ -834,6 +834,26 @@ alist of (CHAR . TYPE) preserving TYPES order."
             (push (cons key type) result))))
       (nreverse result)))
 
+  (defun zetta-embark--pick-target-type-key-do (choices key->type targets)
+    "Read a single key and re-enter `embark-act' on the picked target.
+Runs *after* the outer `embark-act' exits so `read-multiple-choice'
+has a clean minibuffer/echo-area context."
+    (let* ((picked (read-multiple-choice "Pick: " choices))
+           (key (car picked))
+           (type (alist-get key key->type))
+           (tgt (cl-find type targets
+                         :key (lambda (tgt) (plist-get tgt :type)))))
+      (when tgt
+        (let* ((sym (plist-get tgt :type))
+               (text (plist-get tgt :target))
+               (b (plist-get tgt :bounds))
+               (beg (car b))
+               (end (cdr b))
+               (embark-target-finders
+                (list (lambda ()
+                        (cons sym (cons text (cons beg end)))))))
+          (call-interactively #'embark-act)))))
+
   (defun zetta-embark-pick-target-type-key ()
     "Pick a target type at point via a single-key transient menu.
 
@@ -843,7 +863,10 @@ when you already know the type you want and don't need a preview.
 
 Keys are inferred dynamically from the available types: for each
 type, the first free char of its symbol-name wins (so `url' is `u',
-`org-url-link' falls through to `o', `line' is `l', `defun' is `d')."
+`org-url-link' falls through to `o', `line' is `l', `defun' is `d').
+
+Defers the read via `run-at-time' so the menu opens cleanly after
+embark-act's prompt exits."
     (interactive)
     (let* ((targets (cl-remove-if-not
                      (lambda (tgt) (plist-get tgt :bounds))
@@ -868,23 +891,14 @@ type, the first free char of its symbol-name wins (so `url' is `u',
        ((null choices)
         (message "No key could be assigned to any target type"))
        (t
-        (let* ((picked (read-multiple-choice "Pick: " choices))
-               (key (car picked))
-               (type (alist-get key key->type))
-               (tgt (cl-find type targets
-                             :key (lambda (tgt) (plist-get tgt :type)))))
-          (when tgt
-            (let* ((sym (plist-get tgt :type))
-                   (text (plist-get tgt :target))
-                   (b (plist-get tgt :bounds))
-                   (beg (car b))
-                   (end (cdr b))
-                   (embark-target-finders
-                    (list (lambda ()
-                            (cons sym (cons text (cons beg end)))))))
-              (call-interactively #'embark-act))))))))
+        (run-at-time 0 nil
+                     #'zetta-embark--pick-target-type-key-do
+                     choices key->type targets)))))
 
-  (define-key embark-general-map (kbd ",") #'zetta-embark-pick-target-type-key)
+  ;; `,' would collide with the global `launch-key' prefix.  `;' pairs
+  ;; naturally with `C-;' (zetta-embark-avy-pick-instance) which is
+  ;; already in this map.
+  (define-key embark-general-map (kbd ";") #'zetta-embark-pick-target-type-key)
 
   (defun zetta-embark--pick-instance-do (type thing candidates start)
     "Open consult to pick one of CANDIDATES. Called *after* the

--- a/modules/completion/embark.el
+++ b/modules/completion/embark.el
@@ -173,11 +173,25 @@ TYPE is the embark target type reported; defaults to THING."
   ;; doc-style modes so it doesn't add noise in prog-mode buffers
   ;; where symbol semantics are preferred.
   (defun zetta-embark-target-word-at-point ()
-    "Embark target finder for `word' in prose / text modes."
+    "Embark target finder for `word'.
+
+Active in prose buffers (text/org/eww/help/Info/Man) AND in elisp
+buffers.  Elisp opts in because `-' is symbol-constituent there:
+inside `some-function-here', word=function (the sub-word the cursor
+is on) and symbol=some-function-here.  Both are useful targets and
+`zetta-embark--sort-targets-by-bounds' surfaces the smaller-bounds
+`word' first in the embark cycle, so embark-act lands on the
+sub-word by default.
+
+Still gated away from other prog-mode buffers where word and symbol
+would conflate noisily (the sort would still surface word first, but
+hyphens are not symbol-constituents in most languages so the
+distinction is less useful there)."
     (when (and (not (or (minibufferp)
                         (derived-mode-p 'completion-list-mode
                                         'embark-collect-mode)))
-               (or (derived-mode-p 'text-mode 'org-mode)
+               (or (derived-mode-p 'text-mode 'org-mode
+                                   'emacs-lisp-mode)
                    (memq major-mode
                          '(eww-mode help-mode Info-mode Man-mode))))
       (when-let* ((b (ignore-errors (bounds-of-thing-at-point 'word)))

--- a/modules/completion/tap.el
+++ b/modules/completion/tap.el
@@ -91,14 +91,81 @@ avoided by going through `treesit-navigate-thing' directly."
 (defun zetta-intern-maybe (thing)
   (if (symbolp thing) thing (intern thing)))
 
+(defvar-local zetta-tap--preview-overlay nil
+  "Overlay used by `zetta-tap-set-local' preview.")
+
+(defun zetta-tap--clear-preview ()
+  "Delete `zetta-tap--preview-overlay' if any."
+  (when (overlayp zetta-tap--preview-overlay)
+    (delete-overlay zetta-tap--preview-overlay))
+  (setq zetta-tap--preview-overlay nil))
+
+(defun zetta-tap--first-bounds-for (thing)
+  "Return bounds for an instance of THING in the current buffer.
+At point if available; otherwise the first instance found by scanning
+forward from `window-start' up to `window-end'.  Used by the
+`zetta-tap-set-local' preview to show what each candidate type looks
+like in the buffer."
+  (or (ignore-errors (bounds-of-thing-at-point thing))
+      (let ((win-beg (window-start))
+            (win-end (window-end nil t))
+            found)
+        (save-excursion
+          (goto-char win-beg)
+          (while (and (< (point) win-end) (not found))
+            (let ((b (ignore-errors (bounds-of-thing-at-point thing))))
+              (if b
+                  (setq found b)
+                (forward-char 1)))))
+        found)))
+
+(defun zetta-tap--show-preview (sym)
+  "Paint the preview overlay for thing SYM, if an instance is locatable."
+  (when-let* ((b (zetta-tap--first-bounds-for sym)))
+    (let ((ov (make-overlay (car b) (cdr b))))
+      (overlay-put ov 'face
+                   (if (facep 'zetta-embark-other-instance-face)
+                       'zetta-embark-other-instance-face
+                     'highlight))
+      (overlay-put ov 'priority 100)
+      (setq zetta-tap--preview-overlay ov))))
+
 (defun zetta-tap-set-local (&optional thing)
   "Set the local current thing-at-point thing for zetta-tap navigation.
 Also mirrors to `focus-current-thing' so `focus-mode' (when active)
-dims around the same thing. THING may be a symbol or a string;
-interactively, prompts from `zetta-tap--things'."
+dims around the same thing.  THING may be a symbol or a string;
+interactively, prompts from `zetta-tap--things'.
+
+Interactive selection uses `consult--read' (when available) with a
+preview that highlights an instance of each candidate thing in the
+buffer as you narrow -- the same UI pattern as
+`zetta-embark-pick-target-type'.  Falls back to plain
+`completing-read' without preview when consult is not loaded."
   (interactive)
-  (let ((sym (zetta-intern-maybe
-              (or thing (completing-read "What thing? " zetta-tap--things)))))
+  (let* ((picked
+          (or thing
+              (cond
+               ((fboundp 'consult--read)
+                (unwind-protect
+                    (consult--read
+                     zetta-tap--things
+                     :prompt "What thing? "
+                     :require-match t
+                     :sort nil
+                     :state
+                     (lambda (action cand)
+                       (pcase action
+                         ('preview
+                          (zetta-tap--clear-preview)
+                          (when (and cand (stringp cand))
+                            (zetta-tap--show-preview
+                             (zetta-intern-maybe cand))))
+                         ((or 'exit 'return)
+                          (zetta-tap--clear-preview)))))
+                  (zetta-tap--clear-preview)))
+               (t
+                (completing-read "What thing? " zetta-tap--things)))))
+         (sym (zetta-intern-maybe picked)))
     (setq-local zetta-tap-current-thing sym)
     (when (boundp 'focus-current-thing)
       (setq-local focus-current-thing sym))))

--- a/modules/editor/avy.el
+++ b/modules/editor/avy.el
@@ -10,5 +10,23 @@
   (general-define-key :keymaps 'override
                       "C-s-o" 'evil-avy-goto-char-timer)
 
+  ;; "Avy can do anything" -- press `.' during any avy session to run
+  ;; `embark-act' on the landed target.  After embark exits, returns
+  ;; to the originating window via `avy-ring' so the prompt feels
+  ;; like a handoff rather than a navigation.
+  ;; https://karthinks.com/software/avy-can-do-anything/
+  (defun avy-action-embark (pt)
+    "Dispatch `embark-act' on PT after avy lands."
+    (unwind-protect
+        (save-excursion
+          (goto-char pt)
+          (embark-act))
+      (select-window
+       (cdr (ring-ref avy-ring 0))))
+    t)
+
+  (with-eval-after-load 'embark
+    (setf (alist-get ?. avy-dispatch-alist) #'avy-action-embark))
+
   :hook (use-package--avy--post-config . brushup))
 ;;; avy.el ends here


### PR DESCRIPTION
## Summary

Five small UX improvements to the avy / embark / tap stack — all about making target-type picking quicker and more visible.

- **avy → embark handoff** (`.` dispatch). Karthik's [\"Avy can do anything\"](https://karthinks.com/software/avy-can-do-anything/) pattern: press `.` during any avy session to run `embark-act` on the landed target instead of jumping. Defined eagerly; dispatch only registers under `with-eval-after-load 'embark'`.

- **Single-key transient menu for embark target types** (`;` in `embark-general-map`). Parallels `zetta-embark-pick-target-type` (`C-l`, consult+preview), but uses `read-multiple-choice` for a one-keystroke pick when you already know which type you want. Keys inferred dynamically from type names — `u` for url, `o` for org-url-link, `s` for symbol, etc. Deferred via `run-at-time` so the menu opens cleanly after embark-act exits.

- **`word` as an embark target in elisp buffers.** Inside `some-function-here`, embark-act now offers `word: function` (the sub-word at point) as the first target alongside `symbol: some-function-here`. Possible because `-` is symbol-constituent in elisp, so word and symbol have meaningfully different bounds; `zetta-embark--sort-targets-by-bounds` surfaces the smaller `word` first.

- **Consult preview for `zetta-tap-set-local`.** Picking a tap thing now shows a preview overlay on an instance of that thing in the buffer as you narrow — defun highlights the enclosing defun, sentence the sentence at point, url the next URL in the window. Same `:state` pattern as `zetta-embark-pick-target-type`. Falls back to plain `completing-read` when consult is absent.

## Test plan

- [x] CI green across 29.4 / 30.2 / snapshot
- [x] Live-verified: avy `.` invokes embark-act on landed target
- [x] Live-verified: `;` in embark menu shows single-key transient, picks correct type
- [x] Live-verified: embark-act on a hyphenated elisp symbol surfaces `word` first
- [x] Live-verified: `zetta-tap-set-local` shows preview highlights as you narrow