### PR TITLE
chore: backfill GPL-3 LICENSE for in-tree zettapkgs + factor-out plan

### DIFF
--- a/plan-factor-out.md
+++ b/plan-factor-out.md
@@ -1,0 +1,405 @@
+# Plan: factor out the typed-target stack as standalone packages
+
+> **v3.** Two review rounds done (6 agent passes total). Round 2 surfaced (a) two execution blockers, (b) UX gaps for non-zetta users, and (c) a serious challenge to the premise of factoring at all. This version folds the concrete fixes AND surfaces the strategic challenge prominently.
+
+## TL;DR — decisions you need to make
+
+Read [Strategic challenge: the case for stepping back](#strategic-challenge-the-case-for-stepping-back) first. The devil's-advocate review made a strong case for NOT factoring most of this code. Three live options:
+
+1. **Proceed with full plan**: Phase 0 → Phase 1 (`treesit-tap`) → Phase 1.5 (upstream) → Phase 2 (`embark-by-type`) → Phase 3 (`tap-fold`). v3 plan covers this path.
+2. **Minimal factoring**: Phase 0 only (LICENSE backfill); ship `present` + `treesit-textobj` to MELPA; keep the rest in `modules/`; write `docs/type-bridges.md` as a reference architecture essay. Reviewer #2's explicit recommendation.
+3. **Middle path**: do Phase 0 + Phase 1 (`treesit-tap` is genuinely audience-useful and the smallest scope) but defer or drop `embark-by-type` and `tap-fold`. Keeps the most reusable piece, avoids the heaviest coordination burden.
+
+The remaining open questions ([§Open questions](#open-questions-remaining-user-decisions-needed)) only matter under options 1 or 3.
+
+## Strategic challenge: the case for stepping back
+
+Round-2 devil's-advocate review pushed back on factoring with concrete numbers and arguments. Summarized here so the decision is informed:
+
+**Velocity tax (concrete).** 9 of the last 29 commits in the past 60 days touched the candidate files. If those packages were already factored, those 9 commits would have become 9 cross-repo PRs, ~90 minutes of extra CI waiting, and at least 3 coordinated two-PR releases. Estimated tax: **25-40% slowdown on the most active third of the user's Emacs work.**
+
+**Audience reality.** The intersection of (uses embark) ∩ (uses treesit aggressively) ∩ (wants typed cycle/pick UX) ∩ (won't just copy from a blog post) is tiny. No package as opinionated as `embark-by-type` exists in MELPA — which is signal that it's *too niche*, not an untapped market. `present` is the only candidate with broad appeal.
+
+**Coupling doesn't go away — it relocates.** Six of the v2 coupling findings (#2, #5, #6, #8, #11, #12) describe couplings that survive factoring; they just turn from in-tree function calls into cross-package contracts. Harder to refactor, not easier.
+
+**Minimal-defaults + wrapper-restores-behavior = bad MELPA UX.** A non-zetta installer downloads `embark-by-type`, enables `embark-by-type-mode`, runs a command, gets nothing. They have to read the README and reproduce ~50 lines of wrapper config to get the same behavior the in-tree zetta config has out-of-box. That's worse UX than the status quo for the audience the factoring is supposed to serve.
+
+**Maintenance multiplication.** 3 Eask files, 3 CI matrices, 3 release-please configs, 3 CHANGELOGs, 3 issue trackers. Every cross-cutting change becomes a coordinated 3-PR dance. For a one-person config, that's ~10% of available Emacs-tinkering time vaporized into release plumbing.
+
+**Test investment underestimated ~3×.** Plan calls for ERT smoke per package; zero tests exist today outside `present`. Realistic cost: 1-2 days/package writing, plus ongoing maintenance on every behavior change.
+
+**Upstream-first as procrastination trap.** Phase 1.5 has no SLA. Embark's maintainer is selective; response time is 2-6 weeks if at all. Strict gating means Phase 2 stalls indefinitely.
+
+**Reverse alternative.** A `docs/type-bridges.md` essay + blog post would reach more people with 1% of the effort. Readers cherry-pick what fits their config rather than installing a soft-dep-laden meta-package.
+
+**Reviewer's recommendation, verbatim**: *"Step back. Ship `present` + `treesit-textobj` (with LICENSE backfill), write `docs/type-bridges.md` as a reference architecture essay, and keep the rest in `modules/`. Revisit only if a real external user files an issue asking for `embark-by-type` as a package."*
+
+The other two round-2 reviewers (implementation feasibility, end-user discoverability) operated under the assumption that factoring is happening and surfaced concrete fixes for that path. Their findings are folded into the rest of this plan in case option 1 or 3 is chosen.
+
+---
+
+The remainder of this document covers **option 1 (full factoring)** in detail. If you pick option 2, only [Phase 0](#phase-0-prerequisite-backfill-license-for-existing-packages) and the existing-package status entries are relevant.
+
+## Context
+
+PR #14 (`present`) + the iterative work in PR #17 produced a substantial type-aware navigation / picker stack inside `modules/completion/embark.el` (now ~1300 lines) and `modules/completion/tap.el`. Most of that code is **not** zetta-specific — it's general-purpose embark + tree-sitter + thing-at-point glue.
+
+Already factored (in `source/zettapkg/`, MELPA-ready by design):
+
+| Package | Status |
+|---|---|
+| `present` | Factored, in-tree, awaiting MELPA submission. **Missing LICENSE** — backfill before submission. |
+| `treesit-textobj` | Factored, in-tree, awaiting MELPA submission. **Missing LICENSE** — backfill before submission. |
+
+Critical constraint: each factored package **must not reference any `zetta-*` symbol**. All zetta-specific defaults move into the zetta-side `use-package` wrapper as defcustom overrides.
+
+## Inventory of factor-out candidates
+
+| Bundle | LOC | Files | Purpose |
+|---|---|---|---|
+| Bridge A (treesit → thing-at-point bounds) | ~30 | `tap.el` | Make `treesit-thing-settings` provide `bounds-of-thing-at-point` |
+| Bridge B (`zetta-embark-deftap-finder` macro) | ~50 | `embark.el` | Wrap any TAP thing as an embark target finder. **Pure embark, no treesit code.** |
+| Bridge C (treesit nodes → embark targets) | ~80 | `embark.el` | Walks treesit ancestors, surfaces as `ts-<type>` targets |
+| Bridge E + cycle UX | ~600 | `embark.el` | Nav / pick / avy / focus / narrow / select by current target type |
+| Visible-instance collectors | ~150 | `embark.el` | Window-bounded enumeration |
+| Cycle sort by bounds | ~40 | `embark.el` | Innermost-first target ordering |
+| TAP-current state | ~150 | `tap.el` | Per-buffer "current thing" notion + nav/select/pulse |
+| `tap-fold` | ~150 | `tap-fold.el` | Overlay folding |
+| `avy-action-embark` | ~10 | `avy.el` | Karthik snippet — NOT package material |
+
+## Coupling map (v3, both review rounds folded)
+
+1. **`zetta-*` prefix everywhere.** Mechanical rename, but pervasive.
+
+2. **Third-party module mutation of `zetta-embark-nav-type-map`.** `modules/org/org.el:167-169` does `(setf (alist-get 'org-src-block zetta-embark-nav-type-map) 'org-src-block)`. Needs either a public registration API OR coordinated wrapper updates.
+
+3. **TAP-current has multiple non-embark consumers** — full list (v3 added `narrow.el`):
+   - `modules/editor/tap-fold.el:169`
+   - `modules/editor/narrow.el:61, 68` **← missed in v2**
+   - `modules/core/tab-bar.el:89-91`
+   - `modules/org/org.el` (keybindings)
+   - `modules/app/eww.el` (keybindings)
+   - `modules/ui/focus.el` (focus-current-thing mirror)
+   - `modules/completion/embark.el:438, 519, 525, 550, 552` — reads + setq-local writes from inside embark functions
+
+4. **Cross-package symbol dependency (NEW in v3, blocks v2 split).** `embark.el:438` does `(let ((zetta-tap-current-thing thing)) (zetta-tap-forward-thing n))`. After factoring, `embark-by-type` would either:
+   - Hard-depend on `treesit-tap` (add to Package-Requires)
+   - Move those nav functions into `treesit-tap`'s embark sub-extension (inverts plan's split)
+   - Forward-declare via `(defvar treesit-tap-current-thing)` and rely on dynamic binding only when bound — fragile
+
+   v3 decision: **`embark-by-type` Package-Requires `treesit-tap`**. The nav family genuinely uses TAP-current state; pretending otherwise is wishful.
+
+5. **Capture infrastructure is TWO writers, NOT one.** Pre-action `:always` hook AND `:filter-return` advice on `embark--rotate`. `embark-by-type-capture-mode` must install/uninstall both. Advising private `embark--rotate` is policy-risky — upstream embark could break it in any release.
+
+6. **Hook installation is non-idempotent in current code (NEW v3 blocker).** `embark.el:421-423` uses `(setf (alist-get :always embark-pre-action-hooks) (cons ...))`. Re-evaluating duplicates entries. There is no removal logic at all. The factored `capture-mode` toggle MUST be rewritten with proper `add-hook`/`remove-hook` semantics or explicit dedup; this is not a port — it's a redesign.
+
+7. **Hook ordering.** Capture hook must run BEFORE refresh-highlights consumer. Documented as part of `embark-by-type-capture-priority` defcustom.
+
+8. **Cross-file face reference.** `tap.el`'s consult preview falls back to `zetta-embark-other-instance-face`. Each package owns its own face with soft-fallback.
+
+9. **`brick` registration is load-order coupled.** `embark.el:154` calls `(zetta-embark-deftap-finder brick)` at `:config` time; brick's TAP provider is set in `tap.el:383`. The wrapper module must own this registration and sequence load order explicitly.
+
+10. **`focus-current-thing` integration.** Gate is `(boundp ...)`, semantically correct. Doc note: mirror is no-op when focus.el unloaded.
+
+11. **`embark-org` is bundled INSIDE `embark`.** Not a separate MELPA dep. Gate org-link collectors via `(featurep 'embark-org)`.
+
+12. **`ts-*` taxonomy is implicit cross-package schema.** `treesit-tap`'s embark sub-extension owns the `ts-*` entries; `embark-by-type`'s default map ships with zero `ts-*` entries.
+
+13. **`present` wrapper update is THREE references, not one** (v3 finding): `modules/completion/present.el` collector name + treesit-types source, PLUS `source/zettapkg/present/present.el:142, 749` (docstrings), PLUS `source/zettapkg/present/README.md:174`.
+
+14. **Hand-written embark target finders missed from macro inventory (NEW v3).** `zetta-embark-target-word-at-point` (`embark.el:175`) is hand-written, NOT generated by `deftap-finder`. Its prose+elisp gating logic moves with it as a separate function in `embark-by-type`.
+
+15. **Embark sub-keymaps are silently public API (NEW v3).** `embark-defun-map`, `embark-ts-string-map`, `embark-ts-call-map` (`embark.el:231-236, 297-303, 307-313`) — user's live keybindings into these will silently break on rename. Add to rename inventory: `embark-by-type-defun-map`, etc.
+
+16. **Autoload coordination (NEW v3 blocker).** `treesit-tap`'s embark sub-extension installs `ts-*` entries at LOAD time. With `;;;###autoload` only on commands, registration never fires until a command runs. Options: (a) `treesit-tap-embark-setup` autoloaded function the wrapper calls, (b) `;;;###autoload` on a `with-eval-after-load` form (rare pattern), (c) **ship as a separate file `treesit-tap-embark.el` users `require` explicitly**. v3 decision: **option (c)**, mirrors `embark-consult` pattern.
+
+## Suggested factoring
+
+Three new packages, phased smallest → largest.
+
+### Package 1: `treesit-tap`
+
+**One-liner**: turn any tree-sitter node type into a first-class `thing-at-point` thing, with optional embark surface.
+
+**Includes**:
+- `treesit-tap-bounds THING` — bounds provider that calls `treesit-thing-at-point` / `treesit-thing-defined-p` (the symbols that actually force the Emacs 30.1 floor — NOT `treesit-thing-settings`).
+- `treesit-tap-extend-language LANG EXTRAS` — buffer-local appender (this is the API-drift surface).
+- `treesit-tap-language-extras` — defcustom with built-in defaults.
+- `treesit-tap-mode` (global minor mode) — installs the bounds bridge.
+- **TAP-current sub-feature** (moved here per v2 coupling finding #3):
+  - `treesit-tap-current-thing` (defvar-local)
+  - `treesit-tap-set-local` — interactive setter with optional consult preview
+  - `treesit-tap-forward-thing` / `-next` / `-prev` / `-beg` / `-end`
+  - `treesit-tap-pulse` / `-select` / `-comment`
+  - Soft mirror to `focus-current-thing` when bound
+- `treesit-tap-setup` (NEW v3) — convenience function that enables `treesit-tap-mode` and sets a sensible default current thing.
+- **Embark sub-extension as separate file** `treesit-tap-embark.el` (NEW v3, resolves autoload coordination blocker):
+  - `treesit-tap-embark-target-node-at-point` — embark finder
+  - At `require` time: adds finder to `embark-target-finders`, registers `ts-*` entries into `embark-by-type-nav-type-map` (gated by `boundp`)
+
+**Defcustoms** (with `:type` and `:options` per discoverability review):
+```elisp
+(defcustom treesit-tap-language-extras
+  '((python-ts-mode . ((function . "function_definition") ...)))
+  "..."
+  :type '(alist :key-type symbol :value-type (alist :key-type symbol :value-type sexp))
+  :group 'treesit-tap)
+
+(defcustom treesit-tap-embark-types
+  '("function_definition" "call" "string")
+  "Node types to surface as embark targets. Add to or replace this list.
+Example: (\"function_definition\" \"call_expression\" \"if_statement\")"
+  :type '(repeat string)
+  :options '("function_definition" "call" "string" "class_definition" "if_statement")
+  :group 'treesit-tap)
+```
+
+**Hard deps**: `((emacs "30.1"))`. **Soft deps** (documented): `embark`, `consult`, `focus`.
+
+**LOC estimate**: 300-400.
+
+### Package 2: `embark-by-type`
+
+**One-liner**: turn embark into a type-aware structural navigation system.
+
+**Public commands** (three families per round-1 API review):
+
+*Nav family* (`embark-by-type-nav-*`): `nav-next` / `-prev` / `-beg` / `-end`. **All four guarded with `(unless embark-by-type-capture-mode (user-error "Enable embark-by-type-capture-mode first"))`** (NEW v3 per discoverability review).
+
+*Pick family* (`embark-by-type-pick-*`): `pick-target-type` (consult+preview), `pick-target-type-key` (transient), `pick-instance`, `avy-pick-instance`.
+
+*Act family* (`embark-by-type-act-*`): `act-focus`, `act-highlight-instances`, `act-select-as-region`, `act-narrow`. **Same capture-mode guard.**
+
+**Public collector facade**: `embark-by-type-collect-visible TYPE THING`. Internal collectors are private.
+
+**Capture infrastructure**:
+- `embark-by-type-last-target-type` (defvar)
+- `embark-by-type-last-target-bounds` (defvar)
+- `embark-by-type-capture-mode` (global minor mode) — installs **both** the pre-action hook AND the `embark--rotate` advice via proper `add-hook`/`remove-hook` semantics (NEW v3; this is a redesign, not a port — see coupling finding #6)
+
+**Bridge B macro**: `embark-by-type-deftap-finder THING [TYPE]`. Generated names: `embark-by-type-target-<thing>-at-point`.
+
+**Hand-written finders** (NEW v3 — not macro-generated, must move explicitly): `embark-by-type-target-word-at-point` (prose+elisp gated).
+
+**Embark sub-keymap renames** (NEW v3): `embark-by-type-defun-map`, `embark-by-type-ts-string-map`, `embark-by-type-ts-call-map`. Document in MIGRATION.md.
+
+**Modes the user opts into**:
+- `embark-by-type-sort-by-bounds-mode` — cycle-sort advice
+- `embark-by-type-capture-mode` — capture infra (REQUIRED for nav/act)
+- `embark-by-type-install-default-bindings` — function (not a mode) to install bindings into `embark-general-map`
+
+**Setup convenience** (NEW v3): `embark-by-type-setup` — enables `capture-mode`, optionally `sort-by-bounds-mode`, optionally calls `install-default-bindings`. Single function for one-line user setup.
+
+**Defcustoms** (with `:type`, `:options`, and worked examples in docstrings):
+- `embark-by-type-nav-type-map` — `(alist :key-type symbol :value-type symbol)`, no `ts-*` entries default. Docstring: `"Example: ((function . defun) (class . class) (call . sexp))"`.
+- `embark-by-type-symbol-target-types` — `(repeat symbol)`, default subset
+- `embark-by-type-org-link-collectors` — `(alist :key-type symbol :value-type regexp)`
+- `embark-by-type-other-instance-face`
+- `embark-by-type-default-bindings`
+- `embark-by-type-install-default-bindings-p` — boolean default nil
+- `embark-by-type-capture-priority` (NEW v3) — controls hook ordering relative to consumers
+
+**Hard deps**: `((emacs "29.1") (embark "1.0") (treesit-tap "0.1"))`. The `treesit-tap` dep is NEW in v3 — required because the nav family lex-binds `treesit-tap-current-thing` (coupling finding #4).
+
+**Soft deps**: `avy`, `consult`, `marginalia`. `embark-org` bundled in embark, gate via `featurep`.
+
+**LOC estimate**: 800-1000.
+
+### Package 3: `tap-fold`
+
+Unchanged from v2. Soft-depends on `embark-by-type-capture-mode` being on; provides clear `user-error` when invoked while mode is off.
+
+## What NOT to factor
+
+- `avy-action-embark` — community snippet, document in README.
+- Highlight-on-cycle refresh hook — kept as sub-feature of `embark-by-type-act-highlight-instances`.
+
+## Cross-cutting concerns
+
+### Naming (resolved)
+
+| Package | v1 → v2 → v3 | Reason |
+|---|---|---|
+| Tree-sitter bridge | `treesit-thing` → **`treesit-tap`** | Clearer purpose, no built-in collision |
+| Embark extension | `embark-cycle` → **`embark-by-type`** | v1 collided with built-in `embark-cycle` |
+| Folding | `tap-fold` (unchanged) | Clean |
+
+### License (resolved)
+
+GPL-3-or-later for all three new packages + retro-fit `present` + `treesit-textobj` (Phase 0).
+
+### Default behavior
+
+No package installs hooks/advices/bindings on `require`. Each ships a `*-setup` convenience function for one-line user setup. The zetta wrapper calls each `*-setup` to preserve current behavior.
+
+### Capture-mode guards (NEW v3)
+
+Every `embark-by-type-nav-*` and `embark-by-type-act-*` command begins with:
+```elisp
+(unless embark-by-type-capture-mode
+  (user-error "Enable `embark-by-type-capture-mode' first"))
+```
+This is the discoverability fix for the silent-prerequisite UX problem.
+
+### Migration support (NEW v3)
+
+Each package ships `MIGRATION.md` with a `zetta-* → new-*` symbol table covering:
+- `zetta-embark-*` → `embark-by-type-*` (or `treesit-tap-*` for nav vars)
+- `zetta-tap-*` → `treesit-tap-*`
+- Sub-keymap renames (`embark-defun-map` → `embark-by-type-defun-map`)
+- Hand-written finder renames
+
+Optional: ship `embark-by-type-compat.el` providing `defalias` for one release cycle.
+
+### Documentation per-package
+
+`README.md` Quick Start section MUST contain:
+- One-line "what is this" elevator pitch
+- For `treesit-tap`: explicit two-feature breakdown (bounds bridge + per-buffer current-thing)
+- Install snippet (zettapkg form + MELPA form)
+- Single one-liner `(treesit-tap-setup)` / `(embark-by-type-setup)` user calls
+- For `embark-by-type`: use-case → command table (e.g. "Switch active type → `pick-target-type`"; "Jump within current type → `pick-instance`")
+- Soft-dep matrix
+
+### Test strategy
+
+CI matrix per package: `treesit-tap` (30.1 / snapshot), `embark-by-type` (29.4 / 30.x / snapshot), `tap-fold` (29.4 / 30.x / snapshot). Ubuntu + macOS.
+
+ERT smoke tests cover public API. Plan budgets 1-2 days/package writing time.
+
+## Phased execution plan
+
+### Phase 0 (prerequisite): backfill LICENSE for existing packages
+
+Add GPL-3-or-later LICENSE + header to `source/zettapkg/present/` and `source/zettapkg/treesit-textobj/`. One commit. Independent of factoring decision — required regardless if those go to MELPA.
+
+### Phase 1: `treesit-tap`
+
+1. Create `source/zettapkg/treesit-tap/`.
+2. Copy + rename Bridge A, Bridge C, TAP-current, language extras.
+3. Strip zetta-specific defaults.
+4. Write `treesit-tap-mode` and `treesit-tap-setup`.
+5. Create `treesit-tap-embark.el` as separate file for the embark sub-extension (resolves autoload blocker).
+6. ERT tests.
+7. README + MIGRATION.md + Eask + CI (30.1 / snapshot).
+8. Update consumers: `modules/lang/treesit.el`, `modules/completion/tap.el`, `modules/editor/tap-fold.el`, `modules/editor/narrow.el`, `modules/core/tab-bar.el`, `modules/org/org.el`, `modules/app/eww.el`.
+9. Drop Bridge A/C and TAP-current from in-tree `embark.el`/`tap.el`.
+
+### Phase 1.5: upstream embark issue (parallel, NOT a gate)
+
+File issue proposing `embark-sort-targets-by-bounds` as built-in defcustom on embark. **30-day timeout**; if no response or declined, ship in `embark-by-type`. Phase 2 proceeds in parallel — sort-mode is independent of capture-mode + nav + pick + act work.
+
+### Phase 2: `embark-by-type`
+
+Sub-phases:
+1. Pure utilities (collectors, `--assign-type-keys`).
+2. **`embark-by-type-capture-mode` redesigned for clean toggle** (NEW v3 — this is the rewrite). Install/uninstall both pre-action hook AND rotate advice with proper semantics + dedup.
+3. Sort advice (only if upstream declined Phase 1.5).
+4. Collector dispatcher (gates org-link via `featurep`).
+5. Type pickers.
+6. Instance pickers.
+7. Action commands + capture-mode guards.
+8. Nav commands + capture-mode guards.
+9. Bridge B macro.
+10. Hand-written finders (word-at-point).
+11. Sub-keymap renames.
+12. Default-bindings installer + `embark-by-type-setup` convenience fn.
+13. README + MIGRATION.md.
+14. Wrapper updates: `modules/completion/embark.el` (wrapper), `modules/completion/present.el` (collector + treesit-types source), `source/zettapkg/present/present.el` (docstrings:142, 749), `source/zettapkg/present/README.md:174`, `modules/org/org.el:167-169` (consider register-mapping API).
+15. Smoke test asserting post-wrapper-load keymap state.
+
+### Phase 3: `tap-fold`
+
+Only if external interest emerges. Straightforward port.
+
+## Per-package factor-out checklist (v3)
+
+- [ ] Create `source/zettapkg/<name>/` with `<name>.el`, `README.md`, **`MIGRATION.md`**, `test/<name>-test.el`, `Eask`, `.github/workflows/`, release-please config, `version.txt`, `LICENSE` (GPL-3)
+- [ ] License header in main `.el` file
+- [ ] Rename all `zetta-*` symbols
+- [ ] **Include hand-written finders and sub-keymaps in rename inventory** (v3)
+- [ ] Remove zetta-specific defaults
+- [ ] Add `:type` AND `:options` to every defcustom; worked example in docstring (v3)
+- [ ] `;;;###autoload` only on user-facing commands and `define-minor-mode` forms
+- [ ] **For load-time registration: ship as separate file requiring explicit `require`** (v3 — autoload coordination)
+- [ ] Forward-declare external symbols
+- [ ] **`add-hook`/`remove-hook` semantics for any hook installation; explicit dedup** (v3)
+- [ ] `package-lint-current-buffer` clean (warnings OK, errors not)
+- [ ] Byte-compile clean on CI matrix
+- [ ] ERT smoke test suite covering public API
+- [ ] **`*-setup` convenience function** (v3)
+- [ ] **`user-error` guards on commands with implicit prerequisites** (v3)
+- [ ] README "Quick start" with single-call setup line
+- [ ] CHANGELOG.md with initial 0.1.0 entry
+- [ ] Zetta wrapper enables modes/bindings via `*-setup` to preserve pre-factor behavior
+- [ ] Smoke test asserts post-wrapper bindings match pre-factor set
+
+## Open questions (user decisions needed)
+
+If proceeding (options 1 or 3 above):
+
+1. **Name confirmation**: confirm `treesit-tap` and `embark-by-type`.
+2. **License confirmation**: GPL-3-or-later.
+3. **Phase 1.5 scope**: file upstream issue first (30-day timeout) or skip entirely and ship sort-mode in-package immediately?
+4. **`org.el` registration API**: extend `embark-by-type-nav-type-map` directly OR add public `embark-by-type-register-nav-mapping` API?
+5. **`treesit-tap`'s embark sub-extension**: ship as `treesit-tap-embark.el` (v3 default per autoload coordination decision) or in-package with `with-eval-after-load`?
+6. **Compat layer**: ship `*-compat.el` with `defalias` for one release cycle, or rely solely on MIGRATION.md?
+
+## Verification
+
+After each phase: existing CI green; live-test the pre-factor behaviors documented in PR #14 / PR #17 test plans; new smoke test asserting wrapper restores prior keymap state.
+
+## Out of scope (this plan)
+
+- Actually publishing to MELPA (separate effort).
+- Documentation site / homepage.
+- API redesign (rename + extract only).
+- Test coverage beyond smoke.
+
+## Review findings incorporated
+
+**v2 → v3 changes driven by round-2 reviews:**
+
+*From implementation-feasibility review (blockers + concrete issues):*
+- Added coupling finding #4: `embark-by-type` HARD-depends on `treesit-tap` (lex-binding at `embark.el:438`) — Package 2 deps updated.
+- Added coupling finding #6: capture-mode hook installation needs redesign for clean toggle (not just port).
+- Added coupling finding #13 expansion: `present/README.md:174` also needs update.
+- Added coupling finding #14: hand-written finders (`-target-word-at-point`) missed from rename.
+- Added coupling finding #15: embark sub-keymaps (`embark-defun-map` etc.) silently public, need explicit rename.
+- Added coupling finding #16: autoload coordination — resolved by shipping embark sub-extension as separate `treesit-tap-embark.el`.
+- Fixed Emacs 30.1 justification: the symbols are `treesit-thing-at-point` and `treesit-thing-defined-p`, NOT `treesit-thing-settings`.
+- Restructured Phase 1.5 from gate to parallel with 30-day timeout.
+- Added `modules/editor/narrow.el` to TAP-current consumer list.
+- Documented private-symbol advising risk (`embark--rotate`).
+
+*From end-user discoverability review (UX gaps):*
+- Added `treesit-tap-setup` and `embark-by-type-setup` convenience functions per package.
+- Added `user-error` guards on `nav-*` / `act-*` commands when capture-mode is off.
+- Specified `:options` + worked docstring examples for every user-facing defcustom.
+- Added `MIGRATION.md` to per-package checklist.
+- Added README Quick Start template requirements (use-case table for embark-by-type, two-feature breakdown for treesit-tap).
+- New open question #6: compat layer (`defalias` `*-compat.el`)?
+
+*From devil's-advocate review (strategic challenge):*
+- Added prominent "Strategic challenge: the case for stepping back" section.
+- Added TL;DR with three live options (full factor / minimal / middle path).
+- Underestimation flagged: test investment ~3× plan's budget.
+- Velocity tax flagged: 25-40% slowdown on most active third of work.
+- Reverse alternative surfaced: `docs/type-bridges.md` essay as substitute for some / all packages.
+
+## Critical files referenced
+
+- `/Users/charlieholland/.zetta.d/modules/completion/embark.el`
+- `/Users/charlieholland/.zetta.d/modules/completion/tap.el`
+- `/Users/charlieholland/.zetta.d/modules/completion/present.el`
+- `/Users/charlieholland/.zetta.d/modules/editor/tap-fold.el`
+- `/Users/charlieholland/.zetta.d/modules/editor/narrow.el` (NEW v3 — missed consumer)
+- `/Users/charlieholland/.zetta.d/modules/lang/treesit.el`
+- `/Users/charlieholland/.zetta.d/modules/org/org.el`
+- `/Users/charlieholland/.zetta.d/modules/ui/focus.el`
+- `/Users/charlieholland/.zetta.d/modules/core/tab-bar.el`
+- `/Users/charlieholland/.zetta.d/modules/editor/avy.el`
+- `/Users/charlieholland/.zetta.d/docs/type-bridges.md`
+- `/Users/charlieholland/.zetta.d/source/zettapkg/CLAUDE.md`
+- `/Users/charlieholland/.zetta.d/source/zettapkg/present/` (+ `README.md:174`)
+- `/Users/charlieholland/.zetta.d/source/zettapkg/treesit-textobj/`

--- a/source/zettapkg/present/LICENSE
+++ b/source/zettapkg/present/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/source/zettapkg/present/present.el
+++ b/source/zettapkg/present/present.el
@@ -1,11 +1,27 @@
 ;;; present.el --- CLIM-style typed-presentation picker -*- lexical-binding: t; -*-
-;;
+
+;; Copyright (C) 2026 Charlie Holland
+
 ;; Author: Charlie Holland <charliebkr707@gmail.com>
+;; Maintainer: Charlie Holland <charliebkr707@gmail.com>
 ;; URL: https://github.com/<TBD>/present
 ;; Version: 0.1.0
 ;; Package-Requires: ((emacs "29.1"))
 ;; Keywords: convenience, completion, tools
-;;
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;;
 ;; CLIM-style presentation types for Emacs.  Open a minibuffer prompt

--- a/source/zettapkg/treesit-textobj/LICENSE
+++ b/source/zettapkg/treesit-textobj/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/source/zettapkg/treesit-textobj/treesit-textobj.el
+++ b/source/zettapkg/treesit-textobj/treesit-textobj.el
@@ -9,6 +9,19 @@
 ;; Package-Requires: ((emacs "30.1") (evil "1.15"))
 ;; Keywords: convenience, tools, languages
 
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 
 ;; Inner/outer evil text objects backed by Emacs's built-in tree-sitter


### PR DESCRIPTION
## Summary

Phase 0 of the factor-out plan: prerequisite LICENSE backfill before any MELPA submission.

**Two commits:**

- \`c08f2fd\` Backfill GPL-3 LICENSE + header notices for \`present\` and \`treesit-textobj\`. Both were missing license files and notices — a gap MELPA reviewers flag. GPL-3-or-later chosen for ecosystem consistency (embark itself + all major embark extensions are GPL-3+).
- \`8ce44eb\` Archive the v3 factor-out design plan in repo root alongside \`plan-present.md\`. Three review rounds folded in (coupling, MELPA-readiness, API, implementation, discoverability, devil's-advocate). User opted for full factoring (option 1).

## What this PR does NOT include

- Any actual factoring — that's Phase 1 (\`treesit-tap\`) and Phase 2 (\`embark-by-type\`) in separate PRs.
- Code changes to \`present\` or \`treesit-textobj\` — header additions only.

## Test plan

- [x] \`present\` tests: 19/19 pass
- [x] \`present\` byte-compiles clean
- [ ] CI green