### PR TITLE
feat(isr): semantic + generative ISR demos and fixes

### DIFF
--- a/chiply-isr/README.org
+++ b/chiply-isr/README.org
@@ -61,10 +61,30 @@ M-x chiply-isr-index-corpus     ; only if db/ is empty or stale
 M-x chiply-isr-semantic-read    ; bound to the menu-lookup prefix + i
 #+end_src
 
+* Indexing your own files (and on startup)
+
+=chiply-isr-index-sources= is a list of =(DIRECTORY . FILE-REGEXP)= pairs. Each
+directory is searched recursively and every match is embedded:
+
+#+begin_src elisp
+;; in ~/.zetta.el (loads before the module)
+(setq chiply-isr-index-sources
+      '(("~/org/"  . "\\.org\\'")
+        ("~/src/"  . "\\.py\\'")))
+(setq chiply-isr-index-on-startup t)   ; index those on every Emacs start
+#+end_src
+
+- =M-x chiply-isr-index= indexes all sources; a prefix arg (=C-u=) forces a full
+  re-embed. Unchanged files are skipped via an md5 cache (=db/index-md5.eld=), so
+  re-running --- including on startup --- only re-embeds files that changed.
+- With =chiply-isr-index-on-startup= non-nil, the module starts the server (if
+  needed), waits for it, then indexes the sources --- a near no-op when nothing
+  changed.
+- =chiply-isr-index-corpus= is just =chiply-isr-index= scoped to the demo
+  =corpus/=.
+
 * Notes
 
-=index-corpus.sh= (and =M-x chiply-isr-index-corpus=) index only =corpus/=. If
-you ever point this at real notes instead, exclude anything private --- nothing
-here ships embeddings off the machine, but indexed text lands in =db/=.
-=EXPORT_FILE_NAME= targets =src/routes/private=. Private posts must never be
-embedded or indexed.
+Indexed text (the file contents) lands in =db/= as embeddings. Nothing leaves
+the machine, but if you point =chiply-isr-index-sources= at real notes, keep
+anything private out of the indexed directories.

--- a/modules/completion/chiply-isr.el
+++ b/modules/completion/chiply-isr.el
@@ -63,6 +63,31 @@ file while sharing no words with it -- see the files for examples."
 A belt-and-suspenders guard so results stay in the intended corpus."
   :type 'string)
 
+(defcustom chiply-isr-index-sources
+  (list (cons (expand-file-name "corpus/" (expand-file-name "chiply-isr/" user-emacs-directory))
+              "\\.org\\'"))
+  "List of (DIRECTORY . FILE-REGEXP) pairs to index.
+Each DIRECTORY is searched recursively for files whose name matches
+FILE-REGEXP, and every match is sent to the semantic index.  Add your
+own notes, code, etc. here, e.g.:
+
+  \\='((\"~/org/\"  . \"\\\\.org\\\\\\='\")
+    (\"~/src/\"  . \"\\\\.py\\\\\\='\"))"
+  :type '(repeat (cons (directory :tag "Directory")
+                       (regexp :tag "File regexp"))))
+
+(defcustom chiply-isr-index-on-startup nil
+  "When non-nil, index `chiply-isr-index-sources' after Emacs starts.
+Starts the server if needed, waits for it, then indexes only files whose
+content changed since the last run (unchanged ones are skipped via an md5
+cache).  Set this in ~/.zetta.el before this module loads."
+  :type 'boolean)
+
+(defvar chiply-isr--md5-cache-file
+  (expand-file-name "index-md5.eld"
+                    (expand-file-name "db/" (expand-file-name "chiply-isr/" user-emacs-directory)))
+  "File caching FILENAME -> content-md5 so unchanged files are not re-embedded.")
+
 (defun chiply-isr-server-url ()
   "Base URL of the running org-db-v3 server."
   (format "http://%s:%d" chiply-isr-server-host chiply-isr-server-port))
@@ -121,35 +146,108 @@ from any other org-db install."
 
 ;;; Indexing ------------------------------------------------------------------
 
+(defun chiply-isr--gather-files (sources)
+  "Return all files matched by SOURCES, a list of (DIR . REGEXP) pairs.
+Each existing DIR is searched recursively for names matching REGEXP."
+  (apply #'append
+         (mapcar (lambda (pair)
+                   (let ((dir (expand-file-name (car pair))))
+                     (when (file-directory-p dir)
+                       (directory-files-recursively dir (cdr pair)))))
+                 sources)))
+
+(defun chiply-isr--post-file (filename content)
+  "Send FILENAME with CONTENT to /api/file.  Return non-nil on success.
+Content-only: the server embeds CONTENT directly for semantic search, so
+no org parsing happens here."
+  (let* ((url-request-method "POST")
+         (url-request-extra-headers '(("Content-Type" . "application/json")))
+         (url-request-data
+          (encode-coding-string
+           (json-encode `((filename . ,filename)
+                          (md5 . ,(md5 content))
+                          (file_size . ,(string-bytes content))
+                          (content . ,content)
+                          (headlines . ,[]) (links . ,[]) (keywords . ,[])
+                          (src_blocks . ,[]) (images . ,[]) (linked_files . ,[])))
+           'utf-8))
+         (buf (url-retrieve-synchronously
+               (concat (chiply-isr-server-url) "/api/file") t nil 120)))
+    (when buf (kill-buffer buf) t)))
+
+(defun chiply-isr--load-md5-cache ()
+  "Return the saved FILENAME -> md5 alist, or nil."
+  (when (file-exists-p chiply-isr--md5-cache-file)
+    (with-temp-buffer
+      (insert-file-contents chiply-isr--md5-cache-file)
+      (ignore-errors (read (current-buffer))))))
+
+(defun chiply-isr--save-md5-cache (alist)
+  "Persist ALIST (FILENAME -> md5) to `chiply-isr--md5-cache-file'."
+  (make-directory (file-name-directory chiply-isr--md5-cache-file) t)
+  (with-temp-file chiply-isr--md5-cache-file
+    (let ((print-length nil) (print-level nil))
+      (prin1 alist (current-buffer)))))
+
 ;;;###autoload
-(defun chiply-isr-index-corpus ()
-  "Index every .org file in `chiply-isr-corpus-dir' into the running server.
-Content-only: semantic search embeds the file body, so no org parsing is
-needed.  Run once (the database persists), or after editing the samples."
-  (interactive)
+(defun chiply-isr-index (&optional sources force)
+  "Index every file matched by SOURCES into the running server.
+SOURCES is a list of (DIRECTORY . FILE-REGEXP) pairs; it defaults to
+`chiply-isr-index-sources'.  Files whose content is unchanged since the
+last run are skipped (md5 cache); with prefix arg FORCE, re-index all.
+The database persists on disk, so this only needs to run when files change."
+  (interactive (list nil current-prefix-arg))
+  (setq sources (or sources chiply-isr-index-sources))
   (unless (chiply-isr-server-running-p)
     (user-error "chiply-isr: server not running -- M-x chiply-isr-start-server"))
-  (let ((files (directory-files chiply-isr-corpus-dir t "\\.org\\'"))
-        (n 0))
+  (let ((files (chiply-isr--gather-files sources))
+        (cache (unless force (chiply-isr--load-md5-cache)))
+        (seen nil) (indexed 0) (skipped 0))
     (dolist (f files)
       (let* ((content (with-temp-buffer (insert-file-contents f) (buffer-string)))
-             (url-request-method "POST")
-             (url-request-extra-headers '(("Content-Type" . "application/json")))
-             (url-request-data
-              (encode-coding-string
-               (json-encode `((filename . ,f)
-                              (md5 . ,(md5 content))
-                              (file_size . ,(string-bytes content))
-                              (content . ,content)
-                              ;; empty parsed-structure arrays -- the server
-                              ;; embeds `content' directly for semantic search
-                              (headlines . ,[]) (links . ,[]) (keywords . ,[])
-                              (src_blocks . ,[]) (images . ,[]) (linked_files . ,[])))
-               'utf-8))
-             (buf (url-retrieve-synchronously
-                   (concat (chiply-isr-server-url) "/api/file") t nil 120)))
-        (when buf (kill-buffer buf) (setq n (1+ n)))))
-    (message "chiply-isr: indexed %d file(s) from %s" n chiply-isr-corpus-dir)))
+             (sum (md5 content)))
+        (cond
+         ((and (not force) (equal (cdr (assoc f cache)) sum))
+          (push (cons f sum) seen) (setq skipped (1+ skipped)))
+         ((chiply-isr--post-file f content)
+          (push (cons f sum) seen) (setq indexed (1+ indexed))))))
+    ;; `seen' omits files that vanished from disk, so they age out of the cache.
+    (chiply-isr--save-md5-cache seen)
+    (message "chiply-isr: indexed %d, skipped %d unchanged, of %d file(s)"
+             indexed skipped (length files))
+    indexed))
+
+;;;###autoload
+(defun chiply-isr-index-corpus (&optional force)
+  "Index `chiply-isr-corpus-dir' (the demo sample files).
+Thin wrapper over `chiply-isr-index'; FORCE re-indexes unchanged files too."
+  (interactive "P")
+  (chiply-isr-index (list (cons chiply-isr-corpus-dir "\\.org\\'")) force))
+
+;;; Startup indexing ---------------------------------------------------------
+
+(defvar chiply-isr--startup-tries 0
+  "Internal counter for `chiply-isr--startup-attempt' retries.")
+
+(defun chiply-isr--startup-attempt ()
+  "Index sources once the server answers; retry briefly while it boots."
+  (cond
+   ((chiply-isr-server-running-p)
+    (setq chiply-isr--startup-tries 0)
+    (ignore-errors (chiply-isr-index)))
+   ((< (setq chiply-isr--startup-tries (1+ chiply-isr--startup-tries)) 30)
+    (run-with-timer 1 nil #'chiply-isr--startup-attempt))
+   (t (setq chiply-isr--startup-tries 0)
+      (message "chiply-isr: server did not come up; skipped startup index"))))
+
+(defun chiply-isr-maybe-startup-index ()
+  "If `chiply-isr-index-on-startup', start the server and index sources.
+Added to `emacs-startup-hook'; a no-op unless the option is enabled."
+  (when chiply-isr-index-on-startup
+    (chiply-isr-start-server)            ; no-op if already running
+    (chiply-isr--startup-attempt)))
+
+(add-hook 'emacs-startup-hook #'chiply-isr-maybe-startup-index)
 
 ;;; Semantic source ----------------------------------------------------------
 

--- a/modules/completion/consult-omni.el
+++ b/modules/completion/consult-omni.el
@@ -126,7 +126,109 @@ STYLE defaults to `consult-async-split-style'."
     (when (and (boundp 'gptel-backend) gptel-backend)
       (setq consult-omni-gptel-backend gptel-backend))
     (when (and (boundp 'gptel-model) gptel-model)
-      (setq consult-omni-gptel-model (format "%s" gptel-model))))
+      (setq consult-omni-gptel-model (format "%s" gptel-model)))
+    ;; The sync above only fires when gptel *loads*, which can precede the
+    ;; user setting `gptel-backend' -- leaving consult-omni-gptel-backend nil,
+    ;; so `(gptel-backend-name nil)' raises "error in calling :items of gptel
+    ;; source".  Sync at call time too, so the source always uses gptel's
+    ;; current backend/model (and picks up later backend switches).
+    (defun consult-omni--gptel-sync-backend (&rest _)
+      "Point the gptel source at gptel's current backend/model."
+      (when (and (boundp 'gptel-backend) (recordp gptel-backend))
+        (setq consult-omni-gptel-backend gptel-backend))
+      (when (boundp 'gptel-model)
+        (setq consult-omni-gptel-model (format "%s" gptel-model))))
+    (with-eval-after-load 'consult-omni-gptel
+      (advice-add 'consult-omni--gptel-fetch-results :before
+                  #'consult-omni--gptel-sync-backend)
+
+      ;; --- Multiple generated candidates (emphasize ISR) ------------------
+      ;; The built-in cand-title functions emit ONE candidate, and
+      ;; `gptel-request' has no `n' parameter.  So ask the model for several
+      ;; DISTINCT alternatives in a single (non-streamed) request and split
+      ;; the reply into N candidates -- one prompt, many suggestions, all
+      ;; rendered through the ordinary consult/Marginalia/Embark substrate.
+      (defcustom consult-omni-gptel-n-candidates 5
+        "How many alternative gptel candidates to request per query."
+        :group 'consult-omni :type 'integer)
+
+      (cl-defun consult-omni--gptel-make-titles-multi (input &rest args &key callback &allow-other-keys)
+        "Ask gptel for several DISTINCT candidates for INPUT and emit them all."
+        (pcase-let* ((`(,query . ,opts)
+                      (consult-omni--split-command
+                       input (if callback (seq-difference args (list :callback callback)) args)))
+                     (opts (car-safe opts))
+                     (source "gptel")
+                     (backend (and (plist-member opts :backend) (format "%s" (plist-get opts :backend))))
+                     (backend (and backend (car (seq-filter (lambda (item) (when (string-match (format "%s" backend) item) item)) (mapcar #'car gptel--known-backends)))))
+                     (backend (or backend (gptel-backend-name consult-omni-gptel-backend)))
+                     (backend-struct (cdr (assoc (format "%s" backend) gptel--known-backends)))
+                     (model (and (plist-member opts :model) (format "%s" (plist-get opts :model))))
+                     (model (or (and model backend-struct (member model (cl-struct-slot-value (type-of backend-struct) 'models backend-struct)) model)
+                                (and backend-struct (car (cl-struct-slot-value (type-of backend-struct) 'models backend-struct)))
+                                consult-omni-gptel-model))
+                     (stream nil)
+                     (gptel-backend backend-struct)
+                     ;; gptel-model must be a SYMBOL (the mode-line lighter
+                     ;; calls `gptel--model-name' on it); `model' is a string.
+                     (gptel-model (cond ((symbolp model) model)
+                                        ((stringp model) (intern model))
+                                        (t gptel-model)))
+                     (gptel-stream nil)
+                     (output))
+          (gptel-request query
+            :system (format "You are an autocomplete engine.  Provide exactly %d DISTINCT, concise alternative completions or answers for the user's input.  Return ONLY a numbered list (\"1.\", \"2.\", ...), one alternative per line, with no preamble, commentary, or code fences."
+                            consult-omni-gptel-n-candidates)
+            :callback
+            (lambda (response _)
+              ;; The LLM is slow, so an earlier fragment's reply ("what is")
+              ;; can arrive after the input moved on ("what is python").
+              ;; Drop it unless this request's QUERY is still what's typed.
+              (when (and (stringp response)
+                         (let ((cur (and (active-minibuffer-window)
+                                         (car (consult-omni--split-command
+                                               (with-current-buffer (window-buffer (active-minibuffer-window))
+                                                 (minibuffer-contents-no-properties)))))))
+                           (and cur (equal (string-trim query) (string-trim cur)))))
+                (let ((cands
+                       (delq nil
+                             (mapcar
+                              (lambda (line)
+                                (let ((item (string-trim (replace-regexp-in-string "\\`[ \t]*[0-9]+[.)]?[ \t]*" "" line))))
+                                  (when (> (length item) 0)
+                                    (propertize
+                                     (consult-omni--gptel-format-candidate
+                                      :source source :query query :title item
+                                      :model model :backend backend :stream stream)
+                                     :title item :source source :url nil :query query
+                                     :model model :stream stream :backend backend))))
+                              (split-string response "\n" t)))))
+                  (when (and cands (functionp callback)) (funcall callback cands))
+                  (setq output cands)))))
+          output))
+
+      (setq consult-omni-gptel-cand-title #'consult-omni--gptel-make-titles-multi)
+
+      ;; LLM calls are slow and cost money, so require a more substantial
+      ;; query before firing -- short fragments like "what is" should not
+      ;; trigger a request (and then arrive stale).
+      (when-let* ((src (assoc "gptel" consult-omni--sources-alist)))
+        (plist-put (cdr src) :min-input 8))
+
+      ;; consult-omni's gptel preview does `(setq-local gptel-model
+      ;; (format "%s" model))' -- a STRING.  Newer gptel's mode-line lighter
+      ;; calls `(gptel--model-name gptel-model)' which needs a SYMBOL, so the
+      ;; preview buffer errors on every redisplay ("wrong-type-argument
+      ;; symbolp ...").  Coerce the buffer-local value back to a symbol.
+      (defun consult-omni--gptel-fix-preview-model (buf)
+        "Coerce a string-valued buffer-local `gptel-model' in BUF to a symbol."
+        (when (buffer-live-p buf)
+          (with-current-buffer buf
+            (when (and (local-variable-p 'gptel-model) (stringp gptel-model))
+              (setq-local gptel-model (intern gptel-model)))))
+        buf)
+      (advice-add 'consult-omni--gptel-response-preview :filter-return
+                  #'consult-omni--gptel-fix-preview-model)))
 
   ;; embark integration
   (require 'consult-omni-embark)

--- a/modules/completion/copilot-isr.el
+++ b/modules/completion/copilot-isr.el
@@ -1,0 +1,216 @@
+;;; copilot-isr.el --- Generative ISR: pick a Copilot completion via consult -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Incremental Suggesting Read, generative flavor.  GitHub Copilot's panel API
+;; (getPanelCompletions, via `copilot-panel-complete') synthesizes several
+;; candidate completions for the current point; this collects them and surfaces
+;; them through consult -- preview each as ghost text where it would be
+;; inserted, choose with RET.  The candidates are *generated* by a model, not
+;; matched against any corpus, yet the picker is the same ICR substrate
+;; (consult) used everywhere else.
+;;
+;; Why panel and not inline: inline completion (`copilot-complete' /
+;; `copilot-next-completion') returns however many items the server chose --
+;; often exactly one, hence "Only one completion is available".  The panel API
+;; deliberately produces several.  How many DISTINCT solutions you get still
+;; depends on the context: an unambiguous spot yields few, an open-ended one
+;; yields more.
+
+;;; Code:
+
+(declare-function consult--read "consult")
+(declare-function copilot-panel-complete "copilot")
+(declare-function copilot-clear-overlay "copilot")
+(declare-function general-define-key "general")
+(defvar copilot--notification-handlers)
+
+(defgroup copilot-isr nil
+  "Pick a generated Copilot completion through consult."
+  :group 'completion :prefix "copilot-isr-")
+
+(defcustom copilot-isr-timeout 20
+  "Seconds to wait for Copilot to finish synthesizing before giving up."
+  :type 'number)
+
+(defcustom copilot-isr-suppress-panel-buffer t
+  "When non-nil, keep Copilot's *copilot-panel* window from popping up.
+This module reads the panel solutions and shows them through consult
+instead, so the raw panel buffer is just noise.  Set to nil to get
+Copilot's native panel window back."
+  :type 'boolean)
+
+(defcustom copilot-isr-newline-indicator " ↵ "
+  "String marking a line break in the one-line minibuffer candidate.
+Each candidate carries the WHOLE body (collapsed to one line, since
+vertico shows one line per candidate), so you can filter by any code in
+it.  The real multi-line text still previews as ghost text and inserts
+intact.  Use e.g. \" / \" if your font lacks the arrow glyph."
+  :type 'string)
+
+(defvar copilot-isr--collecting nil)
+(defvar copilot-isr--solutions nil
+  "Alist of (SCORE . TEXT) collected from the current panel request.")
+(defvar copilot-isr--done-fn nil)
+(defvar copilot-isr--timeout-timer nil)
+
+(defun copilot-isr--on-solution (msg)
+  "Collect one PanelSolution MSG (deduplicated by text) while collecting."
+  (when copilot-isr--collecting
+    (let ((text  (plist-get msg :completionText))
+          (score (or (plist-get msg :score) 0)))
+      (when (and text (not (rassoc text copilot-isr--solutions)))
+        (push (cons score text) copilot-isr--solutions)))))
+
+(defun copilot-isr--on-done (_msg)
+  "Finish collection when Copilot signals PanelSolutionsDone."
+  (copilot-isr--finish))
+
+(defun copilot-isr--ensure-handler (method fn)
+  "Add FN to Copilot's notification handler list for METHOD if absent.
+Uses named functions + `memq', so it is robust across module reloads and
+sits alongside Copilot's own handlers (which still fill *copilot-panel*)."
+  (let ((handlers (gethash method copilot--notification-handlers)))
+    (unless (memq fn handlers)
+      (puthash method (cons fn handlers) copilot--notification-handlers))))
+
+(defun copilot-isr--install-handlers ()
+  "Ensure our PanelSolution/PanelSolutionsDone collectors are registered."
+  (copilot-isr--ensure-handler 'PanelSolution #'copilot-isr--on-solution)
+  (copilot-isr--ensure-handler 'PanelSolutionsDone #'copilot-isr--on-done))
+
+(defun copilot-isr--finish ()
+  "Stop collecting and hand the solutions to the continuation (deferred)."
+  (when copilot-isr--collecting
+    (setq copilot-isr--collecting nil)
+    (when (timerp copilot-isr--timeout-timer) (cancel-timer copilot-isr--timeout-timer))
+    (setq copilot-isr--timeout-timer nil)
+    (let ((fn copilot-isr--done-fn))
+      (setq copilot-isr--done-fn nil)
+      ;; Defer out of the jsonrpc/process-filter context before opening a
+      ;; blocking minibuffer.
+      (when fn (run-at-time 0 nil fn)))))
+
+(defun copilot-isr--oneline (text)
+  "Collapse TEXT to one line for the minibuffer candidate.
+Line breaks and their surrounding indentation become
+`copilot-isr-newline-indicator', leaving the whole body matchable on a
+single line."
+  (string-trim
+   (replace-regexp-in-string "[ \t]*\n[ \t]*"
+                             copilot-isr-newline-indicator
+                             (string-trim text))))
+
+(defun copilot-isr--candidates (solutions)
+  "Return (CANDS . MAP) from SOLUTIONS (alist (SCORE . TEXT)).
+CANDS is a list of unique display STRINGS -- each the WHOLE body collapsed
+to one line, so completing-read matches on any code in it (plain strings,
+so prescient/vertico filter them happily).  MAP is DISPLAY -> full TEXT."
+  (let ((map (make-hash-table :test 'equal))
+        (cands nil) (i 0))
+    (dolist (s solutions)
+      (setq i (1+ i))
+      (let* ((text (cdr s))
+             (disp (format "%2d. %s" i (copilot-isr--oneline text))))
+        ;; Guarantee uniqueness even if two collapsed bodies collide.
+        (while (gethash disp map) (setq disp (concat disp " ")))
+        (puthash disp text map)
+        (push disp cands)))
+    (cons (nreverse cands) map)))
+
+(defun copilot-isr--fit (text prefix)
+  "Drop PREFIX from TEXT when point already sits in that leading whitespace.
+Avoids double-indentation when inserting at an indented point."
+  (if (and text (string-match-p "\\`[ \t]*\\'" prefix) (string-prefix-p prefix text))
+      (substring text (length prefix))
+    (or text "")))
+
+(defun copilot-isr--state (prefix ov)
+  "Return a consult state fn previewing the candidate as ghost text via OV.
+With `consult--lookup-cdr' the CAND passed here is the completion TEXT."
+  (lambda (action cand)
+    (pcase action
+      ('preview
+       (when (overlayp ov)
+         (overlay-put ov 'after-string
+                      (and (stringp cand)
+                           (propertize (copilot-isr--fit cand prefix) 'face 'shadow)))))
+      ((or 'return 'exit)
+       (when (overlayp ov) (delete-overlay ov))))))
+
+(defun copilot-isr--choose (buf pt)
+  "Pick one collected solution for BUF and insert it at PT."
+  (when (buffer-live-p buf)
+    (with-current-buffer buf
+      ;; Clear any inline ghost that re-appeared during the async wait, so the
+      ;; preview starts on a clean buffer.
+      (when (fboundp 'copilot-clear-overlay) (copilot-clear-overlay))
+      (let ((sols (sort (copy-sequence copilot-isr--solutions)
+                        (lambda (a b) (> (car a) (car b))))))
+        (if (null sols)
+            (message "Copilot: no solutions synthesized (try a richer context)")
+          (let* ((cm (copilot-isr--candidates sols))
+                 (cands (car cm))
+                 (map (cdr cm))
+                 (table (lambda (&rest _) cands))   ; consult calls (table nil) -> string list
+                 (prefix (buffer-substring-no-properties
+                          (save-excursion (goto-char pt) (line-beginning-position)) pt))
+                 (ov (make-overlay pt pt buf))
+                 (choice nil))
+            (unwind-protect
+                (setq choice
+                      (consult--read
+                       table
+                       :prompt (format "Copilot suggestion (%d): " (length cands))
+                       ;; selected DISPLAY string -> TEXT, so both the preview
+                       ;; cand and the return value are the completion text.
+                       :lookup (lambda (sel &rest _) (gethash sel map))
+                       :category 'copilot-isr
+                       :sort nil
+                       :require-match t
+                       :preview-key 'any            ; preview as you cycle
+                       :state (copilot-isr--state prefix ov)))
+              (when (overlayp ov) (delete-overlay ov)))
+            ;; Clear any lingering Copilot inline ghost so it does not paint
+            ;; over the inserted text (otherwise it shows until you hit escape).
+            (when (fboundp 'copilot-clear-overlay) (copilot-clear-overlay))
+            (when (stringp choice)
+              (goto-char pt)
+              (insert (copilot-isr--fit choice prefix)))))))))
+
+;;;###autoload
+(defun copilot-isr-panel-read ()
+  "Synthesize several Copilot completions and pick one via consult.
+Run with point where the completion should go (e.g. an empty function
+body).  Each candidate previews as ghost text at point; RET inserts it."
+  (interactive)
+  (require 'consult)
+  (require 'copilot)
+  (copilot-isr--install-handlers)
+  ;; Drop the inline ghost showing now, so it does not compete with the
+  ;; consult preview that takes over.
+  (when (fboundp 'copilot-clear-overlay) (copilot-clear-overlay))
+  (let ((buf (current-buffer))
+        (pt (point)))
+    (setq copilot-isr--solutions nil
+          copilot-isr--collecting t
+          copilot-isr--done-fn (lambda () (copilot-isr--choose buf pt)))
+    (when (timerp copilot-isr--timeout-timer) (cancel-timer copilot-isr--timeout-timer))
+    (setq copilot-isr--timeout-timer
+          (run-at-time copilot-isr-timeout nil #'copilot-isr--finish))
+    (message "Copilot: synthesizing solutions... (consult opens when ready)")
+    (copilot-panel-complete)))
+
+;; Keep Copilot's panel buffer from stealing a window -- we show the solutions
+;; through consult instead.  (The buffer is still populated, just not displayed.)
+(when copilot-isr-suppress-panel-buffer
+  (add-to-list 'display-buffer-alist
+               '("\\`\\*copilot-panel\\*\\'"
+                 (display-buffer-no-window)
+                 (allow-no-window . t))))
+
+(with-eval-after-load 'general
+  (when (boundp 'menu-lookup-map)
+    (general-define-key :keymaps 'menu-lookup-map "c" 'copilot-isr-panel-read)))
+
+(provide 'copilot-isr)
+;;; copilot-isr.el ends here

--- a/modules/ui/telephone-line.el
+++ b/modules/ui/telephone-line.el
@@ -20,7 +20,10 @@
 
   (telephone-line-defsegment zt-icon-copilot ()
     (when (and (boundp 'copilot-mode) copilot-mode)
-      (all-the-icons-icon-for-mode 'copilot-mode)))
+      ;; `all-the-icons-icon-for-mode' only maps MAJOR modes, so for the
+      ;; copilot-mode minor mode it returned the symbol instead of an icon.
+      ;; Use the real Copilot octicon directly (SVG, like the siblings).
+      (all-the-icons-octicon "copilot" :face 'success)))
 
   (telephone-line-defsegment zt-icon-side-window ()
     (when (zetta-side-window-p (selected-window)) " {S} "))


### PR DESCRIPTION
## Summary
Tooling for the Incremental Suggesting Read (ISR) blog post, plus fixes uncovered along the way.

### New
- **copilot-isr** (`modules/completion/copilot-isr.el`): pick a generated GitHub Copilot panel completion through consult — ghost-text preview at point, clean insert, multi-line candidates collapsed to one matchable line.

### Changed
- **chiply-isr** (`modules/completion/chiply-isr.el`, README): generalized indexing — `chiply-isr-index` over `(DIRECTORY . FILE-REGEXP)` source pairs, md5 skip cache, optional `index-on-startup`.
- **consult-omni gptel source** (`modules/completion/consult-omni.el`): multi-candidate generative ISR (one prompt → N suggestions); call-time backend sync; stale-response guard + higher `:min-input`; `gptel-model` symbol coercion + preview-buffer patch.

### Fixed
- `consult-omni-gptel`: "error in calling :items of gptel source" (nil backend) and the `gptel-model` mode-line redisplay error.
- `telephone-line`: show the real Copilot octicon when `copilot-mode` is active (was returning the mode symbol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)