### PR TITLE
feat: svg-margin — multi-provider SVG margin gutter + config wiring

### DIFF
--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -269,7 +269,7 @@ the recompute yields the same hunks we skip, breaking the cycle."
 (svg-margin-register-provider 'evil-marks   #'zetta-svg-margin-evil-marks   :side 'left  :priority 5)
 (svg-margin-register-provider 'org-headings #'zetta-svg-margin-org-headings :side 'left  :priority 4)
 (svg-margin-register-provider 'long-lines   #'zetta-svg-margin-long-lines   :side 'right :priority 3)
-(svg-margin-register-provider 'symbol       #'zetta-svg-margin-symbol       :side 'right :priority 2)
+(svg-margin-register-provider 'symbol       #'zetta-svg-margin-symbol       :side 'left  :priority 2)
 (svg-margin-register-provider 'trailing-ws  #'zetta-svg-margin-trailing-ws  :side 'right :priority 1)
 
 ;; Refresh triggers, deferred until each source package loads.

--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -1,0 +1,295 @@
+;;; svg-margin.el --- svg-margin gutter configuration -*- lexical-binding: t; -*-
+
+;; Loads the in-tree `svg-margin' package (source/zettapkg/svg-margin) and
+;; wires up MY providers in the window margins instead of the fringe: VC
+;; (via git-gutter), flycheck, TODO/FIXME, bookmarks, evil marks, an Org
+;; heading rail, long-line and trailing-whitespace hygiene, and live
+;; symbol-at-point occurrences.
+;;
+;; This is the config-level analogue of the package's examples/ gallery --
+;; the gallery stays in zettapkg as published reference; this file is my own
+;; setup, so it survives a restart.  Providers read the source packages'
+;; data and guard on their availability at runtime, so this loads cleanly
+;; even before evil/git-gutter/flycheck/bookmark are loaded; the activation
+;; (disabling the fringe drawers it replaces, enabling the mode) runs from
+;; `emacs-startup-hook', and refresh triggers are deferred per package.
+
+(use-package svg-margin
+  :ensure nil
+  :load-path "source/zettapkg/svg-margin")
+
+(require 'svg-margin)
+(require 'svg)
+(require 'cl-lib)
+
+;; External symbols (declared so this byte-compiles without those packages).
+(defvar evil-markers-alist)
+(defvar git-gutter:diffinfos)
+(defvar bookmark-alist)
+(defvar flycheck-current-errors)
+(declare-function git-gutter-hunk-start-line "git-gutter")
+(declare-function git-gutter-hunk-end-line "git-gutter")
+(declare-function git-gutter-hunk-type "git-gutter")
+(declare-function global-git-gutter-mode "git-gutter")
+(declare-function global-evil-fringe-mark-mode "evil-fringe-mark")
+(declare-function bookmark-get-filename "bookmark")
+(declare-function bookmark-get-position "bookmark")
+(declare-function flycheck-error-line "flycheck")
+(declare-function flycheck-error-level "flycheck")
+(declare-function flycheck-error-message "flycheck")
+
+(defcustom zetta-svg-margin-long-line-column 80
+  "Column past which `zetta-svg-margin-long-lines' flags a line."
+  :type 'integer :group 'zetta)
+
+;; A bookmark-ribbon shape (the package ships only geometric primitives).
+(svg-margin-define-shape 'bookmark
+  (lambda (svg x y w h color)
+    (let* ((bw (max 4 (round (* w 0.52))))
+           (bx (+ x (/ (- w bw) 2)))
+           (top (+ y (round (* h 0.16))))
+           (bot (+ y (round (* h 0.84))))
+           (notch (+ y (round (* h 0.6)))))
+      (svg-polygon svg
+                   (list (cons bx top) (cons (+ bx bw) top)
+                         (cons (+ bx bw) bot) (cons (+ bx (/ bw 2)) notch)
+                         (cons bx bot))
+                   :fill color))))
+
+;;;; Providers
+;; ----------------------------------------------------------------
+;; Each returns a list of indicator plists; :side and :priority are set at
+;; registration (below), so the providers only describe what/where to draw.
+
+(defun zetta-svg-margin-todo (buffer)
+  "Dots for TODO/FIXME/HACK keywords in BUFFER."
+  (with-current-buffer buffer
+    (let (out)
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward "\\_<\\(TODO\\|FIXME\\|HACK\\)\\_>" nil t)
+          (push (list :pos (match-beginning 0) :shape 'dot
+                      :color (pcase (match-string 1)
+                               ("TODO" "#d29922") ("FIXME" "#f85149") (_ "#a371f7"))
+                      :help (match-string 1))
+                out)))
+      out)))
+
+(defun zetta-svg-margin-git-gutter (buffer)
+  "VC bars/triangles for git-gutter hunks in BUFFER (git-gutter does not draw)."
+  (with-current-buffer buffer
+    (when (and (bound-and-true-p git-gutter-mode) (boundp 'git-gutter:diffinfos))
+      (let (out)
+        (dolist (info git-gutter:diffinfos)
+          (let* ((start (git-gutter-hunk-start-line info))
+                 (end   (or (git-gutter-hunk-end-line info) start))
+                 (type  (git-gutter-hunk-type info)))
+            (pcase type
+              ((or 'added 'modified)
+               (cl-loop for ln from start to (min end (+ start 1000)) do
+                        (push (list :line ln :shape 'bar
+                                    :color (if (eq type 'added) "#3fb950" "#d29922")
+                                    :help (symbol-name type))
+                              out)))
+              ('deleted
+               (push (list :line start :shape 'triangle :color "#f85149" :help "deleted")
+                     out)))))
+        out))))
+
+(defun zetta-svg-margin-bookmarks (buffer)
+  "Ribbons for bookmarks pointing into BUFFER's file."
+  (with-current-buffer buffer
+    (when (and buffer-file-name (bound-and-true-p bookmark-alist))
+      (let ((file (file-truename buffer-file-name)) out)
+        (dolist (bm bookmark-alist)
+          (let ((bmfile (ignore-errors (bookmark-get-filename bm)))
+                (pos (ignore-errors (bookmark-get-position bm))))
+            (when (and bmfile pos (string= (file-truename bmfile) file))
+              (push (list :pos pos :shape 'bookmark :color "#7d5bed"
+                          :help (format "bookmark: %s" (car bm)))
+                    out))))
+        out))))
+
+(defun zetta-svg-margin-evil-marks (buffer)
+  "Letter glyphs for buffer-local evil marks a-z in BUFFER."
+  (with-current-buffer buffer
+    (when (boundp 'evil-markers-alist)
+      (let (out)
+        (dolist (cell evil-markers-alist)
+          (let ((char (car cell)) (val (cdr cell)))
+            (when (and (markerp val) (eq (marker-buffer val) buffer)
+                       (>= char ?a) (<= char ?z))
+              (push (list :pos (marker-position val) :text (char-to-string char)
+                          :face 'warning :help (format "evil mark `%c'" char))
+                    out))))
+        out))))
+
+(defun zetta-svg-margin-flycheck (buffer)
+  "Severity dots for flycheck diagnostics in BUFFER."
+  (with-current-buffer buffer
+    (when (bound-and-true-p flycheck-mode)
+      (let (out)
+        (dolist (err flycheck-current-errors)
+          (let ((line (flycheck-error-line err))
+                (level (flycheck-error-level err)))
+            (when line
+              (push (list :line line :shape 'dot
+                          :color (pcase level
+                                   ('error "#f85149") ('warning "#d29922") (_ "#3fb950"))
+                          :help (ignore-errors (flycheck-error-message err)))
+                    out))))
+        out))))
+
+(defun zetta-svg-margin-long-lines (buffer)
+  "Bars for over-long lines in prog-mode BUFFER."
+  (with-current-buffer buffer
+    (when (derived-mode-p 'prog-mode)
+      (let ((col zetta-svg-margin-long-line-column) out)
+        (save-excursion
+          (goto-char (point-min))
+          (while (not (eobp))
+            (end-of-line)
+            (when (> (current-column) col)
+              (push (list :pos (line-beginning-position) :shape 'bar :color "#b08800"
+                          :help (format "line exceeds %d columns" col))
+                    out))
+            (forward-line 1)))
+        out))))
+
+(defun zetta-svg-margin-trailing-ws (buffer)
+  "Marks for lines with trailing whitespace in BUFFER."
+  (with-current-buffer buffer
+    (let (out)
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward "[ \t]+$" nil t)
+          (push (list :pos (line-beginning-position) :shape 'dot :color "#8b949e"
+                      :help "trailing whitespace")
+                out)
+          (forward-line 1)))
+      out)))
+
+(defun zetta-svg-margin-org-headings (buffer)
+  "A left rail bar per Org heading, sized and coloured by depth."
+  (with-current-buffer buffer
+    (when (derived-mode-p 'org-mode)
+      (let (out)
+        (save-excursion
+          (goto-char (point-min))
+          (while (re-search-forward "^\\(\\*+\\) " nil t)
+            (let* ((level (length (match-string 1)))
+                   (face (intern (format "org-level-%d" (1+ (mod (1- level) 8)))))
+                   (color (or (face-foreground face nil 'default) "#888888")))
+              (push (list :pos (line-beginning-position) :color color
+                          :help (format "heading level %d" level)
+                          :draw (lambda (svg x y w h c)
+                                  (let* ((frac (/ (max 1 (- 7 level)) 6.0))
+                                         (bh (max 3 (round (* h frac))))
+                                         (yy (+ y (/ (- h bh) 2))))
+                                    (svg-rectangle svg x yy (max 2 (round (* w 0.4))) bh
+                                                   :rx 1 :fill c))))
+                    out))))
+        out))))
+
+(defvar zetta-svg-margin--last-symbol nil
+  "Last symbol at point, to refresh only when it changes.")
+
+(defun zetta-svg-margin-symbol (buffer)
+  "Dots on lines where the symbol at point also appears in BUFFER."
+  (with-current-buffer buffer
+    (let ((sym (and (derived-mode-p 'prog-mode)
+                    (ignore-errors (thing-at-point 'symbol t)))))
+      (when (and sym (>= (length sym) 3))
+        (let ((re (concat "\\_<" (regexp-quote sym) "\\_>")) out)
+          (save-excursion
+            (goto-char (point-min))
+            (while (re-search-forward re nil t)
+              (push (list :pos (match-beginning 0) :shape 'dot :color "#58a6ff"
+                          :help (format "occurrence of `%s'" sym))
+                    out)))
+          out)))))
+
+;;;; Refresh triggers
+;; ----------------------------------------------------------------
+
+(defun zetta-svg-margin--refresh (&rest _)
+  "Refresh the current buffer's svg-margin."
+  (svg-margin-refresh))
+
+(defun zetta-svg-margin--refresh-all (&rest _)
+  "Refresh every svg-margin buffer."
+  (svg-margin-refresh-all))
+
+(defvar-local zetta-svg-margin--gg-last 'none
+  "Last git-gutter diffinfos svg-margin rendered, to break a refresh loop.")
+
+(defun zetta-svg-margin--gg-feed (&rest _)
+  "Override of `git-gutter:view-diff-infos': refresh svg-margin, draw nothing.
+Refresh only when the hunks actually changed.  svg-margin's render changes the
+margin, which fires `window-configuration-change-hook', which makes git-gutter
+recompute and call this again -- so an unconditional refresh would loop.  When
+the recompute yields the same hunks we skip, breaking the cycle."
+  (unless (equal git-gutter:diffinfos zetta-svg-margin--gg-last)
+    (setq zetta-svg-margin--gg-last git-gutter:diffinfos)
+    (svg-margin-refresh)))
+
+(defun zetta-svg-margin--symbol-watch ()
+  "Refresh when the symbol at point changes (for `post-command-hook')."
+  (let ((sym (and (derived-mode-p 'prog-mode)
+                  (ignore-errors (thing-at-point 'symbol t)))))
+    (unless (equal sym zetta-svg-margin--last-symbol)
+      (setq zetta-svg-margin--last-symbol sym)
+      (svg-margin-refresh))))
+
+;;;; Configuration + registration
+;; ----------------------------------------------------------------
+
+;; Reclaim only the left fringe (evil-fringe-mark's old home); the right
+;; fringe stays for yascroll.  Margins are independent of fringes, so the
+;; right-margin providers below still show.
+(setq svg-margin-disable-fringe 'left)
+
+;; Provider -> (side . priority).  Side/priority set here, not in the
+;; providers, so moving one between margins is a one-line edit.
+(svg-margin-register-provider 'git-gutter   #'zetta-svg-margin-git-gutter   :side 'left  :priority 9)
+(svg-margin-register-provider 'flycheck     #'zetta-svg-margin-flycheck     :side 'left  :priority 8)
+(svg-margin-register-provider 'todo         #'zetta-svg-margin-todo         :side 'right :priority 7)
+(svg-margin-register-provider 'bookmarks    #'zetta-svg-margin-bookmarks    :side 'right :priority 6)
+(svg-margin-register-provider 'evil-marks   #'zetta-svg-margin-evil-marks   :side 'left  :priority 5)
+(svg-margin-register-provider 'org-headings #'zetta-svg-margin-org-headings :side 'left  :priority 4)
+(svg-margin-register-provider 'long-lines   #'zetta-svg-margin-long-lines   :side 'right :priority 3)
+(svg-margin-register-provider 'symbol       #'zetta-svg-margin-symbol       :side 'right :priority 2)
+(svg-margin-register-provider 'trailing-ws  #'zetta-svg-margin-trailing-ws  :side 'right :priority 1)
+
+;; Refresh triggers, deferred until each source package loads.
+(with-eval-after-load 'evil
+  (advice-add 'evil-set-marker :after #'zetta-svg-margin--refresh))
+(with-eval-after-load 'bookmark
+  (advice-add 'bookmark-set :after #'zetta-svg-margin--refresh-all)
+  (advice-add 'bookmark-delete :after #'zetta-svg-margin--refresh-all))
+(with-eval-after-load 'flycheck
+  (add-hook 'flycheck-after-syntax-check-hook #'zetta-svg-margin--refresh))
+(add-hook 'post-command-hook #'zetta-svg-margin--symbol-watch)
+
+;;;; Activation
+;; ----------------------------------------------------------------
+;; Runs after init, when the packages svg-margin replaces are loaded: turn
+;; off their fringe drawing, then enable the gutter everywhere.
+
+(defun zetta-svg-margin-activate ()
+  "Disable the fringe drawers svg-margin replaces and enable the gutter."
+  ;; evil marks now come from the margin provider, not the fringe.
+  (when (fboundp 'global-evil-fringe-mark-mode)
+    (global-evil-fringe-mark-mode -1))
+  ;; Let git-gutter keep computing hunks, but stop it drawing (svg-margin draws).
+  (when (and (fboundp 'git-gutter:view-diff-infos)
+             (not (advice-member-p #'zetta-svg-margin--gg-feed 'git-gutter:view-diff-infos)))
+    (advice-add 'git-gutter:view-diff-infos :override #'zetta-svg-margin--gg-feed))
+  (global-svg-margin-mode 1)
+  (svg-margin-refresh-all))
+
+(if after-init-time
+    (zetta-svg-margin-activate)             ; loaded interactively, init already done
+  (add-hook 'emacs-startup-hook #'zetta-svg-margin-activate))
+
+;;; svg-margin.el ends here

--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -200,13 +200,19 @@
     (let ((sym (and (derived-mode-p 'prog-mode)
                     (ignore-errors (thing-at-point 'symbol t)))))
       (when (and sym (>= (length sym) 3))
-        (let ((re (concat "\\_<" (regexp-quote sym) "\\_>")) out)
+        (let ((re (concat "\\_<" (regexp-quote sym) "\\_>"))
+              (seen (make-hash-table :test 'eql)) out)
           (save-excursion
             (goto-char (point-min))
             (while (re-search-forward re nil t)
-              (push (list :pos (match-beginning 0) :shape 'dot :color "#58a6ff"
-                          :help (format "occurrence of `%s'" sym))
-                    out)))
+              ;; one indicator per LINE, not per occurrence -- several matches
+              ;; on the same line must not each claim a column.
+              (let ((bol (line-beginning-position)))
+                (unless (gethash bol seen)
+                  (puthash bol t seen)
+                  (push (list :pos bol :shape 'dot :color "#58a6ff"
+                              :help (format "occurrence of `%s'" sym))
+                        out)))))
           out)))))
 
 ;;;; Refresh triggers
@@ -248,6 +254,11 @@ the recompute yields the same hunks we skip, breaking the cycle."
 ;; fringe stays for yascroll.  Margins are independent of fringes, so the
 ;; right-margin providers below still show.
 (setq svg-margin-disable-fringe 'left)
+
+;; Reserve a baseline margin width so buffer text doesn't shift as indicators
+;; come and go (the margin still grows past this when a line needs more).
+(setq svg-margin-min-left-columns 4
+      svg-margin-min-right-columns 2)
 
 ;; Provider -> (side . priority).  Side/priority set here, not in the
 ;; providers, so moving one between margins is a one-line edit.

--- a/source/bootstrap/bootstrap-modules.el
+++ b/source/bootstrap/bootstrap-modules.el
@@ -72,6 +72,7 @@ in the order they appear in the `zetta-modules!' declaration.")
            "yascroll.el" "nyan-mode.el" "popper.el" "window.el"
            "rainbow-delimiters.el" "symbol-overlay.el" "hi-lock.el"
            "beacon.el" "outline-indent.el" "hl-todo.el" "svg-line.el" "header-line-svg.el"
+           "svg-margin.el"
            "breadcrumb.el" "parrot.el" "hl-block.el" "awesome-tray.el"
            "telephone-line.el" "ef-themes.el" "doric-themes.el"
            "adaptive-wrap.el" "svg-lib.el" "explain-pause-mode.el" "spacetree.el"))

--- a/source/zettapkg/svg-margin/CONFIGURATION.md
+++ b/source/zettapkg/svg-margin/CONFIGURATION.md
@@ -15,6 +15,8 @@ All are plain `defcustom`s (`M-x customize-group RET svg-margin`):
 |--------|---------|---------|
 | `svg-margin-column-width` | `1` | width of one indicator column, in character cells |
 | `svg-margin-default-side` | `left` | side for indicators that don't set `:side` |
+| `svg-margin-min-left-columns` | `0` | columns to always reserve in the left margin |
+| `svg-margin-min-right-columns` | `0` | columns to always reserve in the right margin |
 | `svg-margin-disable-fringe` | `nil` | `left` / `right` / `both` — which fringe to collapse to 0 while active |
 | `svg-margin-provider-sides` | `nil` | alist `(PROVIDER . left|right)` forcing where a provider draws |
 | `svg-margin-debug` | `nil` | message indicators dropped for a missing/out-of-range position |
@@ -23,6 +25,22 @@ All are plain `defcustom`s (`M-x customize-group RET svg-margin`):
 Enable per buffer with `svg-margin-mode`, or everywhere with
 `global-svg-margin-mode`. svg-margin needs a **graphical frame** (it draws SVG),
 so it shows nothing in `emacs -nw`.
+
+### Keeping the buffer from shifting
+
+By default a margin is only as wide as it needs to be, so the buffer text shifts
+left/right as indicators appear and disappear. Reserve a baseline to keep it
+steady:
+
+```elisp
+(setq svg-margin-min-left-columns 1
+      svg-margin-min-right-columns 1)
+```
+
+The margin still grows beyond the minimum when a line needs more columns — it
+just never drops below it, so text stops jiggling up to that width. (Indicators
+are drawn nearest the text within the reserved space, so a wider reservation
+shows as empty room at the window edge, not a gap against the text.)
 
 ## Registering a provider
 

--- a/source/zettapkg/svg-margin/CONFIGURATION.md
+++ b/source/zettapkg/svg-margin/CONFIGURATION.md
@@ -1,0 +1,183 @@
+# Configuring svg-margin
+
+How to set svg-margin up, and — the part most people ask about first — how hard
+it is to **divert data from packages that already use the fringe or margin**
+into the svg-margin gutter.
+
+- For the engine API and indicator keys, see [README.md](README.md).
+- For ready-made providers you can copy, see [EXAMPLES.md](EXAMPLES.md).
+
+## Options
+
+All are plain `defcustom`s (`M-x customize-group RET svg-margin`):
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `svg-margin-column-width` | `1` | width of one indicator column, in character cells |
+| `svg-margin-default-side` | `left` | side for indicators that don't set `:side` |
+| `svg-margin-disable-fringe` | `nil` | `left` / `right` / `both` — which fringe to collapse to 0 while active |
+| `svg-margin-provider-sides` | `nil` | alist `(PROVIDER . left|right)` forcing where a provider draws |
+| `svg-margin-debug` | `nil` | message indicators dropped for a missing/out-of-range position |
+| `svg-margin-idle-delay` | `0.1` | seconds to coalesce changes before re-rendering |
+
+Enable per buffer with `svg-margin-mode`, or everywhere with
+`global-svg-margin-mode`. svg-margin needs a **graphical frame** (it draws SVG),
+so it shows nothing in `emacs -nw`.
+
+## Registering a provider
+
+```elisp
+;; minimal
+(svg-margin-register-provider 'mine #'my-fn)
+
+;; with per-provider defaults (applied to indicators that omit them)
+(svg-margin-register-provider 'mine #'my-fn :side 'right :priority 5)
+```
+
+A provider is a function `BUFFER -> (list of indicator plists)`. One of
+`:pos`/`:line` is required (line numbers are absolute, correct under narrowing);
+an indicator without a valid position is silently skipped unless
+`svg-margin-debug` is on.
+
+## Moving a provider's side (yours or someone else's)
+
+```elisp
+(setq svg-margin-provider-sides '((flycheck . right) (git-gutter . left)))
+```
+
+This is declarative and works for **third-party** providers too — you never
+edit the provider. Side precedence: `svg-margin-provider-sides` →
+the indicator's own `:side` → the provider's registered `:side` →
+`svg-margin-default-side`.
+
+## Reclaiming the fringe
+
+```elisp
+(setq svg-margin-disable-fringe 'left)   ; collapse the left fringe to 0
+```
+
+This is **independent of which margin side you draw in** — margins and fringes
+are separate regions, so right-margin indicators coexist with the right fringe.
+Only disable a fringe once you've migrated *its* users; e.g. don't zero the
+right fringe if `yascroll`/`flycheck` still draw there, or they'll have nowhere
+to render. Original widths are restored when the mode is turned off.
+
+---
+
+# Diverting data from other packages
+
+This is the most common adoption question, so it's worth being precise. Think of
+diversion as **two separate jobs**:
+
+1. **Read the data** — write a provider that reads what the other package
+   already knows, and emit indicators from it.
+2. **Stop the original drawing** — so you don't get duplicates or, if the other
+   package also writes the *margin*, a layout "duel."
+
+For the common case both are easy. Job 1 is almost always the easy half because
+most packages keep their per-line state in a reachable variable; the provider is
+~10 lines. Job 2 is the part whose difficulty varies — and you often don't need
+it at all.
+
+## Job 1 — read the data
+
+Most sources expose their state in a variable or a function. The providers
+shipped in [EXAMPLES.md](EXAMPLES.md) are worked examples:
+
+| Source | Where the data lives | Provider size |
+|--------|----------------------|---------------|
+| evil marks | `evil-markers-alist` | ~10 lines |
+| bookmarks | `bookmark-alist` | ~12 lines |
+| flycheck | `flycheck-current-errors` | ~10 lines |
+| git-gutter | `git-gutter:diffinfos` | ~12 lines |
+| diff-hl | `diff-hl-changes` (a function) | ~14 lines |
+
+The pattern is always the same: read the state, map each entry to a `:line`/`:pos`
+plus a `:shape`/`:text`/`:color`, return the list.
+
+## Job 2 — stop the original drawing
+
+The difficulty depends entirely on *how* the source draws:
+
+- **It has a minor mode you can disable** → trivial. Turn it off and read the
+  underlying data instead. e.g. `evil-fringe-mark`:
+  `(global-evil-fringe-mark-mode -1)`, then read evil's own `evil-markers-alist`.
+- **It draws in the *fringe*, you draw in the *margin*** → you may not need to
+  suppress it at all; the two regions coexist, so "diversion" is just *addition*.
+  Suppress only to reclaim the fringe, usually via the package's own knob
+  (e.g. `flycheck-indication-mode`).
+- **It draws in the *margin* (a true duel)** → override its draw function so it
+  keeps computing but stops drawing. This was the hardest case among everything
+  shipped, and it was **one line** (see the git-gutter example below).
+
+## The fiddly part: refresh timing
+
+Neither job above is usually the tricky one — knowing *when* to re-render is.
+You need a trigger that fires when the source's data changes:
+
+- best — the package provides a hook (`flycheck-after-syntax-check-hook`);
+- common — advise the package's setter (`evil-set-marker`, `bookmark-set`);
+- bonus — when you override a draw function (the duel case), that override
+  *is* your refresh trigger.
+
+Always pair the trigger with a teardown that removes the hook/advice.
+
+## The hard tail (honestly)
+
+- **Data not exposed** — a package that computes and draws in one closure with
+  no stored state. You must advise its compute function to capture the data, or
+  re-derive it yourself. Medium-hard.
+- **Data that's expensive to produce** — git-blame heat, coverage: you run git /
+  parse a report, ideally asynchronously. Real effort, but it lives in *your*
+  provider, not in fighting svg-margin.
+- **No generic interception** — svg-margin can't auto-divert arbitrary fringe
+  users; fringe bitmaps are opaque and drawing mechanisms differ per package.
+  Diversion is adapter-based by design.
+
+The decoupling is what keeps this tractable: svg-margin only ever needs **data +
+a position**, so you never reverse-engineer its rendering — you just read state
+you can already reach.
+
+## Worked example: divert git-gutter (the duel case)
+
+git-gutter draws VC hunks in the *margin* itself, so it would fight svg-margin.
+The fix keeps git-gutter computing but stops it drawing, and renders from its
+data:
+
+```elisp
+;; Job 1: a provider that reads git-gutter's hunks
+(defun my-gg-provider (buffer)
+  (with-current-buffer buffer
+    (when (and (bound-and-true-p git-gutter-mode) (boundp 'git-gutter:diffinfos))
+      (let (out)
+        (dolist (h git-gutter:diffinfos)
+          (let ((start (git-gutter-hunk-start-line h))
+                (end   (or (git-gutter-hunk-end-line h)
+                           (git-gutter-hunk-start-line h)))
+                (type  (git-gutter-hunk-type h)))
+            (if (eq type 'deleted)
+                (push (list :line start :shape 'triangle :color "#f85149") out)
+              (cl-loop for ln from start to end do
+                       (push (list :line ln :shape 'bar
+                                   :color (if (eq type 'added) "#3fb950" "#d29922"))
+                             out)))))
+        out))))
+
+;; Job 2 + refresh: stop git-gutter drawing; its draw call becomes the trigger
+(defun my-gg-feed (&rest _) (svg-margin-refresh))
+
+(advice-add 'git-gutter:view-diff-infos :override #'my-gg-feed)
+(svg-margin-register-provider 'git-gutter #'my-gg-provider :side 'left :priority 9)
+(global-git-gutter-mode 1)   ; still computes; just doesn't draw
+```
+
+To undo:
+
+```elisp
+(advice-remove 'git-gutter:view-diff-infos #'my-gg-feed)
+(svg-margin-unregister-provider 'git-gutter)
+```
+
+A package with a plain variable and a disableable mode (evil marks, bookmarks)
+is simpler still — no override needed. See [EXAMPLES.md](EXAMPLES.md) for all of
+the shipped adapters.

--- a/source/zettapkg/svg-margin/EXAMPLES.md
+++ b/source/zettapkg/svg-margin/EXAMPLES.md
@@ -12,8 +12,12 @@ columns, and draws one composite SVG per line/side.
 
 ## Loading & turning them on
 
+This file is **not installed** with the package (the Eask `files` clause ships
+only `svg-margin.el`), so load it from your checkout — substitute the real path
+to the `examples/` directory of your clone:
+
 ```elisp
-(load-file ".../svg-margin/examples/svg-margin-examples.el")
+(load-file "/path/to/svg-margin/examples/svg-margin-examples.el")
 
 (svg-margin-example-setup)          ; core set + fringe diversion + the mode
 (svg-margin-example-extras-setup)   ; the five "extra" demo providers
@@ -134,6 +138,8 @@ TODO, and so on. Every side is configurable (see *Configuring sides*).
 ### symbol — occurrences of the symbol at point
 
 - **What:** a dot on every line where the symbol under the cursor also appears.
+  Active **only in `prog-mode` buffers, and only for symbols of 3+ characters**
+  (so short identifiers like `i`/`fn` and prose buffers stay quiet).
 - **Looks:** blue dots that move with you as you navigate.
 - **Why:** an instant "where else is this used" map, like a lightweight
   `highlight-symbol`, without changing the buffer text.
@@ -163,6 +169,12 @@ it. Every example stamps `:side` from one alist:
 
 Flip any entry to move that source to the other margin — no code change. The
 engine reserves and draws both margins independently.
+
+`svg-margin-example-sides` is this gallery's own knob. For **third-party**
+providers you didn't write, the engine offers the same control directly:
+`svg-margin-provider-sides` (an alist the engine honours) and the `:side`
+argument to `svg-margin-register-provider` — so you can relocate any provider
+without editing it.
 
 ## Fringe diversion
 

--- a/source/zettapkg/svg-margin/EXAMPLES.md
+++ b/source/zettapkg/svg-margin/EXAMPLES.md
@@ -1,0 +1,213 @@
+# svg-margin example providers
+
+`examples/svg-margin-examples.el` is **not part of the package** — it is a
+gallery of ready-made providers that feed the [svg-margin](README.md) gutter
+from real data sources. They double as a tutorial: each one is short, and
+together they exercise every technique you'd use to write your own.
+
+A **provider** is just a function `BUFFER -> (list of indicators)`; see the
+[README](README.md) for the indicator keys. The engine pulls every registered
+provider on render, groups indicators by `(line, side)`, packs them into
+columns, and draws one composite SVG per line/side.
+
+## Loading & turning them on
+
+```elisp
+(load-file ".../svg-margin/examples/svg-margin-examples.el")
+
+(svg-margin-example-setup)          ; core set + fringe diversion + the mode
+(svg-margin-example-extras-setup)   ; the five "extra" demo providers
+```
+
+Each group also has a matching `…-teardown`. `svg-margin-example-setup` enables
+`svg-margin-mode`, reclaims the **left** fringe (see *Fringe diversion* below),
+and picks a single VC source (git-gutter if present, else diff-hl).
+
+## At a glance
+
+| Provider | Source | Side | Drawn as | Prio | Setup |
+|----------|--------|------|----------|:----:|-------|
+| `git-gutter` | `git-gutter:diffinfos` | left | bar (green/amber) · triangle (del) | 9 | `…-git-gutter-setup` |
+| `vc` | `diff-hl-changes` | left | bar / triangle | 9 | core (fallback) |
+| `flycheck` | `flycheck-current-errors` | left | dot (red/amber/green) | 8 | extras |
+| `todo` | buffer scan | right | dot (amber/red/purple) | 7 | core |
+| `bookmarks` | `bookmark-alist` | right | ribbon (purple) | 6 | core |
+| `evil-marks` | `evil-markers-alist` | left | letter glyph | 5 | core |
+| `org-headings` | buffer scan | left | depth-sized rail | 4 | extras |
+| `long-lines` | buffer scan | right | bar (gold) | 3 | extras |
+| `symbol` | symbol at point | right | dot (blue) | 2 | extras |
+| `trailing-ws` | buffer scan | right | dot (grey) | 1 | extras |
+
+Priority sets packing order: higher numbers claim the column **nearest the
+text**, so on a shared line you read outward — VC bar, then flycheck dot, then
+TODO, and so on. Every side is configurable (see *Configuring sides*).
+
+## The providers
+
+### git-gutter — version-control hunks
+
+- **What:** a coloured bar on every added/modified line, a triangle where a
+  hunk was deleted, read from git-gutter's own `git-gutter:diffinfos`.
+- **Looks:** thin vertical bar hugging the text — green = added, amber =
+  modified, red triangle = deletion.
+- **Why:** the canonical gutter, but now sharing the margin with everything
+  else instead of monopolising it.
+- **Technique — coexisting with a package that also draws.** git-gutter
+  normally draws into the margin itself and would *duel* with svg-margin
+  (each resets the margin width → flicker). The setup overrides
+  `git-gutter:view-diff-infos` so git-gutter keeps **computing** hunks but
+  **draws nothing**; svg-margin renders them. Use this pattern for any package
+  that owns a margin/fringe you want to take over.
+
+### vc — version-control hunks via diff-hl
+
+- **What:** the same idea sourced from `diff-hl-changes` instead of git-gutter.
+- **Why:** an alternative for diff-hl users. Use **one** VC provider, not both
+  (both draw at priority 9 and would stack two bars per line).
+- **Technique — parsing a less obvious data shape.** `diff-hl-changes` returns
+  `((:working . CHANGES) …)` where each change is `(LINE INSERTS DELETES TYPE)`
+  — a good reminder to read the source rather than guess the format.
+
+### flycheck — diagnostics
+
+- **What:** a severity-coloured dot on each line with a flycheck error.
+- **Looks:** red = error, amber = warning, green = info; the message is the
+  tooltip.
+- **Why:** replaces the fringe error bitmaps with crisper dots that can sit
+  beside VC and marks instead of fighting them for the fringe.
+- **Technique — external-package integration + its refresh hook.** Reads
+  `flycheck-current-errors` and refreshes on `flycheck-after-syntax-check-hook`,
+  so the gutter updates exactly when new diagnostics arrive.
+
+### todo — keyword markers
+
+- **What:** a dot wherever `TODO`, `FIXME`, or `HACK` appears.
+- **Looks:** amber (TODO), red (FIXME), purple (HACK).
+- **Why:** a lightweight "things to come back to" map down the side of the file.
+- **Technique — a pure buffer scan.** No dependency: `re-search-forward` over
+  the buffer, emitting an indicator per match.
+
+### bookmarks — Emacs bookmarks
+
+- **What:** a ribbon on each line that a bookmark points to (matched by file).
+- **Looks:** a purple bookmark-ribbon (a notched pennant).
+- **Why:** see your bookmarks in context instead of only in a list, without the
+  bookmark fringe glyph.
+- **Technique — a custom shape via `svg-margin-define-shape`.** The ribbon is
+  registered once as the `bookmark` shape (an `svg-polygon`), then any indicator
+  can use `:shape 'bookmark`. This is the SVG analogue of
+  `define-fringe-bitmap`. Refreshes on `bookmark-set` / `bookmark-delete`.
+
+### evil-marks — evil marks
+
+- **What:** the mark letter (`a`–`z`) drawn where the mark sits.
+- **Looks:** the literal letter in the warning face.
+- **Why:** a drop-in replacement for `evil-fringe-mark` that reads evil's own
+  data, so it needs no fringe at all — and several marks on one line pack into
+  columns instead of overwriting each other.
+- **Technique — text as an indicator (`:text`) + reading another package's
+  state.** Reads `evil-markers-alist` directly; refreshes via advice on
+  `evil-set-marker`.
+
+### org-headings — a structure rail
+
+- **What:** a tick beside every Org heading, in `org-mode` buffers.
+- **Looks:** a short vertical bar whose **height and colour encode the heading
+  depth** — level 1 tallest, deeper levels shorter, coloured by the matching
+  `org-level-N` face.
+- **Why:** an at-a-glance outline rail in the margin.
+- **Technique — mode-specific + a custom `:draw` with variable geometry.**
+  Instead of a named shape it supplies a `:draw` lambda that closes over the
+  heading level and sizes the rectangle accordingly — the "you can draw
+  anything" escape hatch.
+
+### long-lines — overlong-line warning
+
+- **What:** a bar on every prog-mode line past
+  `svg-margin-example-long-line-column` (default 80).
+- **Looks:** a gold vertical bar on the right.
+- **Why:** spot lines that blow past your width budget without `whitespace-mode`
+  cluttering the text.
+- **Technique — a pure scan with per-line measurement** (`current-column` at
+  end of line).
+
+### symbol — occurrences of the symbol at point
+
+- **What:** a dot on every line where the symbol under the cursor also appears.
+- **Looks:** blue dots that move with you as you navigate.
+- **Why:** an instant "where else is this used" map, like a lightweight
+  `highlight-symbol`, without changing the buffer text.
+- **Technique — a dynamic, point-driven provider.** A `post-command-hook`
+  watcher refreshes svg-margin **only when the symbol at point changes**
+  (tracked in a variable), so cursor motion doesn't cause render churn.
+
+### trailing-ws — trailing whitespace
+
+- **What:** a small grey dot on each line ending in spaces/tabs.
+- **Why:** catch stray whitespace at a glance.
+- **Technique — the simplest possible scan**, included to show how little a
+  provider needs to be.
+
+## Configuring sides
+
+Which margin a source uses is **pure configuration** — providers never hardcode
+it. Every example stamps `:side` from one alist:
+
+```elisp
+(setq svg-margin-example-sides
+      '((git-gutter . left) (vc . left) (evil-marks . left)
+        (flycheck . left)   (org-headings . left)
+        (todo . right) (bookmarks . right) (long-lines . right)
+        (trailing-ws . right) (symbol . right)))
+```
+
+Flip any entry to move that source to the other margin — no code change. The
+engine reserves and draws both margins independently.
+
+## Fringe diversion
+
+`svg-margin-example-setup` reclaims only the **left** fringe
+(`svg-margin-disable-fringe 'left`) — evil-fringe-mark's old home, now migrated
+into the margin. Disabling a fringe is about migrating *that fringe's users*,
+not about which margin side you draw in: margins and fringes are separate
+regions, so right-margin indicators show fine while the **right** fringe stays
+available for `yascroll` / `flycheck` / continuation arrows. Only disable a
+fringe once nothing else needs it.
+
+## Writing your own
+
+A minimal provider and registration:
+
+```elisp
+(defun my-margin-provider (buffer)
+  (with-current-buffer buffer
+    (when (derived-mode-p 'prog-mode)
+      (list (list :line 1 :side 'left :shape 'dot :color "#f85149"
+                  :help "first line")))))
+
+(svg-margin-register-provider 'mine #'my-margin-provider)
+```
+
+Patterns worth copying from the gallery:
+- **pure scan** (`todo`, `long-lines`, `trailing-ws`) — no dependency;
+- **read another package's state** (`evil-marks`, `bookmarks`, `git-gutter`);
+- **custom shape** once, reused (`svg-margin-define-shape`, see `bookmarks`);
+- **custom `:draw`** per indicator for variable geometry (`org-headings`);
+- **dynamic refresh** keyed to a change you care about (`symbol`,
+  `flycheck`) — and refresh *only* when it changes, to avoid churn;
+- **take over a drawing package** by overriding its draw function and reading
+  its data (`git-gutter`).
+
+## More ideas (not yet built)
+
+The same model fits many other per-line, sparse data sources:
+
+- **git-blame heat** — a bar coloured by each line's commit age (recent = warm).
+- **test coverage** — green/red bars for covered/uncovered lines.
+- **LSP diagnostics**, **compilation errors**, **flyspell** misspellings.
+- **merge-conflict** regions; **forge/PR review** comments.
+- **imenu / outline** rail (like `org-headings`, for any language).
+- **multiple-cursors** positions; **occur / isearch** match map.
+- **debugger** breakpoints and the current execution line.
+- **annotations** (annotate.el), **footnotes/links**, **registers**.
+- **recently-edited heat** that fades over time.

--- a/source/zettapkg/svg-margin/Eask
+++ b/source/zettapkg/svg-margin/Eask
@@ -1,0 +1,23 @@
+; -*- lexical-binding: t -*-
+
+(package "svg-margin"
+         "0.1.0"
+         "Multi-provider SVG indicators in the window margins")
+
+(website-url "https://github.com/chiply/svg-margin")
+(keywords "convenience" "faces" "frames")
+
+(package-file "svg-margin.el")
+
+;; Only the engine ships; tests and examples are excluded from the package.
+(files "svg-margin.el")
+
+(script "test" "eask test ert ./test/svg-margin-test.el")
+
+(source "gnu")
+(source "melpa")
+
+(depends-on "emacs" "29.1")
+
+(development
+ (depends-on "package-lint"))

--- a/source/zettapkg/svg-margin/LICENSE
+++ b/source/zettapkg/svg-margin/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -26,8 +26,9 @@ a tiny adapter) supply them.
 
 ## Installation
 
-Requires **Emacs 29.1+**; no dependencies beyond the built-in `svg.el`.
-Once on MELPA:
+Requires **Emacs 29.1+** and a **graphical frame** (it draws SVG images, so
+it shows nothing in a terminal `emacs -nw`); no dependencies beyond the
+built-in `svg.el`. Once on MELPA:
 
 ```elisp
 (use-package svg-margin
@@ -56,11 +57,11 @@ Or manually, with `svg-margin.el` on your `load-path`:
 
 | Key         | Meaning                                                        |
 |-------------|----------------------------------------------------------------|
-| `:pos`/`:line` | buffer position or 1-based line (one is required)           |
+| `:pos`/`:line` | buffer position or **absolute** 1-based line (one is required; resolved against the whole buffer, so it is correct under narrowing) |
 | `:side`     | `left` (default `svg-margin-default-side`) or `right`          |
 | `:column`   | explicit slot (0 = nearest the text); else auto-packed         |
 | `:priority` | higher is packed first → claims the inner column (default 0)    |
-| `:shape`    | a registered shape: `dot` `circle` `bar` `box` `triangle`      |
+| `:shape`    | a built-in shape: `dot` (filled disc) · `circle` (hollow ring) · `bar` (vertical bar) · `box` (rounded square) · `triangle`, or your own via `svg-margin-define-shape` |
 | `:text`     | a short string drawn centred (e.g. an evil mark letter)        |
 | `:draw`     | `(lambda (SVG X Y W H COLOR) ...)` for full control            |
 | `:color`/`:face` | fill colour, or a face whose foreground is used           |
@@ -68,6 +69,27 @@ Or manually, with `svg-margin.el` on your `load-path`:
 
 Indicators sharing a `(line, side)` pack into adjacent columns; an explicit
 free `:column` is honoured, otherwise each takes the lowest free slot.
+
+One of `:pos`/`:line` is **required** — an indicator without a (valid, in-range)
+position is silently skipped. Set `svg-margin-debug` to `t` to get a message
+naming the provider when that happens (handy while writing one).
+
+### Provider defaults and moving a provider's side
+
+A provider can set defaults so it needn't stamp every indicator, and **users
+can relocate any provider — including a third-party one — without editing it**:
+
+```elisp
+;; provider author: default everything from this provider to the right margin
+(svg-margin-register-provider 'my-source #'my-fn :side 'right :priority 5)
+
+;; user: override where a provider draws, declaratively
+(setq svg-margin-provider-sides '((my-source . left) (flycheck . right)))
+```
+
+Precedence for an indicator's side: `svg-margin-provider-sides` override →
+the indicator's own `:side` → the provider's registered `:side` →
+`svg-margin-default-side`.
 
 ### Custom shapes
 

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -147,6 +147,10 @@ like, why it's useful, and how to write your own.
   the number of indicators, not buffer size.
 - Margins and the composite image are pinned to `:scale 1.0`, so the gutter
   doesn't inherit `image-scaling-factor` and overflow.
+- A side's margin grows to its widest line and shrinks back as indicators come
+  and go. To stop that shifting the buffer, reserve a baseline with
+  `svg-margin-min-left-columns` / `svg-margin-min-right-columns` (see
+  [CONFIGURATION.md](CONFIGURATION.md)).
 
 ## Caveats (v1)
 

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -1,0 +1,131 @@
+# svg-margin
+
+Turn the Emacs window margins into a flexible, **multi-column gutter** that
+many independent sources can draw into — with their indicators packed **side
+by side on the same line**, as crisp **SVG**.
+
+The fringe can only render monochrome bitmaps, and only **one** bitmap per
+line per side — so `git-gutter`, `evil-fringe-mark`, `flycheck`, bookmarks,
+and continuation arrows all compete for the same ~8px strip and clobber each
+other. svg-margin sidesteps that: a margin can show arbitrary SVG, so the
+engine composites *every* indicator for a line/side into **one SVG image** at
+exact pixel coordinates. Both the **left and right** margins are supported.
+
+svg-margin is the rendering **engine** only — it ships no providers. You (or
+a tiny adapter) supply them.
+
+## How it works
+
+- A **provider** is a function `BUFFER -> (list of indicators)`. Register any
+  number of them; they're fully decoupled, so several packages can feed the
+  same gutter.
+- An **indicator** is a plist describing *where* and *what* to draw.
+- On each render the engine pulls all providers, groups indicators by
+  `(line, side)`, **packs them into columns**, and draws one composite SVG
+  per line/side. The margin width on a side grows to the widest line.
+
+## Installation
+
+Requires **Emacs 29.1+**; no dependencies beyond the built-in `svg.el`.
+Once on MELPA:
+
+```elisp
+(use-package svg-margin
+  :ensure t)
+```
+
+Or manually, with `svg-margin.el` on your `load-path`:
+
+```elisp
+(require 'svg-margin)
+```
+
+## Usage
+
+```elisp
+(svg-margin-register-provider 'my-source
+  (lambda (_buffer)
+    (list (list :line 10 :shape 'bar :color "#3fb950")          ; col 0
+          (list :line 10 :text "a"  :face 'warning)             ; col 1, same line
+          (list :line 25 :shape 'dot :side 'right :color "red"))))
+
+(svg-margin-mode 1)            ; buffer-local; or global-svg-margin-mode
+```
+
+### Indicator keys
+
+| Key         | Meaning                                                        |
+|-------------|----------------------------------------------------------------|
+| `:pos`/`:line` | buffer position or 1-based line (one is required)           |
+| `:side`     | `left` (default `svg-margin-default-side`) or `right`          |
+| `:column`   | explicit slot (0 = nearest the text); else auto-packed         |
+| `:priority` | higher is packed first → claims the inner column (default 0)    |
+| `:shape`    | a registered shape: `dot` `circle` `bar` `box` `triangle`      |
+| `:text`     | a short string drawn centred (e.g. an evil mark letter)        |
+| `:draw`     | `(lambda (SVG X Y W H COLOR) ...)` for full control            |
+| `:color`/`:face` | fill colour, or a face whose foreground is used           |
+| `:help`     | tooltip string                                                 |
+
+Indicators sharing a `(line, side)` pack into adjacent columns; an explicit
+free `:column` is honoured, otherwise each takes the lowest free slot.
+
+### Custom shapes
+
+Register your own, the SVG analogue of `define-fringe-bitmap`:
+
+```elisp
+(svg-margin-define-shape 'chevron
+  (lambda (svg x y w h color)
+    (svg-polygon svg (list (cons x y) (cons (+ x w) (+ y (/ h 2))) (cons x (+ y h)))
+                 :fill color)))
+```
+
+## Diverting the fringe
+
+Two independent pieces:
+
+1. **Reclaim the space** — set `svg-margin-disable-fringe` to `left`,
+   `right`, or `both`; svg-margin zeroes that fringe while active and restores
+   it on exit. (Note: a zeroed fringe also hides its truncation/continuation
+   arrows.)
+2. **Move the data** — write a provider that reads the package's own state.
+   No interception needed; adapters are ~10 lines.
+
+`examples/svg-margin-examples.el` ships three, stacking on one line:
+
+- **evil marks** — reads evil's `evil-markers-alist` (no `evil-fringe-mark`,
+  no fringe), drawing each mark letter in the margin;
+- **VC hunks** — reads `diff-hl-changes`, drawing a coloured bar that hugs the
+  text like a gutter;
+- **TODO/FIXME/HACK** — coloured dots.
+
+`M-x svg-margin-example-setup` wires all three plus the fringe diversion.
+
+## Layout notes
+
+- Margin width is measured in **character columns**, so column *N* maps
+  directly to margin width *N* (times `svg-margin-column-width`).
+- Overlays are created **only where indicators exist**, so cost scales with
+  the number of indicators, not buffer size.
+- Margins and the composite image are pinned to `:scale 1.0`, so the gutter
+  doesn't inherit `image-scaling-factor` and overflow.
+
+## Caveats (v1)
+
+- svg-margin **owns** the managed margins while active (one consumer at a time).
+- Margin *content* (the overlay images) is per-buffer, while the reserved
+  *width* is per-window — so the same indicators show in every window on the
+  buffer.
+- Each indicator occupies one column (multi-column-wide single indicators are
+  not yet modelled).
+
+## Tests
+
+```sh
+cd test
+emacs -Q --batch -L .. -l svg-margin-test.el -f ert-run-tests-batch-and-exit
+```
+
+Rendering/overlay/margin behaviour needs a live graphical frame; the test
+suite covers the pure logic (column packing, colour, normalisation, grouping,
+shape registry).

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -113,6 +113,12 @@ Two independent pieces:
 ## Caveats (v1)
 
 - svg-margin **owns** the managed margins while active (one consumer at a time).
+  Another package that also writes the *same* window margin — e.g. `git-gutter`
+  in its margin (non-fringe) mode — will duel with it: each re-sets the margin
+  width to its own value and reacts to the other's change, so the buffer text
+  **flickers left/right**. Disable the other margin user (and instead feed its
+  data in through an svg-margin provider). svg-margin only writes a window whose
+  margins actually changed, so it never duels with *itself*.
 - Margin *content* (the overlay images) is per-buffer, while the reserved
   *width* is per-window — so the same indicators show in every window on the
   buffer.

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -88,6 +88,12 @@ Two independent pieces:
    `right`, or `both`; svg-margin zeroes that fringe while active and restores
    it on exit. (Note: a zeroed fringe also hides its truncation/continuation
    arrows.)
+
+   This is **independent of which margin side you draw in** — margins and
+   fringes are separate regions, so right-margin indicators coexist with the
+   right fringe. Disable a fringe only once you've migrated *its* users:
+   e.g. don't zero the right fringe if `yascroll`/`flycheck` still draw a
+   scroll bar / checker marks there, or they'll have nowhere to render.
 2. **Move the data** — write a provider that reads the package's own state.
    No interception needed; adapters are ~10 lines.
 

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -14,6 +14,10 @@ exact pixel coordinates. Both the **left and right** margins are supported.
 svg-margin is the rendering **engine** only — it ships no providers. You (or
 a tiny adapter) supply them.
 
+**Docs:** this README (engine + API) · [CONFIGURATION.md](CONFIGURATION.md)
+(options, and diverting data from other fringe/margin packages) ·
+[EXAMPLES.md](EXAMPLES.md) (ten ready-made providers).
+
 ## How it works
 
 - A **provider** is a function `BUFFER -> (list of indicators)`. Register any
@@ -118,6 +122,11 @@ Two independent pieces:
    scroll bar / checker marks there, or they'll have nowhere to render.
 2. **Move the data** — write a provider that reads the package's own state.
    No interception needed; adapters are ~10 lines.
+
+For how hard this is in practice — reading a package's data vs. stopping its own
+drawing, the difficulty tiers, refresh triggers, and a worked git-gutter
+example — see **[CONFIGURATION.md](CONFIGURATION.md)** ("Diverting data from
+other packages").
 
 `examples/svg-margin-examples.el` ships ten ready-made providers — VC
 (git-gutter or diff-hl), flycheck, TODO/FIXME, bookmarks, evil marks, an Org

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -97,15 +97,16 @@ Two independent pieces:
 2. **Move the data** — write a provider that reads the package's own state.
    No interception needed; adapters are ~10 lines.
 
-`examples/svg-margin-examples.el` ships three, stacking on one line:
+`examples/svg-margin-examples.el` ships ten ready-made providers — VC
+(git-gutter or diff-hl), flycheck, TODO/FIXME, bookmarks, evil marks, an Org
+heading rail, long-line and trailing-whitespace hygiene, and live
+symbol-at-point occurrences — that stack into columns on shared lines. Each is
+short and demonstrates a different technique. `M-x svg-margin-example-setup`
+(plus `M-x svg-margin-example-extras-setup`) wires them up with the fringe
+diversion.
 
-- **evil marks** — reads evil's `evil-markers-alist` (no `evil-fringe-mark`,
-  no fringe), drawing each mark letter in the margin;
-- **VC hunks** — reads `diff-hl-changes`, drawing a coloured bar that hugs the
-  text like a gutter;
-- **TODO/FIXME/HACK** — coloured dots.
-
-`M-x svg-margin-example-setup` wires all three plus the fringe diversion.
+See **[EXAMPLES.md](EXAMPLES.md)** for what each provider does, what it looks
+like, why it's useful, and how to write your own.
 
 ## Layout notes
 

--- a/source/zettapkg/svg-margin/examples/svg-margin-examples.el
+++ b/source/zettapkg/svg-margin/examples/svg-margin-examples.el
@@ -17,7 +17,29 @@
 (require 'svg-margin)
 
 (defvar evil-markers-alist)
+(defvar git-gutter:diffinfos)
+(defvar bookmark-alist)
 (declare-function diff-hl-changes "diff-hl")
+(declare-function git-gutter-hunk-start-line "git-gutter")
+(declare-function git-gutter-hunk-end-line "git-gutter")
+(declare-function git-gutter-hunk-type "git-gutter")
+(declare-function global-git-gutter-mode "git-gutter")
+(declare-function bookmark-get-filename "bookmark")
+(declare-function bookmark-get-position "bookmark")
+
+;; A bookmark-ribbon shape, to show `svg-margin-define-shape'.
+(svg-margin-define-shape 'bookmark
+  (lambda (svg x y w h color)
+    (let* ((bw (max 4 (round (* w 0.52))))
+           (bx (+ x (/ (- w bw) 2)))
+           (top (+ y (round (* h 0.16))))
+           (bot (+ y (round (* h 0.84))))
+           (notch (+ y (round (* h 0.6)))))
+      (svg-polygon svg
+                   (list (cons bx top) (cons (+ bx bw) top)
+                         (cons (+ bx bw) bot) (cons (+ bx (/ bw 2)) notch)
+                         (cons bx bot))
+                   :fill color))))
 
 ;;;; Provider: TODO/FIXME/HACK keywords -> coloured dots
 
@@ -40,22 +62,83 @@
 ;;;; Provider: VC hunks (diverted from the diff-hl/git-gutter fringe)
 
 (defun svg-margin-example-vc (buffer)
-  "Return vertical-bar indicators for VC hunks in BUFFER (via `diff-hl-changes').
-Drawn at the inner column (priority 9) so it hugs the text like a gutter."
+  "Return vertical-bar indicators for VC hunks in BUFFER via `diff-hl-changes'.
+An ALTERNATIVE VC source to `svg-margin-example-git-gutter' -- use one, not
+both (both draw at priority 9 and would stack two bars per line).
+
+`diff-hl-changes' returns an alist ((:working . CHANGES) ...) where each
+change is (LINE INSERTS DELETES TYPE) and TYPE is `insert', `delete' or
+`change'."
   (with-current-buffer buffer
     (when (fboundp 'diff-hl-changes)
+      (let ((changes (ignore-errors (alist-get :working (diff-hl-changes))))
+            out)
+        (dolist (chg changes)
+          (cl-destructuring-bind (line inserts _deletes type) chg
+            (if (eq type 'delete)
+                (push (list :line line :shape 'triangle :priority 9
+                            :color "#f85149" :help "deleted")
+                      out)
+              (cl-loop for i from 0 below (max 1 inserts) do
+                       (push (list :line (+ line i) :shape 'bar :priority 9
+                                   :color (if (eq type 'insert) "#3fb950" "#d29922")
+                                   :help (symbol-name type))
+                             out)))))
+        out))))
+
+;;;; Provider: VC hunks via git-gutter (data-only; git-gutter does not draw)
+
+(defun svg-margin-example-git-gutter (buffer)
+  "Return vertical-bar indicators for git-gutter's hunks in BUFFER.
+Reads git-gutter's buffer-local `git-gutter:diffinfos'.  Use together with
+`svg-margin-example-git-gutter-setup', which keeps git-gutter computing but
+stops it drawing (so it does not duel with svg-margin over the margin)."
+  (with-current-buffer buffer
+    (when (and (bound-and-true-p git-gutter-mode) (boundp 'git-gutter:diffinfos))
       (let (out)
-        (dolist (hunk (ignore-errors (diff-hl-changes)))
-          (cl-destructuring-bind (line len type) hunk
-            (dotimes (i (max 1 len))
-              (push (list :line (+ line i)
-                          :shape 'bar
-                          :priority 9
-                          :color (pcase type
-                                   ('insert "#3fb950") ('delete "#f85149") (_ "#d29922"))
-                          :help (symbol-name type))
+        (dolist (info git-gutter:diffinfos)
+          (let* ((start (git-gutter-hunk-start-line info))
+                 (end   (or (git-gutter-hunk-end-line info) start))
+                 (type  (git-gutter-hunk-type info)))
+            (pcase type
+              ((or 'added 'modified)
+               (cl-loop for ln from start to (min end (+ start 1000)) do
+                        (push (list :line ln :shape 'bar :priority 9
+                                    :color (if (eq type 'added) "#3fb950" "#d29922")
+                                    :help (symbol-name type))
+                              out)))
+              ('deleted
+               (push (list :line start :shape 'triangle :priority 9
+                           :color "#f85149" :help "deleted")
+                     out)))))
+        out))))
+
+(defun svg-margin-example--gg-feed (&rest _)
+  "Override of `git-gutter:view-diff-infos': refresh svg-margin, draw nothing.
+git-gutter still computes `git-gutter:diffinfos'; svg-margin draws from them."
+  (svg-margin-refresh))
+
+;;;; Provider: bookmarks (diverted from the bookmark fringe)
+
+(defun svg-margin-example-bookmarks (buffer)
+  "Return ribbon indicators for bookmarks pointing into BUFFER's file.
+Reads the global `bookmark-alist' and matches by file name."
+  (with-current-buffer buffer
+    (when (and buffer-file-name (bound-and-true-p bookmark-alist))
+      (let ((file (file-truename buffer-file-name)) out)
+        (dolist (bm bookmark-alist)
+          (let ((bmfile (ignore-errors (bookmark-get-filename bm)))
+                (pos (ignore-errors (bookmark-get-position bm))))
+            (when (and bmfile pos (string= (file-truename bmfile) file))
+              (push (list :pos pos :shape 'bookmark :priority 6
+                          :color "#7d5bed"
+                          :help (format "bookmark: %s" (car bm)))
                     out))))
         out))))
+
+(defun svg-margin-example--bookmark-refresh (&rest _)
+  "Refresh svg-margin after a bookmark is set or deleted."
+  (svg-margin-refresh-all))
 
 ;;;; Provider: evil marks (diverted from the evil-fringe-mark fringe)
 
@@ -89,17 +172,58 @@ nor any fringe."
 (defun svg-margin-example-setup ()
   "Register the example providers, divert the left fringe, and enable the mode.
 Demonstrates several sources stacking columns on one line: a VC bar nearest
-the text, a TODO dot, and an evil-mark letter, all in the left margin."
+the text, a TODO dot, a bookmark ribbon, and an evil-mark letter, all in the
+left margin.  For VC it prefers git-gutter and falls back to diff-hl -- never
+both, since they would draw two bars per line."
   (interactive)
   (svg-margin-register-provider 'todo #'svg-margin-example-todo)
-  (when (fboundp 'diff-hl-changes)
-    (svg-margin-register-provider 'vc #'svg-margin-example-vc))
   (when (boundp 'evil-markers-alist)
     (svg-margin-register-provider 'evil-marks #'svg-margin-example-evil-marks)
     (advice-add 'evil-set-marker :after #'svg-margin-example--mark-refresh))
+  (when (fboundp 'bookmark-get-position)
+    (svg-margin-example-bookmarks-setup))
+  (cond ((fboundp 'global-git-gutter-mode) (svg-margin-example-git-gutter-setup))
+        ((fboundp 'diff-hl-changes)
+         (svg-margin-register-provider 'vc #'svg-margin-example-vc)))
   (setq svg-margin-disable-fringe 'left)
   (svg-margin-mode 1)
-  (message "svg-margin example active: VC + TODO + evil marks in the left margin"))
+  (message "svg-margin example active: VC + TODO + bookmarks + evil marks in the left margin"))
+
+;;;###autoload
+(defun svg-margin-example-git-gutter-setup ()
+  "Feed git-gutter's VC hunks into the svg-margin gutter.
+Overrides git-gutter's own drawing (so it does not duel with svg-margin
+over the margin), registers the git-gutter provider, and enables
+`global-git-gutter-mode' for its computation."
+  (interactive)
+  (advice-add 'git-gutter:view-diff-infos :override #'svg-margin-example--gg-feed)
+  (svg-margin-register-provider 'git-gutter #'svg-margin-example-git-gutter)
+  (global-git-gutter-mode 1)
+  (svg-margin-refresh-all)
+  (message "svg-margin: git-gutter hunks now drawn in the margin"))
+
+(defun svg-margin-example-git-gutter-teardown ()
+  "Undo `svg-margin-example-git-gutter-setup'."
+  (interactive)
+  (advice-remove 'git-gutter:view-diff-infos #'svg-margin-example--gg-feed)
+  (svg-margin-unregister-provider 'git-gutter))
+
+;;;###autoload
+(defun svg-margin-example-bookmarks-setup ()
+  "Draw bookmarks in the svg-margin gutter and refresh when they change."
+  (interactive)
+  (svg-margin-register-provider 'bookmarks #'svg-margin-example-bookmarks)
+  (advice-add 'bookmark-set :after #'svg-margin-example--bookmark-refresh)
+  (advice-add 'bookmark-delete :after #'svg-margin-example--bookmark-refresh)
+  (svg-margin-refresh-all)
+  (message "svg-margin: bookmarks now drawn in the margin"))
+
+(defun svg-margin-example-bookmarks-teardown ()
+  "Undo `svg-margin-example-bookmarks-setup'."
+  (interactive)
+  (svg-margin-unregister-provider 'bookmarks)
+  (advice-remove 'bookmark-set #'svg-margin-example--bookmark-refresh)
+  (advice-remove 'bookmark-delete #'svg-margin-example--bookmark-refresh))
 
 (defun svg-margin-example-teardown ()
   "Undo `svg-margin-example-setup' in the current buffer."
@@ -108,7 +232,9 @@ the text, a TODO dot, and an evil-mark letter, all in the left margin."
   (svg-margin-unregister-provider 'todo)
   (svg-margin-unregister-provider 'vc)
   (svg-margin-unregister-provider 'evil-marks)
-  (advice-remove 'evil-set-marker #'svg-margin-example--mark-refresh))
+  (advice-remove 'evil-set-marker #'svg-margin-example--mark-refresh)
+  (svg-margin-example-bookmarks-teardown)
+  (svg-margin-example-git-gutter-teardown))
 
 (provide 'svg-margin-examples)
 ;;; svg-margin-examples.el ends here

--- a/source/zettapkg/svg-margin/examples/svg-margin-examples.el
+++ b/source/zettapkg/svg-margin/examples/svg-margin-examples.el
@@ -302,15 +302,21 @@ nor any fringe."
     (let ((sym (and (derived-mode-p 'prog-mode)
                     (ignore-errors (thing-at-point 'symbol t)))))
       (when (and sym (>= (length sym) 3))
-        (let ((re (concat "\\_<" (regexp-quote sym) "\\_>")) out)
+        (let ((re (concat "\\_<" (regexp-quote sym) "\\_>"))
+              (seen (make-hash-table :test 'eql)) out)
           (save-excursion
             (goto-char (point-min))
             (while (re-search-forward re nil t)
-              (push (list :pos (match-beginning 0)
-                          :side (svg-margin-example--side 'symbol)
-                          :shape 'dot :priority 2 :color "#58a6ff"
-                          :help (format "occurrence of `%s'" sym))
-                    out)))
+              ;; one indicator per LINE, not per occurrence -- several matches
+              ;; on the same line must not each claim a column.
+              (let ((bol (line-beginning-position)))
+                (unless (gethash bol seen)
+                  (puthash bol t seen)
+                  (push (list :pos bol
+                              :side (svg-margin-example--side 'symbol)
+                              :shape 'dot :priority 2 :color "#58a6ff"
+                              :help (format "occurrence of `%s'" sym))
+                        out)))))
           out)))))
 
 (defun svg-margin-example--symbol-watch ()

--- a/source/zettapkg/svg-margin/examples/svg-margin-examples.el
+++ b/source/zettapkg/svg-margin/examples/svg-margin-examples.el
@@ -1,0 +1,114 @@
+;;; svg-margin-examples.el --- Example svg-margin providers -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;;
+;; NOT part of the svg-margin package -- example providers showing how to
+;; feed the margin gutter from several independent sources, including
+;; DIVERTING fringe data (evil marks, VC hunks) into the margin so they can
+;; coexist column-by-column on the same line.
+;;
+;; Try it:  M-M-x load this file, then `M-x svg-margin-example-setup'.
+;;
+;; A provider is just (BUFFER -> list of indicator plists); see the
+;; svg-margin Commentary for the indicator keys.
+
+;;; Code:
+
+(require 'svg-margin)
+
+(defvar evil-markers-alist)
+(declare-function diff-hl-changes "diff-hl")
+
+;;;; Provider: TODO/FIXME/HACK keywords -> coloured dots
+
+(defun svg-margin-example-todo (buffer)
+  "Return dot indicators for TODO/FIXME/HACK keywords in BUFFER."
+  (with-current-buffer buffer
+    (let (out)
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward "\\_<\\(TODO\\|FIXME\\|HACK\\)\\_>" nil t)
+          (push (list :pos (match-beginning 0)
+                      :shape 'dot
+                      :priority 7
+                      :color (pcase (match-string 1)
+                               ("TODO" "#d29922") ("FIXME" "#f85149") (_ "#a371f7"))
+                      :help (match-string 1))
+                out)))
+      out)))
+
+;;;; Provider: VC hunks (diverted from the diff-hl/git-gutter fringe)
+
+(defun svg-margin-example-vc (buffer)
+  "Return vertical-bar indicators for VC hunks in BUFFER (via `diff-hl-changes').
+Drawn at the inner column (priority 9) so it hugs the text like a gutter."
+  (with-current-buffer buffer
+    (when (fboundp 'diff-hl-changes)
+      (let (out)
+        (dolist (hunk (ignore-errors (diff-hl-changes)))
+          (cl-destructuring-bind (line len type) hunk
+            (dotimes (i (max 1 len))
+              (push (list :line (+ line i)
+                          :shape 'bar
+                          :priority 9
+                          :color (pcase type
+                                   ('insert "#3fb950") ('delete "#f85149") (_ "#d29922"))
+                          :help (symbol-name type))
+                    out))))
+        out))))
+
+;;;; Provider: evil marks (diverted from the evil-fringe-mark fringe)
+
+(defun svg-margin-example-evil-marks (buffer)
+  "Return letter indicators for buffer-local evil marks a-z in BUFFER.
+Reads evil's own `evil-markers-alist', so it needs neither evil-fringe-mark
+nor any fringe."
+  (with-current-buffer buffer
+    (when (boundp 'evil-markers-alist)
+      (let (out)
+        (dolist (cell evil-markers-alist)
+          (let ((char (car cell)) (val (cdr cell)))
+            (when (and (markerp val)
+                       (eq (marker-buffer val) buffer)
+                       (>= char ?a) (<= char ?z))
+              (push (list :pos (marker-position val)
+                          :text (char-to-string char)
+                          :priority 5
+                          :face 'warning
+                          :help (format "evil mark `%c'" char))
+                    out))))
+        out))))
+
+(defun svg-margin-example--mark-refresh (&rest _)
+  "Refresh svg-margin after an evil mark changes."
+  (svg-margin-refresh))
+
+;;;; Wiring
+
+;;;###autoload
+(defun svg-margin-example-setup ()
+  "Register the example providers, divert the left fringe, and enable the mode.
+Demonstrates several sources stacking columns on one line: a VC bar nearest
+the text, a TODO dot, and an evil-mark letter, all in the left margin."
+  (interactive)
+  (svg-margin-register-provider 'todo #'svg-margin-example-todo)
+  (when (fboundp 'diff-hl-changes)
+    (svg-margin-register-provider 'vc #'svg-margin-example-vc))
+  (when (boundp 'evil-markers-alist)
+    (svg-margin-register-provider 'evil-marks #'svg-margin-example-evil-marks)
+    (advice-add 'evil-set-marker :after #'svg-margin-example--mark-refresh))
+  (setq svg-margin-disable-fringe 'left)
+  (svg-margin-mode 1)
+  (message "svg-margin example active: VC + TODO + evil marks in the left margin"))
+
+(defun svg-margin-example-teardown ()
+  "Undo `svg-margin-example-setup' in the current buffer."
+  (interactive)
+  (svg-margin-mode -1)
+  (svg-margin-unregister-provider 'todo)
+  (svg-margin-unregister-provider 'vc)
+  (svg-margin-unregister-provider 'evil-marks)
+  (advice-remove 'evil-set-marker #'svg-margin-example--mark-refresh))
+
+(provide 'svg-margin-examples)
+;;; svg-margin-examples.el ends here

--- a/source/zettapkg/svg-margin/examples/svg-margin-examples.el
+++ b/source/zettapkg/svg-margin/examples/svg-margin-examples.el
@@ -26,13 +26,22 @@
 (declare-function global-git-gutter-mode "git-gutter")
 (declare-function bookmark-get-filename "bookmark")
 (declare-function bookmark-get-position "bookmark")
+(defvar flycheck-current-errors)
+(declare-function flycheck-error-line "flycheck")
+(declare-function flycheck-error-level "flycheck")
+(declare-function flycheck-error-message "flycheck")
 
 (defcustom svg-margin-example-sides
-  '((git-gutter . left)
-    (vc         . left)
-    (evil-marks . left)
-    (todo       . right)
-    (bookmarks  . right))
+  '((git-gutter   . left)
+    (vc           . left)
+    (evil-marks   . left)
+    (flycheck     . left)
+    (org-headings . left)
+    (todo         . right)
+    (bookmarks    . right)
+    (long-lines   . right)
+    (trailing-ws  . right)
+    (symbol       . right))
   "Margin side (`left' or `right') for each example provider.
 Providers stamp their indicators with the side looked up here, so moving a
 source between margins is pure configuration -- the engine renders each
@@ -190,6 +199,127 @@ nor any fringe."
   "Refresh svg-margin after an evil mark changes."
   (svg-margin-refresh))
 
+;;;; Provider: flycheck/flymake-style diagnostics (external integration)
+
+(defun svg-margin-example-flycheck (buffer)
+  "Return severity-coloured dots for flycheck diagnostics in BUFFER."
+  (with-current-buffer buffer
+    (when (bound-and-true-p flycheck-mode)
+      (let (out)
+        (dolist (err flycheck-current-errors)
+          (let ((line (flycheck-error-line err))
+                (level (flycheck-error-level err)))
+            (when line
+              (push (list :line line :side (svg-margin-example--side 'flycheck)
+                          :shape 'dot :priority 8
+                          :color (pcase level
+                                   ('error "#f85149") ('warning "#d29922") (_ "#3fb950"))
+                          :help (ignore-errors (flycheck-error-message err)))
+                    out))))
+        out))))
+
+(defun svg-margin-example--flycheck-refresh (&rest _)
+  "Refresh svg-margin after a flycheck check finishes."
+  (svg-margin-refresh))
+
+;;;; Provider: long lines (pure buffer scan, no dependency)
+
+(defcustom svg-margin-example-long-line-column 80
+  "Column past which `svg-margin-example-long-lines' flags a line."
+  :type 'integer :group 'svg-margin)
+
+(defun svg-margin-example-long-lines (buffer)
+  "Return bar indicators for over-long lines in prog-mode BUFFER."
+  (with-current-buffer buffer
+    (when (derived-mode-p 'prog-mode)
+      (let ((col svg-margin-example-long-line-column) out)
+        (save-excursion
+          (goto-char (point-min))
+          (while (not (eobp))
+            (end-of-line)
+            (when (> (current-column) col)
+              (push (list :pos (line-beginning-position)
+                          :side (svg-margin-example--side 'long-lines)
+                          :shape 'bar :priority 3 :color "#b08800"
+                          :help (format "line exceeds %d columns" col))
+                    out))
+            (forward-line 1)))
+        out))))
+
+;;;; Provider: trailing whitespace (pure buffer scan)
+
+(defun svg-margin-example-trailing-ws (buffer)
+  "Return small marks for lines with trailing whitespace in BUFFER."
+  (with-current-buffer buffer
+    (let (out)
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward "[ \t]+$" nil t)
+          (push (list :pos (line-beginning-position)
+                      :side (svg-margin-example--side 'trailing-ws)
+                      :shape 'dot :priority 1 :color "#8b949e"
+                      :help "trailing whitespace")
+                out)
+          (forward-line 1)))
+      out)))
+
+;;;; Provider: org heading rail (mode-specific, variable-geometry :draw)
+
+(defun svg-margin-example-org-headings (buffer)
+  "Return a left rail bar per org heading, sized and coloured by depth."
+  (with-current-buffer buffer
+    (when (derived-mode-p 'org-mode)
+      (let (out)
+        (save-excursion
+          (goto-char (point-min))
+          (while (re-search-forward "^\\(\\*+\\) " nil t)
+            (let* ((level (length (match-string 1)))
+                   (face (intern (format "org-level-%d" (1+ (mod (1- level) 8)))))
+                   (color (or (face-foreground face nil 'default) "#888888")))
+              (push (list :pos (line-beginning-position)
+                          :side (svg-margin-example--side 'org-headings)
+                          :priority 4 :color color
+                          :help (format "heading level %d" level)
+                          ;; deeper headings draw a shorter, centred tick
+                          :draw (lambda (svg x y w h c)
+                                  (let* ((frac (/ (max 1 (- 7 level)) 6.0))
+                                         (bh (max 3 (round (* h frac))))
+                                         (yy (+ y (/ (- h bh) 2))))
+                                    (svg-rectangle svg x yy (max 2 (round (* w 0.4))) bh
+                                                   :rx 1 :fill c))))
+                    out))))
+        out))))
+
+;;;; Provider: occurrences of the symbol at point (dynamic, point-driven)
+
+(defvar svg-margin-example--last-symbol nil
+  "Last symbol at point, to refresh svg-margin only when it changes.")
+
+(defun svg-margin-example-symbol-occurrences (buffer)
+  "Return dots on lines where the symbol at point also appears in BUFFER."
+  (with-current-buffer buffer
+    (let ((sym (and (derived-mode-p 'prog-mode)
+                    (ignore-errors (thing-at-point 'symbol t)))))
+      (when (and sym (>= (length sym) 3))
+        (let ((re (concat "\\_<" (regexp-quote sym) "\\_>")) out)
+          (save-excursion
+            (goto-char (point-min))
+            (while (re-search-forward re nil t)
+              (push (list :pos (match-beginning 0)
+                          :side (svg-margin-example--side 'symbol)
+                          :shape 'dot :priority 2 :color "#58a6ff"
+                          :help (format "occurrence of `%s'" sym))
+                    out)))
+          out)))))
+
+(defun svg-margin-example--symbol-watch ()
+  "Refresh svg-margin when the symbol at point changes (for `post-command-hook')."
+  (let ((sym (and (derived-mode-p 'prog-mode)
+                  (ignore-errors (thing-at-point 'symbol t)))))
+    (unless (equal sym svg-margin-example--last-symbol)
+      (setq svg-margin-example--last-symbol sym)
+      (svg-margin-refresh))))
+
 ;;;; Wiring
 
 ;;;###autoload
@@ -255,6 +385,33 @@ over the margin), registers the git-gutter provider, and enables
   (advice-remove 'bookmark-set #'svg-margin-example--bookmark-refresh)
   (advice-remove 'bookmark-delete #'svg-margin-example--bookmark-refresh))
 
+;;;###autoload
+(defun svg-margin-example-extras-setup ()
+  "Register the extra demo providers: flycheck, long-lines, trailing-ws,
+org-headings, and symbol-at-point occurrences.  Showcases more techniques
+\(external integration, pure scans, mode-specific variable-geometry drawing,
+and dynamic point-driven refresh)."
+  (interactive)
+  (svg-margin-register-provider 'long-lines #'svg-margin-example-long-lines)
+  (svg-margin-register-provider 'trailing-ws #'svg-margin-example-trailing-ws)
+  (svg-margin-register-provider 'org-headings #'svg-margin-example-org-headings)
+  (svg-margin-register-provider 'symbol #'svg-margin-example-symbol-occurrences)
+  (add-hook 'post-command-hook #'svg-margin-example--symbol-watch)
+  (when (boundp 'flycheck-current-errors)
+    (svg-margin-register-provider 'flycheck #'svg-margin-example-flycheck)
+    (add-hook 'flycheck-after-syntax-check-hook #'svg-margin-example--flycheck-refresh))
+  (svg-margin-refresh-all)
+  (message "svg-margin extras: flycheck, long-lines, trailing-ws, org-headings, symbol"))
+
+(defun svg-margin-example-extras-teardown ()
+  "Undo `svg-margin-example-extras-setup'."
+  (interactive)
+  (dolist (p '(long-lines trailing-ws org-headings symbol flycheck))
+    (svg-margin-unregister-provider p))
+  (remove-hook 'post-command-hook #'svg-margin-example--symbol-watch)
+  (when (boundp 'flycheck-after-syntax-check-hook)
+    (remove-hook 'flycheck-after-syntax-check-hook #'svg-margin-example--flycheck-refresh)))
+
 (defun svg-margin-example-teardown ()
   "Undo `svg-margin-example-setup' in the current buffer."
   (interactive)
@@ -264,7 +421,8 @@ over the margin), registers the git-gutter provider, and enables
   (svg-margin-unregister-provider 'evil-marks)
   (advice-remove 'evil-set-marker #'svg-margin-example--mark-refresh)
   (svg-margin-example-bookmarks-teardown)
-  (svg-margin-example-git-gutter-teardown))
+  (svg-margin-example-git-gutter-teardown)
+  (svg-margin-example-extras-teardown))
 
 (provide 'svg-margin-examples)
 ;;; svg-margin-examples.el ends here

--- a/source/zettapkg/svg-margin/examples/svg-margin-examples.el
+++ b/source/zettapkg/svg-margin/examples/svg-margin-examples.el
@@ -27,6 +27,23 @@
 (declare-function bookmark-get-filename "bookmark")
 (declare-function bookmark-get-position "bookmark")
 
+(defcustom svg-margin-example-sides
+  '((git-gutter . left)
+    (vc         . left)
+    (evil-marks . left)
+    (todo       . right)
+    (bookmarks  . right))
+  "Margin side (`left' or `right') for each example provider.
+Providers stamp their indicators with the side looked up here, so moving a
+source between margins is pure configuration -- the engine renders each
+indicator on its `:side' and reserves both margins as needed."
+  :type '(alist :key-type symbol :value-type (choice (const left) (const right)))
+  :group 'svg-margin)
+
+(defun svg-margin-example--side (provider)
+  "Return the configured margin side for PROVIDER (see `svg-margin-example-sides')."
+  (alist-get provider svg-margin-example-sides 'left))
+
 ;; A bookmark-ribbon shape, to show `svg-margin-define-shape'.
 (svg-margin-define-shape 'bookmark
   (lambda (svg x y w h color)
@@ -51,6 +68,7 @@
         (goto-char (point-min))
         (while (re-search-forward "\\_<\\(TODO\\|FIXME\\|HACK\\)\\_>" nil t)
           (push (list :pos (match-beginning 0)
+                      :side (svg-margin-example--side 'todo)
                       :shape 'dot
                       :priority 7
                       :color (pcase (match-string 1)
@@ -76,11 +94,13 @@ change is (LINE INSERTS DELETES TYPE) and TYPE is `insert', `delete' or
         (dolist (chg changes)
           (cl-destructuring-bind (line inserts _deletes type) chg
             (if (eq type 'delete)
-                (push (list :line line :shape 'triangle :priority 9
+                (push (list :line line :side (svg-margin-example--side 'vc)
+                            :shape 'triangle :priority 9
                             :color "#f85149" :help "deleted")
                       out)
               (cl-loop for i from 0 below (max 1 inserts) do
-                       (push (list :line (+ line i) :shape 'bar :priority 9
+                       (push (list :line (+ line i) :side (svg-margin-example--side 'vc)
+                                   :shape 'bar :priority 9
                                    :color (if (eq type 'insert) "#3fb950" "#d29922")
                                    :help (symbol-name type))
                              out)))))
@@ -103,12 +123,14 @@ stops it drawing (so it does not duel with svg-margin over the margin)."
             (pcase type
               ((or 'added 'modified)
                (cl-loop for ln from start to (min end (+ start 1000)) do
-                        (push (list :line ln :shape 'bar :priority 9
+                        (push (list :line ln :side (svg-margin-example--side 'git-gutter)
+                                    :shape 'bar :priority 9
                                     :color (if (eq type 'added) "#3fb950" "#d29922")
                                     :help (symbol-name type))
                               out)))
               ('deleted
-               (push (list :line start :shape 'triangle :priority 9
+               (push (list :line start :side (svg-margin-example--side 'git-gutter)
+                           :shape 'triangle :priority 9
                            :color "#f85149" :help "deleted")
                      out)))))
         out))))
@@ -130,7 +152,8 @@ Reads the global `bookmark-alist' and matches by file name."
           (let ((bmfile (ignore-errors (bookmark-get-filename bm)))
                 (pos (ignore-errors (bookmark-get-position bm))))
             (when (and bmfile pos (string= (file-truename bmfile) file))
-              (push (list :pos pos :shape 'bookmark :priority 6
+              (push (list :pos pos :side (svg-margin-example--side 'bookmarks)
+                          :shape 'bookmark :priority 6
                           :color "#7d5bed"
                           :help (format "bookmark: %s" (car bm)))
                     out))))
@@ -155,6 +178,7 @@ nor any fringe."
                        (eq (marker-buffer val) buffer)
                        (>= char ?a) (<= char ?z))
               (push (list :pos (marker-position val)
+                          :side (svg-margin-example--side 'evil-marks)
                           :text (char-to-string char)
                           :priority 5
                           :face 'warning
@@ -185,7 +209,12 @@ both, since they would draw two bars per line."
   (cond ((fboundp 'global-git-gutter-mode) (svg-margin-example-git-gutter-setup))
         ((fboundp 'diff-hl-changes)
          (svg-margin-register-provider 'vc #'svg-margin-example-vc)))
-  (setq svg-margin-disable-fringe 'left)
+  ;; Reclaim whichever fringe(s) the configured sides actually use.
+  (let ((sides (mapcar #'cdr svg-margin-example-sides)))
+    (setq svg-margin-disable-fringe
+          (cond ((and (memq 'left sides) (memq 'right sides)) 'both)
+                ((memq 'right sides) 'right)
+                (t 'left))))
   (svg-margin-mode 1)
   (message "svg-margin example active: VC + TODO + bookmarks + evil marks in the left margin"))
 

--- a/source/zettapkg/svg-margin/examples/svg-margin-examples.el
+++ b/source/zettapkg/svg-margin/examples/svg-margin-examples.el
@@ -209,12 +209,13 @@ both, since they would draw two bars per line."
   (cond ((fboundp 'global-git-gutter-mode) (svg-margin-example-git-gutter-setup))
         ((fboundp 'diff-hl-changes)
          (svg-margin-register-provider 'vc #'svg-margin-example-vc)))
-  ;; Reclaim whichever fringe(s) the configured sides actually use.
-  (let ((sides (mapcar #'cdr svg-margin-example-sides)))
-    (setq svg-margin-disable-fringe
-          (cond ((and (memq 'left sides) (memq 'right sides)) 'both)
-                ((memq 'right sides) 'right)
-                (t 'left))))
+  ;; Reclaim ONLY the left fringe -- evil-fringe-mark's old home, now migrated
+  ;; into the margin.  Disabling a fringe is about migrating that fringe's
+  ;; USERS, not about which margin side you draw in: margins are independent of
+  ;; fringes, so right-margin indicators show fine while the right fringe stays
+  ;; available for yascroll / flycheck / continuation arrows.  Only disable a
+  ;; fringe once nothing else needs it.
+  (setq svg-margin-disable-fringe 'left)
   (svg-margin-mode 1)
   (message "svg-margin example active: VC + TODO + bookmarks + evil marks in the left margin"))
 

--- a/source/zettapkg/svg-margin/examples/svg-margin-examples.el
+++ b/source/zettapkg/svg-margin/examples/svg-margin-examples.el
@@ -15,6 +15,7 @@
 ;;; Code:
 
 (require 'svg-margin)
+(require 'cl-lib)
 
 (defvar evil-markers-alist)
 (defvar git-gutter:diffinfos)

--- a/source/zettapkg/svg-margin/svg-margin-recipe
+++ b/source/zettapkg/svg-margin/svg-margin-recipe
@@ -1,0 +1,1 @@
+(svg-margin :fetcher github :repo "chiply/svg-margin")

--- a/source/zettapkg/svg-margin/svg-margin-recipe
+++ b/source/zettapkg/svg-margin/svg-margin-recipe
@@ -1,1 +1,2 @@
-(svg-margin :fetcher github :repo "chiply/svg-margin")
+(svg-margin :fetcher github :repo "chiply/svg-margin"
+            :files ("svg-margin.el"))

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -91,6 +91,18 @@ is this value times the number of indicator columns on the widest line."
   "Default margin side for indicators that do not specify `:side'."
   :type '(choice (const left) (const right)))
 
+(defcustom svg-margin-min-left-columns 0
+  "Minimum number of columns to always reserve in the left margin.
+The left margin still grows past this when a line needs more columns, but
+never shrinks below it -- so reserving a baseline keeps buffer text from
+shifting left/right as indicators come and go (up to this width)."
+  :type 'integer)
+
+(defcustom svg-margin-min-right-columns 0
+  "Minimum number of columns to always reserve in the right margin.
+See `svg-margin-min-left-columns'."
+  :type 'integer)
+
 (defcustom svg-margin-disable-fringe nil
   "Which window fringe(s) svg-margin collapses to 0 while active.
 nil leaves the fringe alone; `left', `right', `both' (or t) zero the
@@ -333,20 +345,21 @@ A non-function `:draw' is ignored (falls through to `:text'/`:shape')."
       (funcall (gethash (plist-get ind :shape) svg-margin--shapes) svg x y w h color))
      (t (svg-margin--shape-dot svg x y w h color)))))
 
-(defun svg-margin--image (packed side ncols cw lh)
+(defun svg-margin--image (packed side rcols cw lh)
   "Build the composite margin image for PACKED cells on SIDE.
-NCOLS is the number of columns to reserve; column 0 is nearest the buffer
-text on either side.  CW is one column's pixel width and LH the line height
-\(both passed in so they track the displaying window's frame, not just the
-selected one).  A cell whose draw signals is skipped so one bad indicator
-cannot blank the whole line."
+RCOLS is the SIDE's reserved column count (>= this line's own column count),
+so the image fills the whole margin and column 0 lands nearest the buffer text
+\(rightmost on the left margin, leftmost on the right).  CW is one column's
+pixel width and LH the line height (both passed in so they track the displaying
+window's frame, not just the selected one).  A cell whose draw signals is
+skipped so one bad indicator cannot blank the whole line."
   (let* ((h (max 1 lh))
-         (w (max 1 (* ncols cw)))
+         (w (max 1 (* rcols cw)))
          (svg (svg-create w h)))
     (dolist (cell packed)
       (let* ((col (plist-get cell :column))
              (ind (plist-get cell :indicator))
-             (x (if (eq side 'left) (* (- ncols 1 col) cw) (* col cw))))
+             (x (if (eq side 'left) (* (- rcols 1 col) cw) (* col cw))))
         (condition-case err
             (svg-margin--draw ind svg x 0 cw h)
           (error (message "svg-margin: drawing an indicator failed: %s"
@@ -364,11 +377,11 @@ cannot blank the whole line."
   (mapc #'delete-overlay svg-margin--overlays)
   (setq svg-margin--overlays nil))
 
-(defun svg-margin--place (pos side packed ncols cw lh)
+(defun svg-margin--place (pos side packed rcols cw lh)
   "Create an overlay at POS carrying the composite SIDE image for PACKED.
-NCOLS is the number of columns the image spans; CW and LH are the column
-pixel width and line height for the image."
-  (let* ((img (svg-margin--image packed side ncols cw lh))
+RCOLS is the SIDE's reserved column count the image spans; CW and LH are the
+column pixel width and line height for the image."
+  (let* ((img (svg-margin--image packed side rcols cw lh))
          (marg (if (eq side 'left) 'left-margin 'right-margin))
          (help (string-join
                 (delq nil (mapcar (lambda (c) (plist-get (plist-get c :indicator) :help))
@@ -473,7 +486,11 @@ before first being zeroed, so they can be restored exactly -- including when
                    (cw (* svg-margin-column-width (frame-char-width frame)))
                    (lh (max 1 (default-line-height)))
                    (groups (svg-margin--group (svg-margin--collect)))
-                   (max-left 0) (max-right 0))
+                   (max-left (max 0 svg-margin-min-left-columns))
+                   (max-right (max 0 svg-margin-min-right-columns))
+                   (cells nil))
+              ;; Pass 1: pack each line and find the reserved width per side
+              ;; (at least the configured minimum).
               (maphash
                (lambda (key inds)
                  (let* ((pos (car key)) (side (cdr key))
@@ -483,8 +500,15 @@ before first being zeroed, so they can be restored exactly -- including when
                      (if (eq side 'left)
                          (setq max-left (max max-left ncols))
                        (setq max-right (max max-right ncols)))
-                     (svg-margin--place pos side packed ncols cw lh))))
+                     (push (list pos side packed) cells))))
                groups)
+              ;; Pass 2: place each line filling its side's reserved width, so
+              ;; indicators align to the text regardless of per-line variation.
+              (dolist (c cells)
+                (cl-destructuring-bind (pos side packed) c
+                  (svg-margin--place pos side packed
+                                     (if (eq side 'left) max-left max-right)
+                                     cw lh)))
               (svg-margin--apply-margins max-left max-right)
               (svg-margin--apply-fringes))))))))
 

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -308,13 +308,17 @@ NCOLS is the number of columns the image spans."
                 (delq nil (mapcar (lambda (c) (plist-get (plist-get c :indicator) :help))
                                   packed))
                 "\n"))
-         (str (propertize " " 'display (list (list 'margin marg)
-                                             (propertize " " 'display img))))
+         ;; Put the image descriptor DIRECTLY as the margin spec's element;
+         ;; wrapping it in a string (((margin SIDE) STRING)) reserves the
+         ;; margin space but does not render the nested image.
+         (str (propertize " " 'display (list (list 'margin marg) img)))
          (ov (make-overlay pos pos)))
     (when (> (length help) 0) (setq str (propertize str 'help-echo help)))
     (overlay-put ov 'svg-margin t)
     (overlay-put ov 'before-string str)
-    (overlay-put ov 'evaporate t)
+    ;; NB: do NOT set `evaporate' -- these overlays are zero-length, and an
+    ;; evaporate overlay is auto-deleted the instant it is empty, so it would
+    ;; vanish before display.  `svg-margin--clear' rebuilds them each render.
     (push ov svg-margin--overlays)))
 
 ;;;; Window geometry (margins + fringes)
@@ -325,11 +329,18 @@ NCOLS is the number of columns the image spans."
   (get-buffer-window-list (current-buffer) nil t))
 
 (defun svg-margin--apply-margins (left right)
-  "Reserve LEFT and RIGHT indicator columns in every window showing the buffer."
+  "Reserve LEFT and RIGHT indicator columns in every window showing the buffer.
+Only writes a window whose margins actually differ, so the call cannot
+induce a redundant `window-configuration-change-hook' (and the re-render
+loop / flicker that would follow)."
   (let ((lw (* left svg-margin-column-width))
         (rw (* right svg-margin-column-width)))
     (dolist (win (svg-margin--windows))
-      (set-window-margins win lw rw))))
+      (let* ((cur (window-margins win))
+             (cl (or (car cur) 0))
+             (cr (or (cdr cur) 0)))
+        (unless (and (= cl lw) (= cr rw))
+          (set-window-margins win lw rw))))))
 
 (defun svg-margin--restore-margins ()
   "Restore window margins to the buffer's own margin widths."
@@ -349,11 +360,12 @@ NCOLS is the number of columns the image spans."
   (let ((sides (svg-margin--fringe-sides)))
     (when sides
       (dolist (win (svg-margin--windows))
-        (let* ((fr (window-fringes win)) (l (nth 0 fr)) (r (nth 1 fr)))
-          (set-window-fringes
-           win
-           (cond ((not (memq 'left sides)) l) (restore nil) (t 0))
-           (cond ((not (memq 'right sides)) r) (restore nil) (t 0))))))))
+        (let* ((fr (window-fringes win)) (l (nth 0 fr)) (r (nth 1 fr))
+               (nl (cond ((not (memq 'left sides)) l) (restore nil) (t 0)))
+               (nr (cond ((not (memq 'right sides)) r) (restore nil) (t 0))))
+          ;; Only write when changed (see `svg-margin--apply-margins').
+          (unless (and (equal nl l) (equal nr r))
+            (set-window-fringes win nl nr)))))))
 
 ;;;; Render
 ;; ----------------------------------------------------------------

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -1,0 +1,448 @@
+;;; svg-margin.el --- Multi-provider SVG indicators in the window margins -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Charlie Holland
+
+;; Author: Charlie Holland <charliebkr707@gmail.com>
+;; Maintainer: Charlie Holland <charliebkr707@gmail.com>
+;; URL: https://github.com/chiply/svg-margin
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "29.1"))
+;; Keywords: convenience, faces, frames
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; svg-margin turns the window margins into a flexible, multi-column gutter
+;; that many independent sources ("providers") can draw into, with their
+;; indicators packed side by side on the same line.  Unlike the fringe --
+;; which renders only monochrome bitmaps and shows a single bitmap per line
+;; per side -- a margin can display arbitrary SVG, and svg-margin composites
+;; every indicator for a line/side into ONE SVG image at exact pixel
+;; coordinates.  Both the left and right margins are supported.
+;;
+;; This is the rendering ENGINE only.  It ships no providers; you (or a
+;; small adapter) supply them.  A provider is just a function of one
+;; argument BUFFER that returns a list of indicator plists:
+;;
+;;   (svg-margin-register-provider 'todo
+;;     (lambda (_buffer)
+;;       (list (list :line 10 :shape 'dot   :color "#cc3333")
+;;             (list :line 10 :shape 'bar   :color "#3333cc" :column 1)
+;;             (list :line 25 :text "a"     :side 'left :face 'warning))))
+;;   (svg-margin-mode 1)
+;;
+;; An indicator plist recognises:
+;;   :pos / :line  buffer position or 1-based line (one is required)
+;;   :side         `left' (default `svg-margin-default-side') or `right'
+;;   :column       explicit slot (0 = nearest the text); else auto-packed
+;;   :priority     higher is packed first (default 0)
+;;   :shape        a registered shape symbol (see `svg-margin-define-shape')
+;;   :text         a short string drawn centred (e.g. an evil mark letter)
+;;   :draw         a function (SVG X Y W H COLOR) for full control
+;;   :color/:face  fill colour, or a face whose foreground is used
+;;   :help         tooltip string
+;;
+;; Indicators sharing a (line, side) are packed into columns and drawn into
+;; a single composite SVG; the margin width on that side grows to the widest
+;; line.  Providers are decoupled, so several packages can contribute to the
+;; same gutter and stack on one line.
+;;
+;; To move what a package draws in the fringe into the margin instead, write
+;; a provider that reads that package's data (e.g. evil's `evil-markers-alist')
+;; and set `svg-margin-disable-fringe' to reclaim the fringe space.  See the
+;; examples/ directory.
+
+;;; Code:
+
+(require 'svg)
+(require 'cl-lib)
+(require 'color)
+(require 'subr-x)
+
+(defgroup svg-margin nil
+  "Multi-provider SVG indicators in the window margins."
+  :group 'convenience
+  :prefix "svg-margin-")
+
+(defcustom svg-margin-column-width 1
+  "Width of one indicator column, in character cells.
+The reserved margin width (in columns, as `set-window-margins' measures it)
+is this value times the number of indicator columns on the widest line."
+  :type 'integer)
+
+(defcustom svg-margin-default-side 'left
+  "Default margin side for indicators that do not specify `:side'."
+  :type '(choice (const left) (const right)))
+
+(defcustom svg-margin-disable-fringe nil
+  "Which window fringe(s) svg-margin collapses to 0 while active.
+nil leaves the fringe alone; `left', `right', `both' (or t) zero the
+named fringe(s) so the margin reclaims the space.  Restored on mode exit.
+Note: zeroing a fringe also hides its truncation/continuation arrows."
+  :type '(choice (const :tag "Leave fringe alone" nil)
+                 (const left) (const right)
+                 (const :tag "Both" both) (const :tag "Both (t)" t)))
+
+(defcustom svg-margin-idle-delay 0.1
+  "Idle seconds to coalesce changes before re-rendering a buffer."
+  :type 'number)
+
+;;;; Colour
+;; ----------------------------------------------------------------
+
+(defun svg-margin--color (c)
+  "Normalise colour C to a 6-digit \"#RRGGBB\" string for SVG, else nil.
+Names and the 12-digit \"#RRRRGGGGBBBB\" form are resolved via `color.el';
+6-digit hex passes through; nil returns nil."
+  (cond
+   ((null c) nil)
+   ((not (stringp c)) c)
+   ((string-match-p "\\`#[0-9a-fA-F]\\{6\\}\\'" c) c)
+   (t (let ((rgb (ignore-errors (color-name-to-rgb c))))
+        (if rgb (apply #'color-rgb-to-hex (append rgb '(2))) c)))))
+
+;;;; Shape registry
+;; ----------------------------------------------------------------
+;; The SVG analogue of `define-fringe-bitmap': a named drawing function
+;; (SVG X Y W H COLOR) that fills the cell rectangle [X,X+W] x [Y,Y+H].
+
+(defvar svg-margin--shapes (make-hash-table :test 'eq)
+  "Map of shape NAME symbol -> drawing function (SVG X Y W H COLOR).")
+
+(defun svg-margin-define-shape (name fn)
+  "Register drawing FN under shape NAME (a symbol).
+FN is called as (FN SVG X Y W H COLOR) and should draw within the cell
+rectangle whose top-left is (X, Y) and size is W by H pixels."
+  (puthash name fn svg-margin--shapes))
+
+(defun svg-margin--shape-dot (svg x y w h color)
+  "Draw a filled dot of COLOR centred in the (X Y W H) cell of SVG."
+  (svg-circle svg (+ x (/ w 2.0)) (+ y (/ h 2.0)) (* (min w h) 0.30)
+              :fill (svg-margin--color color)))
+
+(defun svg-margin--shape-bar (svg x y w h color)
+  "Draw a vertical bar of COLOR spanning the height of the (X Y W H) cell of SVG."
+  (svg-rectangle svg (+ x (round (* w 0.12))) y (max 2 (round (* w 0.34))) h
+                 :rx 1 :fill (svg-margin--color color)))
+
+(defun svg-margin--shape-box (svg x y w h color)
+  "Draw a rounded filled box of COLOR centred in the (X Y W H) cell of SVG."
+  (let ((s (* (min w h) 0.6)))
+    (svg-rectangle svg (+ x (/ (- w s) 2.0)) (+ y (/ (- h s) 2.0)) s s
+                   :rx 2 :fill (svg-margin--color color))))
+
+(defun svg-margin--shape-triangle (svg x y w h color)
+  "Draw a right-pointing triangle of COLOR centred in the (X Y W H) cell of SVG."
+  (let* ((cx (+ x (/ w 2.0))) (cy (+ y (/ h 2.0))) (r (* (min w h) 0.34)))
+    (svg-polygon svg (list (cons (- cx r) (- cy r))
+                           (cons (+ cx r) cy)
+                           (cons (- cx r) (+ cy r)))
+                 :fill (svg-margin--color color))))
+
+(dolist (s '((dot . svg-margin--shape-dot)
+             (circle . svg-margin--shape-dot)
+             (bar . svg-margin--shape-bar)
+             (box . svg-margin--shape-box)
+             (triangle . svg-margin--shape-triangle)))
+  (svg-margin-define-shape (car s) (cdr s)))
+
+;;;; Providers
+;; ----------------------------------------------------------------
+
+(defvar svg-margin--providers nil
+  "Alist of (NAME . FUNCTION); each FUNCTION maps a buffer to indicators.")
+
+(defun svg-margin-register-provider (name fn)
+  "Register provider FN under NAME (a symbol), replacing any prior one.
+FN is called with one argument, the buffer, and returns a list of
+indicator plists (see Commentary).  Registered buffers are re-rendered."
+  (setf (alist-get name svg-margin--providers) fn)
+  (svg-margin-refresh-all))
+
+(defun svg-margin-unregister-provider (name)
+  "Remove the provider registered under NAME and re-render."
+  (setq svg-margin--providers (assq-delete-all name svg-margin--providers))
+  (svg-margin-refresh-all))
+
+;;;; Collection, normalisation, grouping
+;; ----------------------------------------------------------------
+
+(defun svg-margin--normalize (ind)
+  "Return a normalised copy of indicator IND, or nil if it has no position.
+The result carries a `:pos' at beginning-of-line and a `:side' of `left'
+or `right'."
+  (let* ((pos (or (plist-get ind :pos)
+                  (and (plist-get ind :line)
+                       (save-excursion
+                         (goto-char (point-min))
+                         (forward-line (1- (plist-get ind :line)))
+                         (point)))))
+         (side (or (plist-get ind :side) svg-margin-default-side)))
+    (when (and pos (<= (point-min) pos (point-max)))
+      (let ((bol (save-excursion (goto-char pos) (line-beginning-position))))
+        (append (list :pos bol :side (if (memq side '(right right-margin)) 'right 'left))
+                ind)))))
+
+(defun svg-margin--collect ()
+  "Run every provider against the current buffer and return all indicators."
+  (let ((buf (current-buffer)) (out nil))
+    (dolist (p svg-margin--providers)
+      (condition-case err
+          (dolist (ind (funcall (cdr p) buf))
+            (when-let* ((n (svg-margin--normalize ind)))
+              (push n out)))
+        (error (message "svg-margin: provider %s failed: %s"
+                        (car p) (error-message-string err)))))
+    out))
+
+(defun svg-margin--group (indicators)
+  "Group INDICATORS into a hash keyed by (POS . SIDE) -> list of indicators."
+  (let ((h (make-hash-table :test 'equal)))
+    (dolist (ind indicators)
+      (push ind (gethash (cons (plist-get ind :pos) (plist-get ind :side)) h)))
+    h))
+
+(defun svg-margin--pack-columns (indicators)
+  "Assign each of INDICATORS a column, packing them side by side.
+Higher `:priority' is placed first.  An explicit free `:column' is
+honoured; otherwise the lowest unoccupied column is used.  Returns a list
+of (:indicator IND :column N)."
+  (let ((sorted (sort (copy-sequence indicators)
+                      (lambda (a b) (> (or (plist-get a :priority) 0)
+                                       (or (plist-get b :priority) 0)))))
+        (used nil) (result nil))
+    (dolist (ind sorted)
+      (let ((col (plist-get ind :column)))
+        (when (or (null col) (memq col used))
+          (setq col 0)
+          (while (memq col used) (setq col (1+ col))))
+        (push col used)
+        (push (list :indicator ind :column col) result)))
+    (nreverse result)))
+
+(defun svg-margin--max-column (packed)
+  "Return the number of columns occupied by PACKED (max column + 1)."
+  (1+ (apply #'max -1 (mapcar (lambda (c) (plist-get c :column)) packed))))
+
+;;;; Drawing
+;; ----------------------------------------------------------------
+
+(defun svg-margin--indicator-color (ind)
+  "Return the fill colour for indicator IND from `:color' or `:face'."
+  (or (plist-get ind :color)
+      (let ((f (plist-get ind :face)))
+        (and f (face-foreground f nil 'default)))
+      (face-foreground 'default nil 'default)
+      "#000000"))
+
+(defun svg-margin--draw-text (svg text x y w h color)
+  "Draw TEXT centred in the (X Y W H) cell of SVG in COLOR."
+  (let ((fs (max 6 (round (* h 0.7)))))
+    (svg-text svg text
+              :x (+ x (/ w 2.0))
+              :y (+ y (/ h 2.0) (* (max 6 (round (* h 0.7))) 0.35))
+              :font-size fs
+              :font-family (face-attribute 'default :family nil t)
+              :font-weight "bold"
+              :text-anchor "middle"
+              :fill (svg-margin--color color))))
+
+(defun svg-margin--draw (ind svg x y w h)
+  "Draw indicator IND into the (X Y W H) cell of SVG."
+  (let ((color (svg-margin--indicator-color ind)))
+    (cond
+     ((plist-get ind :draw) (funcall (plist-get ind :draw) svg x y w h color))
+     ((plist-get ind :text) (svg-margin--draw-text svg (plist-get ind :text) x y w h color))
+     ((gethash (plist-get ind :shape) svg-margin--shapes)
+      (funcall (gethash (plist-get ind :shape) svg-margin--shapes) svg x y w h color))
+     (t (svg-margin--shape-dot svg x y w h color)))))
+
+(defun svg-margin--line-height ()
+  "Pixel height of a default line in the selected frame."
+  (max 1 (default-line-height)))
+
+(defun svg-margin--image (packed side ncols)
+  "Build the composite margin image for PACKED cells on SIDE.
+NCOLS is the number of columns to reserve; column 0 is nearest the buffer
+text on either side."
+  (let* ((cw (* svg-margin-column-width (frame-char-width)))
+         (h (svg-margin--line-height))
+         (w (max 1 (* ncols cw)))
+         (svg (svg-create w h)))
+    (dolist (cell packed)
+      (let* ((col (plist-get cell :column))
+             (ind (plist-get cell :indicator))
+             (x (if (eq side 'left) (* (- ncols 1 col) cw) (* col cw))))
+        (svg-margin--draw ind svg x 0 cw h)))
+    (svg-image svg :ascent 'center :scale 1.0)))
+
+;;;; Overlays
+;; ----------------------------------------------------------------
+
+(defvar-local svg-margin--overlays nil
+  "List of overlays this buffer uses to carry margin images.")
+
+(defun svg-margin--clear ()
+  "Delete all svg-margin overlays in the current buffer."
+  (mapc #'delete-overlay svg-margin--overlays)
+  (setq svg-margin--overlays nil))
+
+(defun svg-margin--place (pos side packed ncols)
+  "Create an overlay at POS carrying the composite SIDE image for PACKED.
+NCOLS is the number of columns the image spans."
+  (let* ((img (svg-margin--image packed side ncols))
+         (marg (if (eq side 'left) 'left-margin 'right-margin))
+         (help (string-join
+                (delq nil (mapcar (lambda (c) (plist-get (plist-get c :indicator) :help))
+                                  packed))
+                "\n"))
+         (str (propertize " " 'display (list (list 'margin marg)
+                                             (propertize " " 'display img))))
+         (ov (make-overlay pos pos)))
+    (when (> (length help) 0) (setq str (propertize str 'help-echo help)))
+    (overlay-put ov 'svg-margin t)
+    (overlay-put ov 'before-string str)
+    (overlay-put ov 'evaporate t)
+    (push ov svg-margin--overlays)))
+
+;;;; Window geometry (margins + fringes)
+;; ----------------------------------------------------------------
+
+(defun svg-margin--windows ()
+  "Return the windows currently displaying the current buffer."
+  (get-buffer-window-list (current-buffer) nil t))
+
+(defun svg-margin--apply-margins (left right)
+  "Reserve LEFT and RIGHT indicator columns in every window showing the buffer."
+  (let ((lw (* left svg-margin-column-width))
+        (rw (* right svg-margin-column-width)))
+    (dolist (win (svg-margin--windows))
+      (set-window-margins win lw rw))))
+
+(defun svg-margin--restore-margins ()
+  "Restore window margins to the buffer's own margin widths."
+  (dolist (win (svg-margin--windows))
+    (set-window-margins win (or left-margin-width 0) (or right-margin-width 0))))
+
+(defun svg-margin--fringe-sides ()
+  "Return the list of fringe sides to zero per `svg-margin-disable-fringe'."
+  (pcase svg-margin-disable-fringe
+    ((or 't 'both) '(left right))
+    ('left '(left))
+    ('right '(right))
+    (_ nil)))
+
+(defun svg-margin--apply-fringes (restore)
+  "Zero (or, when RESTORE, reset to default) the configured fringe sides."
+  (let ((sides (svg-margin--fringe-sides)))
+    (when sides
+      (dolist (win (svg-margin--windows))
+        (let* ((fr (window-fringes win)) (l (nth 0 fr)) (r (nth 1 fr)))
+          (set-window-fringes
+           win
+           (cond ((not (memq 'left sides)) l) (restore nil) (t 0))
+           (cond ((not (memq 'right sides)) r) (restore nil) (t 0))))))))
+
+;;;; Render
+;; ----------------------------------------------------------------
+
+(defun svg-margin--render (&optional buffer)
+  "Re-render all svg-margin indicators in BUFFER (default current)."
+  (let ((buffer (or buffer (current-buffer))))
+    (when (and (buffer-live-p buffer) (display-graphic-p))
+      (with-current-buffer buffer
+        (when (bound-and-true-p svg-margin-mode)
+          (svg-margin--clear)
+          (let ((groups (svg-margin--group (svg-margin--collect)))
+                (max-left 0) (max-right 0))
+            (maphash
+             (lambda (key inds)
+               (let* ((pos (car key)) (side (cdr key))
+                      (packed (svg-margin--pack-columns inds))
+                      (ncols (svg-margin--max-column packed)))
+                 (when (> ncols 0)
+                   (if (eq side 'left)
+                       (setq max-left (max max-left ncols))
+                     (setq max-right (max max-right ncols)))
+                   (svg-margin--place pos side packed ncols))))
+             groups)
+            (svg-margin--apply-margins max-left max-right)
+            (svg-margin--apply-fringes nil)))))))
+
+(defvar-local svg-margin--timer nil
+  "Idle timer coalescing re-renders for this buffer.")
+
+(defun svg-margin--schedule (&optional buffer)
+  "Schedule a debounced re-render of BUFFER (default current)."
+  (let ((buf (or buffer (current-buffer))))
+    (when (buffer-live-p buf)
+      (with-current-buffer buf
+        (when (timerp svg-margin--timer) (cancel-timer svg-margin--timer))
+        (setq svg-margin--timer
+              (run-with-idle-timer svg-margin-idle-delay nil
+                                   #'svg-margin--render buf))))))
+
+(defun svg-margin--after-change (&rest _)
+  "Schedule a re-render after a buffer change."
+  (svg-margin--schedule))
+
+(defun svg-margin--window-config ()
+  "Schedule a re-render after a window configuration change."
+  (svg-margin--schedule))
+
+;;;; Public commands + mode
+;; ----------------------------------------------------------------
+
+;;;###autoload
+(defun svg-margin-refresh (&optional buffer)
+  "Re-render svg-margin indicators in BUFFER (default current)."
+  (interactive)
+  (svg-margin--schedule buffer))
+
+(defun svg-margin-refresh-all ()
+  "Re-render every buffer in which `svg-margin-mode' is enabled."
+  (dolist (buf (buffer-list))
+    (when (buffer-local-value 'svg-margin-mode buf)
+      (svg-margin--schedule buf))))
+
+;;;###autoload
+(define-minor-mode svg-margin-mode
+  "Display SVG indicators from registered providers in the window margins.
+Providers are registered globally with `svg-margin-register-provider'; this
+buffer-local mode renders whatever they contribute for the current buffer."
+  :lighter " SVGm"
+  (if svg-margin-mode
+      (progn
+        (add-hook 'after-change-functions #'svg-margin--after-change nil t)
+        (add-hook 'window-configuration-change-hook #'svg-margin--window-config nil t)
+        (svg-margin--render (current-buffer)))
+    (remove-hook 'after-change-functions #'svg-margin--after-change t)
+    (remove-hook 'window-configuration-change-hook #'svg-margin--window-config t)
+    (when (timerp svg-margin--timer) (cancel-timer svg-margin--timer))
+    (svg-margin--clear)
+    (svg-margin--apply-fringes t)
+    (svg-margin--restore-margins)))
+
+(defun svg-margin--maybe-enable ()
+  "Turn on `svg-margin-mode' in an ordinary file buffer."
+  (when (and (not (minibufferp)) buffer-file-name)
+    (svg-margin-mode 1)))
+
+;;;###autoload
+(define-globalized-minor-mode global-svg-margin-mode
+  svg-margin-mode svg-margin--maybe-enable)
+
+(provide 'svg-margin)
+;;; svg-margin.el ends here

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -59,6 +59,11 @@
 ;; line.  Providers are decoupled, so several packages can contribute to the
 ;; same gutter and stack on one line.
 ;;
+;; A provider may set per-provider defaults so it need not stamp every
+;; indicator: (svg-margin-register-provider NAME FN :side 'right :priority 5).
+;; Users can relocate any provider's margin declaratively, without editing it,
+;; via `svg-margin-provider-sides'.
+;;
 ;; To move what a package draws in the fringe into the margin instead, write
 ;; a provider that reads that package's data (e.g. evil's `evil-markers-alist')
 ;; and set `svg-margin-disable-fringe' to reclaim the fringe space.  See the
@@ -99,6 +104,22 @@ Note: zeroing a fringe also hides its truncation/continuation arrows."
   "Idle seconds to coalesce changes before re-rendering a buffer."
   :type 'number)
 
+(defcustom svg-margin-provider-sides nil
+  "Alist of (PROVIDER-NAME . SIDE) overriding where a provider draws.
+SIDE is `left' or `right'.  An entry here forces every indicator from that
+provider onto SIDE, even one that stamps its own `:side' -- so you can move
+any provider (including a third-party one) to the other margin declaratively,
+without editing its source.  See also the `:side' argument to
+`svg-margin-register-provider'."
+  :type '(alist :key-type symbol :value-type (choice (const left) (const right))))
+
+(defcustom svg-margin-debug nil
+  "When non-nil, report indicators that are dropped for lack of a position.
+A provider whose indicator has no `:pos'/`:line' (or an out-of-range one) has
+that indicator silently skipped; enable this to get a message naming the
+provider, which helps when writing one."
+  :type 'boolean)
+
 ;;;; Colour
 ;; ----------------------------------------------------------------
 
@@ -121,6 +142,7 @@ Names and the 12-digit \"#RRRRGGGGBBBB\" form are resolved via `color.el';
 (defvar svg-margin--shapes (make-hash-table :test 'eq)
   "Map of shape NAME symbol -> drawing function (SVG X Y W H COLOR).")
 
+;;;###autoload
 (defun svg-margin-define-shape (name fn)
   "Register drawing FN under shape NAME (a symbol).
 FN is called as (FN SVG X Y W H COLOR) and should draw within the cell
@@ -131,6 +153,12 @@ rectangle whose top-left is (X, Y) and size is W by H pixels."
   "Draw a filled dot of COLOR centred in the (X Y W H) cell of SVG."
   (svg-circle svg (+ x (/ w 2.0)) (+ y (/ h 2.0)) (* (min w h) 0.30)
               :fill (svg-margin--color color)))
+
+(defun svg-margin--shape-circle (svg x y w h color)
+  "Draw a hollow ring of COLOR centred in the (X Y W H) cell of SVG."
+  (let ((c (svg-margin--color color)))
+    (svg-circle svg (+ x (/ w 2.0)) (+ y (/ h 2.0)) (* (min w h) 0.30)
+                :fill "none" :stroke c :stroke-width (max 1 (round (* (min w h) 0.12))))))
 
 (defun svg-margin--shape-bar (svg x y w h color)
   "Draw a vertical bar of COLOR spanning the height of the (X Y W H) cell of SVG."
@@ -152,7 +180,7 @@ rectangle whose top-left is (X, Y) and size is W by H pixels."
                  :fill (svg-margin--color color))))
 
 (dolist (s '((dot . svg-margin--shape-dot)
-             (circle . svg-margin--shape-dot)
+             (circle . svg-margin--shape-circle)
              (bar . svg-margin--shape-bar)
              (box . svg-margin--shape-box)
              (triangle . svg-margin--shape-triangle)))
@@ -162,19 +190,42 @@ rectangle whose top-left is (X, Y) and size is W by H pixels."
 ;; ----------------------------------------------------------------
 
 (defvar svg-margin--providers nil
-  "Alist of (NAME . FUNCTION); each FUNCTION maps a buffer to indicators.")
+  "Alist of (NAME . PLIST); PLIST has :fn and optional :side/:priority/:column.
+The optional values are per-provider DEFAULTS applied to any indicator that
+omits the corresponding key (see `svg-margin--apply-provider-defaults').")
 
-(defun svg-margin-register-provider (name fn)
+;;;###autoload
+(cl-defun svg-margin-register-provider (name fn &key side priority column)
   "Register provider FN under NAME (a symbol), replacing any prior one.
-FN is called with one argument, the buffer, and returns a list of
-indicator plists (see Commentary).  Registered buffers are re-rendered."
-  (setf (alist-get name svg-margin--providers) fn)
+FN is called with one argument, the buffer, and returns a list of indicator
+plists (see Commentary).  The optional keywords set per-provider DEFAULTS:
+SIDE (`left'/`right'), PRIORITY, and COLUMN are applied to any indicator this
+provider emits that does not specify them itself, so a provider need not stamp
+every indicator.  `svg-margin-provider-sides' can override SIDE per provider.
+Registered buffers are re-rendered."
+  (setf (alist-get name svg-margin--providers)
+        (list :fn fn :side side :priority priority :column column))
   (svg-margin-refresh-all))
 
+;;;###autoload
 (defun svg-margin-unregister-provider (name)
   "Remove the provider registered under NAME and re-render."
   (setq svg-margin--providers (assq-delete-all name svg-margin--providers))
   (svg-margin-refresh-all))
+
+(defun svg-margin--apply-provider-defaults (ind props override-side)
+  "Fill IND's missing :side/:priority/:column from provider PROPS.
+OVERRIDE-SIDE, when non-nil, forces `:side' regardless of what IND carries."
+  (let ((ind (copy-sequence ind)))
+    (when (and (plist-get props :side) (not (plist-member ind :side)))
+      (setq ind (plist-put ind :side (plist-get props :side))))
+    (when (and (plist-get props :priority) (not (plist-member ind :priority)))
+      (setq ind (plist-put ind :priority (plist-get props :priority))))
+    (when (and (plist-get props :column) (not (plist-member ind :column)))
+      (setq ind (plist-put ind :column (plist-get props :column))))
+    (when override-side
+      (setq ind (plist-put ind :side override-side)))
+    ind))
 
 ;;;; Collection, normalisation, grouping
 ;; ----------------------------------------------------------------
@@ -182,29 +233,41 @@ indicator plists (see Commentary).  Registered buffers are re-rendered."
 (defun svg-margin--normalize (ind)
   "Return a normalised copy of indicator IND, or nil if it has no position.
 The result carries a `:pos' at beginning-of-line and a `:side' of `left'
-or `right'."
-  (let* ((pos (or (plist-get ind :pos)
-                  (and (plist-get ind :line)
-                       (save-excursion
-                         (goto-char (point-min))
-                         (forward-line (1- (plist-get ind :line)))
-                         (point)))))
-         (side (or (plist-get ind :side) svg-margin-default-side)))
-    (when (and pos (<= (point-min) pos (point-max)))
-      (let ((bol (save-excursion (goto-char pos) (line-beginning-position))))
-        (append (list :pos bol :side (if (memq side '(right right-margin)) 'right 'left))
-                ind)))))
+or `right'.  `:line' and `:pos' are resolved against the WHOLE buffer (the
+position math widens), so line numbers are absolute regardless of narrowing."
+  (save-restriction
+    (widen)
+    (let* ((pos (or (plist-get ind :pos)
+                    (and (plist-get ind :line)
+                         (save-excursion
+                           (goto-char (point-min))
+                           (forward-line (1- (plist-get ind :line)))
+                           (point)))))
+           (side (or (plist-get ind :side) svg-margin-default-side)))
+      (when (and pos (<= (point-min) pos (point-max)))
+        (let ((bol (save-excursion (goto-char pos) (line-beginning-position))))
+          (append (list :pos bol :side (if (memq side '(right right-margin)) 'right 'left))
+                  ind))))))
 
 (defun svg-margin--collect ()
-  "Run every provider against the current buffer and return all indicators."
+  "Run every provider against the current buffer and return all indicators.
+Per-provider defaults and `svg-margin-provider-sides' overrides are applied,
+and (when `svg-margin-debug') position-less indicators are reported."
   (let ((buf (current-buffer)) (out nil))
     (dolist (p svg-margin--providers)
-      (condition-case err
-          (dolist (ind (funcall (cdr p) buf))
-            (when-let* ((n (svg-margin--normalize ind)))
-              (push n out)))
-        (error (message "svg-margin: provider %s failed: %s"
-                        (car p) (error-message-string err)))))
+      (let* ((name (car p)) (props (cdr p)) (fn (plist-get props :fn))
+             (override (alist-get name svg-margin-provider-sides)))
+        (condition-case err
+            (dolist (ind (funcall fn buf))
+              (let* ((ind (svg-margin--apply-provider-defaults ind props override))
+                     (n (svg-margin--normalize ind)))
+                (if n
+                    (push n out)
+                  (when svg-margin-debug
+                    (message "svg-margin: provider %s dropped an indicator (no/out-of-range :pos/:line): %S"
+                             name ind)))))
+          (error (message "svg-margin: provider %s failed: %s"
+                          name (error-message-string err))))))
     out))
 
 (defun svg-margin--group (indicators)
@@ -260,32 +323,34 @@ of (:indicator IND :column N)."
               :fill (svg-margin--color color))))
 
 (defun svg-margin--draw (ind svg x y w h)
-  "Draw indicator IND into the (X Y W H) cell of SVG."
+  "Draw indicator IND into the (X Y W H) cell of SVG.
+A non-function `:draw' is ignored (falls through to `:text'/`:shape')."
   (let ((color (svg-margin--indicator-color ind)))
     (cond
-     ((plist-get ind :draw) (funcall (plist-get ind :draw) svg x y w h color))
+     ((functionp (plist-get ind :draw)) (funcall (plist-get ind :draw) svg x y w h color))
      ((plist-get ind :text) (svg-margin--draw-text svg (plist-get ind :text) x y w h color))
      ((gethash (plist-get ind :shape) svg-margin--shapes)
       (funcall (gethash (plist-get ind :shape) svg-margin--shapes) svg x y w h color))
      (t (svg-margin--shape-dot svg x y w h color)))))
 
-(defun svg-margin--line-height ()
-  "Pixel height of a default line in the selected frame."
-  (max 1 (default-line-height)))
-
-(defun svg-margin--image (packed side ncols)
+(defun svg-margin--image (packed side ncols cw lh)
   "Build the composite margin image for PACKED cells on SIDE.
 NCOLS is the number of columns to reserve; column 0 is nearest the buffer
-text on either side."
-  (let* ((cw (* svg-margin-column-width (frame-char-width)))
-         (h (svg-margin--line-height))
+text on either side.  CW is one column's pixel width and LH the line height
+\(both passed in so they track the displaying window's frame, not just the
+selected one).  A cell whose draw signals is skipped so one bad indicator
+cannot blank the whole line."
+  (let* ((h (max 1 lh))
          (w (max 1 (* ncols cw)))
          (svg (svg-create w h)))
     (dolist (cell packed)
       (let* ((col (plist-get cell :column))
              (ind (plist-get cell :indicator))
              (x (if (eq side 'left) (* (- ncols 1 col) cw) (* col cw))))
-        (svg-margin--draw ind svg x 0 cw h)))
+        (condition-case err
+            (svg-margin--draw ind svg x 0 cw h)
+          (error (message "svg-margin: drawing an indicator failed: %s"
+                          (error-message-string err))))))
     (svg-image svg :ascent 'center :scale 1.0)))
 
 ;;;; Overlays
@@ -299,10 +364,11 @@ text on either side."
   (mapc #'delete-overlay svg-margin--overlays)
   (setq svg-margin--overlays nil))
 
-(defun svg-margin--place (pos side packed ncols)
+(defun svg-margin--place (pos side packed ncols cw lh)
   "Create an overlay at POS carrying the composite SIDE image for PACKED.
-NCOLS is the number of columns the image spans."
-  (let* ((img (svg-margin--image packed side ncols))
+NCOLS is the number of columns the image spans; CW and LH are the column
+pixel width and line height for the image."
+  (let* ((img (svg-margin--image packed side ncols cw lh))
          (marg (if (eq side 'left) 'left-margin 'right-margin))
          (help (string-join
                 (delq nil (mapcar (lambda (c) (plist-get (plist-get c :indicator) :help))
@@ -325,8 +391,12 @@ NCOLS is the number of columns the image spans."
 ;; ----------------------------------------------------------------
 
 (defun svg-margin--windows ()
-  "Return the windows currently displaying the current buffer."
-  (get-buffer-window-list (current-buffer) nil t))
+  "Return the GRAPHICAL windows currently displaying the current buffer.
+Margins/fringes are only meaningful where the SVG can render, so terminal
+windows showing the same buffer are excluded (they would otherwise reserve
+dead gutter space)."
+  (cl-remove-if-not (lambda (w) (display-graphic-p (window-frame w)))
+                    (get-buffer-window-list (current-buffer) nil t)))
 
 (defun svg-margin--apply-margins (left right)
   "Reserve LEFT and RIGHT indicator columns in every window showing the buffer.
@@ -355,17 +425,31 @@ loop / flicker that would follow)."
     ('right '(right))
     (_ nil)))
 
-(defun svg-margin--apply-fringes (restore)
-  "Zero (or, when RESTORE, reset to default) the configured fringe sides."
-  (let ((sides (svg-margin--fringe-sides)))
-    (when sides
-      (dolist (win (svg-margin--windows))
-        (let* ((fr (window-fringes win)) (l (nth 0 fr)) (r (nth 1 fr))
-               (nl (cond ((not (memq 'left sides)) l) (restore nil) (t 0)))
-               (nr (cond ((not (memq 'right sides)) r) (restore nil) (t 0))))
-          ;; Only write when changed (see `svg-margin--apply-margins').
-          (unless (and (equal nl l) (equal nr r))
-            (set-window-fringes win nl nr)))))))
+(defun svg-margin--apply-fringes ()
+  "Zero the configured fringe side(s); restore the others to their saved widths.
+Each window's original fringe widths are saved once (in a window parameter)
+before first being zeroed, so they can be restored exactly -- including when
+`svg-margin-disable-fringe' changes at runtime."
+  (dolist (win (svg-margin--windows))
+    (let* ((sides (svg-margin--fringe-sides))
+           (fr (window-fringes win)) (l (nth 0 fr)) (r (nth 1 fr))
+           (saved (window-parameter win 'svg-margin--saved-fringes)))
+      (when (and sides (not saved))
+        (setq saved (cons l r))
+        (set-window-parameter win 'svg-margin--saved-fringes saved))
+      (let* ((ol (if saved (car saved) l)) (or* (if saved (cdr saved) r))
+             (nl (if (memq 'left sides) 0 ol))
+             (nr (if (memq 'right sides) 0 or*)))
+        (unless (and (= nl l) (= nr r))
+          (set-window-fringes win nl nr))))))
+
+(defun svg-margin--restore-fringes ()
+  "Restore each window's fringes to the widths saved before svg-margin zeroed them."
+  (dolist (win (svg-margin--windows))
+    (let ((saved (window-parameter win 'svg-margin--saved-fringes)))
+      (when saved
+        (set-window-fringes win (car saved) (cdr saved))
+        (set-window-parameter win 'svg-margin--saved-fringes nil)))))
 
 ;;;; Render
 ;; ----------------------------------------------------------------
@@ -376,22 +460,33 @@ loop / flicker that would follow)."
     (when (and (buffer-live-p buffer) (display-graphic-p))
       (with-current-buffer buffer
         (when (bound-and-true-p svg-margin-mode)
-          (svg-margin--clear)
-          (let ((groups (svg-margin--group (svg-margin--collect)))
-                (max-left 0) (max-right 0))
-            (maphash
-             (lambda (key inds)
-               (let* ((pos (car key)) (side (cdr key))
-                      (packed (svg-margin--pack-columns inds))
-                      (ncols (svg-margin--max-column packed)))
-                 (when (> ncols 0)
-                   (if (eq side 'left)
-                       (setq max-left (max max-left ncols))
-                     (setq max-right (max max-right ncols)))
-                   (svg-margin--place pos side packed ncols))))
-             groups)
-            (svg-margin--apply-margins max-left max-right)
-            (svg-margin--apply-fringes nil)))))))
+          ;; Widen so providers see -- and `:line'/`:pos' resolve against -- the
+          ;; whole buffer (absolute positions); overlays outside a narrowing
+          ;; simply will not display.
+          (save-restriction
+            (widen)
+            (svg-margin--clear)
+            ;; Size columns/lines from a window actually showing the buffer (its
+            ;; frame's font), falling back to the selected frame when off-screen.
+            (let* ((win (car (svg-margin--windows)))
+                   (frame (if win (window-frame win) (selected-frame)))
+                   (cw (* svg-margin-column-width (frame-char-width frame)))
+                   (lh (max 1 (default-line-height)))
+                   (groups (svg-margin--group (svg-margin--collect)))
+                   (max-left 0) (max-right 0))
+              (maphash
+               (lambda (key inds)
+                 (let* ((pos (car key)) (side (cdr key))
+                        (packed (svg-margin--pack-columns inds))
+                        (ncols (svg-margin--max-column packed)))
+                   (when (> ncols 0)
+                     (if (eq side 'left)
+                         (setq max-left (max max-left ncols))
+                       (setq max-right (max max-right ncols)))
+                     (svg-margin--place pos side packed ncols cw lh))))
+               groups)
+              (svg-margin--apply-margins max-left max-right)
+              (svg-margin--apply-fringes))))))))
 
 (defvar-local svg-margin--timer nil
   "Idle timer coalescing re-renders for this buffer.")
@@ -433,10 +528,15 @@ loop / flicker that would follow)."
 (define-minor-mode svg-margin-mode
   "Display SVG indicators from registered providers in the window margins.
 Providers are registered globally with `svg-margin-register-provider'; this
-buffer-local mode renders whatever they contribute for the current buffer."
+buffer-local mode renders whatever they contribute for the current buffer.
+
+svg-margin draws SVG images, so it only shows anything in a GRAPHICAL frame;
+in a terminal (`emacs -nw') it does nothing."
   :lighter " SVGm"
   (if svg-margin-mode
       (progn
+        (unless (display-graphic-p)
+          (message "svg-margin-mode: needs a graphical frame; nothing will show in a terminal"))
         (add-hook 'after-change-functions #'svg-margin--after-change nil t)
         (add-hook 'window-configuration-change-hook #'svg-margin--window-config nil t)
         (svg-margin--render (current-buffer)))
@@ -444,7 +544,7 @@ buffer-local mode renders whatever they contribute for the current buffer."
     (remove-hook 'window-configuration-change-hook #'svg-margin--window-config t)
     (when (timerp svg-margin--timer) (cancel-timer svg-margin--timer))
     (svg-margin--clear)
-    (svg-margin--apply-fringes t)
+    (svg-margin--restore-fringes)
     (svg-margin--restore-margins)))
 
 (defun svg-margin--maybe-enable ()

--- a/source/zettapkg/svg-margin/test/svg-margin-test.el
+++ b/source/zettapkg/svg-margin/test/svg-margin-test.el
@@ -1,0 +1,102 @@
+;;; svg-margin-test.el --- Tests for svg-margin -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Pure-logic tests (column packing, colour, normalisation, grouping, shape
+;; registry).  Rendering/overlay/margin behaviour needs a live graphical
+;; frame and is not exercised here.
+
+;;; Code:
+
+(require 'ert)
+(require 'svg-margin)
+
+;;;; Colour
+
+(ert-deftest svg-margin/color-passthrough-and-names ()
+  (should (equal (svg-margin--color "#ab12ef") "#ab12ef"))
+  (should (equal (svg-margin--color nil) nil))
+  (should (string-prefix-p "#" (svg-margin--color "red")))
+  ;; 12-digit form collapses to 6
+  (should (string-match-p "\\`#[0-9a-f]\\{6\\}\\'" (svg-margin--color "#ffff00000000"))))
+
+;;;; Column packing
+
+(ert-deftest svg-margin/pack-auto-fills-lowest-free ()
+  (let* ((inds (list (list :id 'a) (list :id 'b) (list :id 'c)))
+         (packed (svg-margin--pack-columns inds))
+         (cols (mapcar (lambda (c) (plist-get c :column)) packed)))
+    (should (equal (sort cols #'<) '(0 1 2)))))
+
+(ert-deftest svg-margin/pack-honours-explicit-column ()
+  (let* ((inds (list (list :id 'a :column 2) (list :id 'b)))
+         (packed (svg-margin--pack-columns inds))
+         (by-id (lambda (id) (cl-find-if (lambda (c) (eq (plist-get (plist-get c :indicator) :id) id)) packed))))
+    (should (= 2 (plist-get (funcall by-id 'a) :column)))
+    ;; b takes the lowest free slot (0), not colliding with a's explicit 2
+    (should (= 0 (plist-get (funcall by-id 'b) :column)))))
+
+(ert-deftest svg-margin/pack-priority-orders-first ()
+  ;; Higher priority is placed first, so it claims column 0.
+  (let* ((inds (list (list :id 'lo :priority 1) (list :id 'hi :priority 9)))
+         (packed (svg-margin--pack-columns inds))
+         (hi (cl-find-if (lambda (c) (eq (plist-get (plist-get c :indicator) :id) 'hi)) packed)))
+    (should (= 0 (plist-get hi :column)))))
+
+(ert-deftest svg-margin/max-column-counts-slots ()
+  (should (= 3 (svg-margin--max-column
+                (list (list :column 0) (list :column 2) (list :column 1))))))
+
+;;;; Normalisation + grouping
+
+(ert-deftest svg-margin/normalize-line-to-bol-pos ()
+  (with-temp-buffer
+    (insert "line one\nline two\nline three\n")
+    (let ((n (svg-margin--normalize '(:line 2 :shape dot))))
+      (should n)
+      (should (eq (plist-get n :side) 'left))
+      ;; pos is beginning of line 2
+      (should (= (plist-get n :pos)
+                 (save-excursion (goto-char (point-min)) (forward-line 1) (point)))))))
+
+(ert-deftest svg-margin/normalize-rejects-positionless ()
+  (with-temp-buffer
+    (insert "x\n")
+    (should-not (svg-margin--normalize '(:shape dot)))))
+
+(ert-deftest svg-margin/normalize-right-side ()
+  (with-temp-buffer
+    (insert "a\n")
+    (should (eq 'right (plist-get (svg-margin--normalize '(:line 1 :side right)) :side)))))
+
+(ert-deftest svg-margin/group-by-pos-and-side ()
+  (let* ((a (list :pos 1 :side 'left)) (b (list :pos 1 :side 'left))
+         (c (list :pos 1 :side 'right))
+         (h (svg-margin--group (list a b c))))
+    (should (= 2 (length (gethash '(1 . left) h))))
+    (should (= 1 (length (gethash '(1 . right) h))))))
+
+;;;; Shape registry
+
+(ert-deftest svg-margin/builtin-shapes-registered ()
+  (dolist (s '(dot circle bar box triangle))
+    (should (functionp (gethash s svg-margin--shapes)))))
+
+(ert-deftest svg-margin/define-shape-adds-entry ()
+  (unwind-protect
+      (progn
+        (svg-margin-define-shape 'test-shape (lambda (&rest _) nil))
+        (should (functionp (gethash 'test-shape svg-margin--shapes))))
+    (remhash 'test-shape svg-margin--shapes)))
+
+;;;; Provider registry
+
+(ert-deftest svg-margin/register-and-unregister-provider ()
+  (let ((svg-margin--providers nil))
+    (cl-letf (((symbol-function 'svg-margin-refresh-all) #'ignore))
+      (svg-margin-register-provider 'p (lambda (_b) nil))
+      (should (assq 'p svg-margin--providers))
+      (svg-margin-unregister-provider 'p)
+      (should-not (assq 'p svg-margin--providers)))))
+
+(provide 'svg-margin-test)
+;;; svg-margin-test.el ends here

--- a/source/zettapkg/svg-margin/test/svg-margin-test.el
+++ b/source/zettapkg/svg-margin/test/svg-margin-test.el
@@ -88,6 +88,38 @@
         (should (functionp (gethash 'test-shape svg-margin--shapes))))
     (remhash 'test-shape svg-margin--shapes)))
 
+;;;; Provider defaults + side override
+
+(ert-deftest svg-margin/provider-defaults-fill-missing ()
+  (let ((ind (svg-margin--apply-provider-defaults
+              '(:line 3) '(:fn ignore :side right :priority 5) nil)))
+    (should (eq 'right (plist-get ind :side)))
+    (should (= 5 (plist-get ind :priority)))))
+
+(ert-deftest svg-margin/provider-defaults-respect-explicit ()
+  (let ((ind (svg-margin--apply-provider-defaults
+              '(:line 3 :side left) '(:fn ignore :side right) nil)))
+    ;; the indicator's own :side wins over the provider default
+    (should (eq 'left (plist-get ind :side)))))
+
+(ert-deftest svg-margin/provider-side-override-forces ()
+  (let ((ind (svg-margin--apply-provider-defaults
+              '(:line 3 :side left) '(:fn ignore :side left) 'right)))
+    ;; an override forces the side even over an explicit indicator :side
+    (should (eq 'right (plist-get ind :side)))))
+
+;;;; Narrowing-safe normalisation
+
+(ert-deftest svg-margin/normalize-line-is-absolute-under-narrowing ()
+  (with-temp-buffer
+    (insert "l1\nl2\nl3\nl4\nl5\n")
+    (let ((want (save-excursion (goto-char (point-min)) (forward-line 3) (point))))
+      (narrow-to-region (save-excursion (goto-char (point-min)) (forward-line 2) (point))
+                        (point-max))
+      ;; :line 4 must still resolve to absolute file line 4, not the 4th
+      ;; visible line within the narrowing.
+      (should (= want (plist-get (svg-margin--normalize '(:line 4 :shape dot)) :pos))))))
+
 ;;;; Provider registry
 
 (ert-deftest svg-margin/register-and-unregister-provider ()


### PR DESCRIPTION
## Summary

Adds **svg-margin**, a new self-contained package (`source/zettapkg/svg-margin/`) that renders the window margins as a flexible, multi-column gutter many decoupled *providers* draw SVG indicators into — left and right, packed side by side on a line — plus the config wiring that turns it on for this distro.

The fringe can only show one monochrome bitmap per line per side, so git-gutter, evil-fringe-mark, flycheck, bookmarks, etc. all clobber each other in one ~8px strip. svg-margin composites *every* indicator for a line/side into one SVG image at exact pixel coordinates.

## Package (`source/zettapkg/svg-margin/`)

- **Engine** (`svg-margin.el`): provider registry (`buffer -> indicators`), column packing, shape registry, left/right margins with a configurable minimum width, fringe reclaiming, per-frame geometry, error isolation, anti-flicker. Built-in deps only (`svg.el`), Emacs 29.1+.
- **Docs**: `README.md` (engine/API), `CONFIGURATION.md` (options + how hard it is to divert other fringe/margin packages), `EXAMPLES.md` (ten worked providers).
- **Examples gallery** (`examples/svg-margin-examples.el`): VC (git-gutter/diff-hl), flycheck, TODO, bookmarks, evil marks, Org heading rail, long-lines, trailing-ws, symbol occurrences.
- `Eask`, MELPA recipe, LICENSE, ERT tests.
- Pre-publication reviewed by a multi-agent pass; blocker (autoloads) + portability/config/docs findings addressed.

## Config wiring

- `modules/ui/svg-margin.el` — loads the package and registers my providers with their sides/priorities; min widths left 4 / right 2; disables evil-fringe-mark and git-gutter's own drawing; enables `global-svg-margin-mode` from `emacs-startup-hook`.
- Registered in the `:ui` load order in `source/bootstrap/bootstrap-modules.el`.

## Verification

Engine + examples byte-compile clean (no optional packages loaded), checkdoc clean, package-lint clean, 16/16 ERT tests pass. Wired live and verified stable.