### PR TITLE
feat: clickable, hover-aware indicators in the SVG bars and margins

### DIFF
--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -96,6 +96,128 @@
 ;; into lines (they only compose, not define).  line-utils.el (:core)
 ;; loads before those :ui consumers, so the functions are defined first.
 
+;; Interactive (clickable/hover/menu) segments are built with the svg-line
+;; engine's `svg-line-seg'; `zetta-svg-seg' wraps it to give every segment a
+;; per-window-unique id (so only the hovered window's copy of an indicator
+;; highlights) and to no-op gracefully when the engine isn't loaded.
+(declare-function svg-line-seg "svg-line")
+(declare-function svg-line-segs "svg-line")
+
+(defun zetta-svg-seg (text key &rest plist)
+  "Return an interactive svg-line segment for TEXT, keyed by KEY.
+The hover/identity id is (KEY . current-buffer) so a per-window bar only
+highlights the indicator in the window under the mouse.  PLIST passes through
+\(`:help' `:action' `:action-help' `:menu' `:color'/`:face').  Returns nil when
+TEXT is empty or the engine is unavailable, so the segment then contributes
+nothing."
+  (when (and text (fboundp 'svg-line-seg)
+             (> (length (format-mode-line text)) 0))
+    (apply #'svg-line-seg text :id (cons key (current-buffer)) plist)))
+
+(defun zetta-svg--crumb-target (str pos text)
+  "Return a buffer position/marker the crumb at POS (text TEXT) in STR points to.
+Reads the target breadcrumb already stashed on the crumb: `breadcrumb-region'
+or `org-imenu-marker' on the crumb itself, else the crumb's entry in the
+`breadcrumb-siblings' alist (matched by TEXT).  Returns nil when no target is
+discoverable (e.g. lsp crumbs, whose own handler we keep instead)."
+  (let ((reg  (get-text-property pos 'breadcrumb-region str))
+        (om   (get-text-property pos 'org-imenu-marker str))
+        (sibs (get-text-property pos 'breadcrumb-siblings str)))
+    (cond
+     ((consp reg) (car reg))                       ; (start . end) -> start
+     ((markerp om) om)
+     ((and (listp sibs) text)
+      (let ((hit (assoc text (mapcar (lambda (e)
+                                       (cons (and (stringp (car-safe e))
+                                                  (substring-no-properties (car e)))
+                                             (cdr-safe e)))
+                                     sibs))))
+        (let ((tgt (cdr hit)))
+          (cond ((markerp tgt) tgt)
+                ((numberp tgt) tgt)
+                ((overlayp tgt) (overlay-start tgt)))))))))
+
+(defun zetta-svg--crumb-jump (target)
+  "Return an interactive command that navigates to TARGET (a marker or position).
+Selects TARGET's window/buffer, pushes the mark, moves point and reveals it
+\(unfolding in org), so a crumb click goes straight there -- no completing-read."
+  (lambda ()
+    (interactive)
+    (let* ((m (if (markerp target) target nil))
+           (buf (if m (marker-buffer m) (current-buffer)))
+           (pos (if m (marker-position m) target)))
+      (when (and buf pos (buffer-live-p buf))
+        (let ((win (get-buffer-window buf)))
+          (if win (select-window win)
+            (pop-to-buffer buf)))
+        (push-mark)
+        (goto-char pos)
+        (cond ((derived-mode-p 'org-mode)
+               (ignore-errors (org-fold-show-context))
+               (ignore-errors (org-fold-show-entry)))
+              ((bound-and-true-p outline-minor-mode)
+               (ignore-errors (outline-show-entry))))
+        (recenter)))))
+
+(defun zetta-svg-segs-from-propertized (str id-key)
+  "Split propertized STR into an svg-line `:svg-segs' group of clickable crumbs.
+Each maximal region carrying a clickable `keymap'/`local-map' (with a mouse-1
+binding) becomes an interactive segment whose action invokes that binding;
+regions without one stay plain text.  This harvests the crumb handlers that
+breadcrumb.el and lsp-headerline already attach to header-line strings -- their
+handlers either ignore the event (`breadcrumb-jump') or read the window from
+its posn, which our header-line click provides correctly.  ID-KEY namespaces
+the per-crumb hover ids.  Returns nil (no segment) for empty STR."
+  (when (and (stringp str) (fboundp 'svg-line-segs) (> (length str) 0))
+    (let ((parts nil) (i 0) (n (length str)) (idx 0) (buf (current-buffer)))
+      (while (< i n)
+        (let* ((km   (or (get-text-property i 'keymap str)
+                         (get-text-property i 'local-map str)))
+               (next (min (or (next-single-property-change i 'keymap str) n)
+                          (or (next-single-property-change i 'local-map str) n)))
+               (text (substring-no-properties str i next))
+               ;; NB: `lookup-key' returns an integer (not nil) when a key is
+               ;; "too long" for the map, so test each result for `functionp'
+               ;; and take the first real command -- don't `or' the raw results.
+               (handler (and (keymapp km)
+                             (seq-some (lambda (k)
+                                         (let ((b (lookup-key km k)))
+                                           (and (functionp b) b)))
+                                       (list [header-line mouse-1] [mouse-1]
+                                             [mode-line mouse-1]))))
+               ;; Prefer a DIRECT jump to the crumb's own target (org/imenu
+               ;; crumbs stash a marker/region) over the package handler, which
+               ;; for breadcrumb is a completing-read.  lsp crumbs expose no
+               ;; target here, so they keep their own (already-direct) handler.
+               (target (and handler (zetta-svg--crumb-target str i text)))
+               (act  (cond (target (zetta-svg--crumb-jump target))
+                           (handler handler)))
+               (he   (get-text-property i 'help-echo str)))
+          ;; Only a left-click action: these crumb handlers take (interactive
+          ;; "e") and read the invoking mouse event, which a real header-line
+          ;; click supplies but a right-click menu selection would not.
+          (if (and act (> (length (string-trim text)) 0))
+              (setq idx (1+ idx)
+                    parts (cons (svg-line-seg
+                                 text
+                                 :id (list id-key buf idx)
+                                 ;; clean, lightweight help -- for a direct jump
+                                 ;; use the crumb text; else the handler's own
+                                 ;; first help line (properties stripped, since
+                                 ;; breadcrumb stuffs its sibling tree in there)
+                                 :help (if target
+                                           (concat "go to " (string-trim text))
+                                         (if (stringp he)
+                                             (substring-no-properties
+                                              (car (split-string he "\n")))
+                                           (format "%s" (string-trim text))))
+                                 :action-help (if target "jump" "open")
+                                 :action act)
+                                parts))
+            (push text parts))
+          (setq i next)))
+      (apply #'svg-line-segs (nreverse parts)))))
+
 ;;; tab-bar / status segments
 (defun zetta-buffer-name ()
   (let ((name (if (buffer-file-name)
@@ -187,53 +309,171 @@ where no local thing has been set via `treesit-tap-set-local'."
 ;;; mode-line text segments
 (defun zetta-modeline-svg--modal ()
   ;; show the modal STATE (normal/insert/...), not the modal system
-  (zetta-line-modal-state))
+  (let ((st (zetta-line-modal-state)))
+    (zetta-svg-seg
+     st 'ml-modal
+     :help (format "modal state: %s" (string-trim (format "%s" st)))
+     :action-help "show key bindings"
+     :action #'describe-bindings
+     :menu (list (cons "Describe bindings" #'describe-bindings)
+                 (cons "Describe mode" #'describe-mode)
+                 (cons "Command (M-x)" #'execute-extended-command)))))
 
 (defun zetta-modeline-svg--ace ()
   (or (window-parameter (selected-window) 'ace-window-path) ""))
 
 (defun zetta-modeline-svg--buffer ()
-  (let ((n (buffer-name)))
-    (if (> (length n) 40) (concat (substring n 0 39) "…") n)))
+  (let* ((buf (current-buffer))
+         (n (buffer-name buf))
+         (label (if (> (length n) 40) (concat (substring n 0 39) "…") n)))
+    (svg-line-seg
+     label
+     ;; id includes the buffer so only THIS window's name boxes on hover
+     :id (list 'ml-buffer buf)
+     :help (format "buffer: %s" n)
+     :action-help "switch buffer"
+     :action #'switch-to-buffer
+     :menu (delq nil
+                 (list
+                  (cons "Switch buffer…" #'switch-to-buffer)
+                  (cons "Save buffer"
+                        (lambda () (interactive)
+                          (with-current-buffer buf (save-buffer))))
+                  (and (buffer-file-name buf)
+                       (cons "Rename file…"
+                             (lambda () (interactive)
+                               (with-current-buffer buf
+                                 (call-interactively #'rename-visited-file)))))
+                  (cons "Revert buffer"
+                        (lambda () (interactive)
+                          (with-current-buffer buf (revert-buffer))))
+                  (cons "Copy buffer name"
+                        (lambda () (interactive) (kill-new n)))
+                  (cons "Kill buffer"
+                        (lambda () (interactive)
+                          (when (buffer-live-p buf) (kill-buffer buf)))))))))
 
 (defun zetta-modeline-svg--mode ()
-  (format-mode-line mode-name))
+  (zetta-svg-seg
+   (format-mode-line mode-name) 'ml-mode
+   :help (format "major mode: %s" major-mode)
+   :action-help "describe mode"
+   :action #'describe-mode
+   :menu (list (cons "Describe mode" #'describe-mode)
+               (cons "Describe bindings" #'describe-bindings)
+               (cons "Customize mode" #'customize-mode))))
 
+;; The vc cluster (git glyph + branch glyph + repo:branch) is one clickable
+;; segment so the whole thing opens magit -- the separate icon segments are
+;; folded in here and dropped from the mode-line content.
 (defun zetta-modeline-svg--vc ()
   (when (and (fboundp 'vc-git-root)
              (vc-git-root (or (buffer-file-name) default-directory)))
-    (let ((repo   (ignore-errors (nth 0 (zetta-get-repo-name))))
-          (branch (ignore-errors (vc-git--symbolic-ref
-                                  (or (buffer-file-name) default-directory)))))
-      (concat (or repo "") (and branch (concat ":" branch))))))
+    (let* ((repo   (ignore-errors (nth 0 (zetta-get-repo-name))))
+           (branch (ignore-errors (vc-git--symbolic-ref
+                                   (or (buffer-file-name) default-directory))))
+           (vcg (and (buffer-file-name) (featurep 'nerd-icons)
+                     (zetta-line--glyph (ignore-errors (nerd-icons-devicon "nf-dev-git")))))
+           (brg (and (buffer-file-name) (featurep 'nerd-icons)
+                     (zetta-line--glyph (ignore-errors (nerd-icons-octicon "nf-oct-git_branch")))))
+           (text (concat (and vcg (concat vcg " "))
+                         (and brg (concat brg " "))
+                         (or repo "") (and branch (concat ":" branch)))))
+      (zetta-svg-seg
+       text 'ml-vc
+       :help (format "git: %s%s" (or repo "?") (if branch (concat " @ " branch) ""))
+       :action-help "open magit"
+       :action (if (fboundp 'magit-status) #'magit-status #'vc-dir)
+       :menu (delq nil
+                   (list (and (fboundp 'magit-status) (cons "Magit status" #'magit-status))
+                         (and (fboundp 'magit-log-current) (cons "Magit log" #'magit-log-current))
+                         (and (fboundp 'magit-blame) (cons "Magit blame" #'magit-blame))
+                         (and (fboundp 'magit-file-dispatch) (cons "File dispatch" #'magit-file-dispatch))
+                         (cons "VC dir" #'vc-dir)
+                         (and branch (cons "Copy branch name"
+                                           (let ((b branch))
+                                             (lambda () (interactive) (kill-new b)))))))))))
 
 (defun zetta-modeline-svg--checkers ()
   ;; copilot is shown as an icon (zetta-modeline-svg--copilot-icon), not text
-  (concat
-   (when (and (boundp 'lsp-mode) lsp-mode) "lsp ")))
+  (when (and (boundp 'lsp-mode) lsp-mode)
+    (zetta-svg-seg
+     "lsp " 'ml-lsp
+     :help "LSP session"
+     :action-help "LSP diagnostics"
+     :action (cond ((fboundp 'consult-lsp-diagnostics) #'consult-lsp-diagnostics)
+                   ((fboundp 'lsp-treemacs-errors-list) #'lsp-treemacs-errors-list)
+                   ((fboundp 'flymake-show-buffer-diagnostics) #'flymake-show-buffer-diagnostics)
+                   (t #'ignore))
+     :menu (delq nil
+                 (list (and (fboundp 'lsp-describe-session) (cons "Describe session" #'lsp-describe-session))
+                       (and (fboundp 'lsp-rename) (cons "Rename symbol" #'lsp-rename))
+                       (and (fboundp 'lsp-find-references) (cons "Find references" #'lsp-find-references))
+                       (and (fboundp 'lsp-organize-imports) (cons "Organize imports" #'lsp-organize-imports))
+                       (and (fboundp 'lsp-workspace-restart) (cons "Restart workspace" #'lsp-workspace-restart)))))))
 
 (defun zetta-modeline-svg--flycheck ()
   (if (fboundp 'flycheck-indicator--mode-line)
       (let ((text (flycheck-indicator--mode-line)))
-        (if (string= " not-checked" text) "" (substring-no-properties text)))
+        (if (string= " not-checked" text)
+            ""
+          (zetta-svg-seg
+           (substring-no-properties text) 'ml-flycheck
+           :help "syntax checker results"
+           :action-help "list errors"
+           :action (if (fboundp 'flycheck-list-errors) #'flycheck-list-errors #'ignore)
+           :menu (delq nil
+                       (list (and (fboundp 'flycheck-list-errors) (cons "List errors" #'flycheck-list-errors))
+                             (and (fboundp 'flycheck-next-error) (cons "Next error" #'flycheck-next-error))
+                             (and (fboundp 'flycheck-previous-error) (cons "Previous error" #'flycheck-previous-error))
+                             (and (fboundp 'flycheck-buffer) (cons "Recheck buffer" #'flycheck-buffer))
+                             (and (fboundp 'flycheck-verify-setup) (cons "Verify setup" #'flycheck-verify-setup)))))))
     ""))
 
 (defun zetta-modeline-svg--indicators ()
-  (concat
-   (when (bound-and-true-p repeat-in-progress) "R")
-   (when (and (fboundp 'zetta-line-tramp-icon) (zetta-line-tramp-icon)) "T")
-   (when (and (fboundp 'zetta-line-docker-icon) (zetta-line-docker-icon)) "D")
-   (when (and (fboundp 'zetta-line-narrowed-icon) (zetta-line-narrowed-icon)) "N")
-   (when (and (fboundp 'zetta-line-hydra-indicator-icon) (zetta-line-hydra-indicator-icon)) "H")))
+  (let* ((flags (delq nil
+                      (list (and (bound-and-true-p repeat-in-progress) (cons "R" "repeat in progress"))
+                            (and (fboundp 'zetta-line-tramp-icon) (zetta-line-tramp-icon) (cons "T" "remote (TRAMP)"))
+                            (and (fboundp 'zetta-line-docker-icon) (zetta-line-docker-icon) (cons "D" "docker"))
+                            (and (buffer-narrowed-p) (cons "N" "buffer narrowed"))
+                            (and (fboundp 'zetta-line-hydra-indicator-icon) (zetta-line-hydra-indicator-icon) (cons "H" "hydra active")))))
+         (text (mapconcat #'car flags "")))
+    (when (> (length text) 0)
+      (zetta-svg-seg
+       text 'ml-flags
+       :help (concat "flags: " (mapconcat #'cdr flags ", "))
+       :action-help (if (buffer-narrowed-p) "widen buffer" "describe")
+       :action (if (buffer-narrowed-p) #'widen #'ignore)
+       :menu (delq nil
+                   (list (and (buffer-narrowed-p) (cons "Widen buffer" #'widen))
+                         (and (bound-and-true-p repeat-in-progress) (cons "Repeat help" #'describe-bindings))))))))
 
 (defun zetta-modeline-svg--docpos ()
   (cond
    ((and (eq major-mode 'pdf-view-mode) (fboundp 'pdf-view-current-page))
-    (ignore-errors (format "%d/%d" (pdf-view-current-page) (pdf-cache-number-of-pages))))
+    (let ((text (ignore-errors (format "%d/%d" (pdf-view-current-page)
+                                       (pdf-cache-number-of-pages)))))
+      (when text
+        (zetta-svg-seg
+         text 'ml-docpos
+         :help "PDF page"
+         :action-help "go to page"
+         :action (if (fboundp 'pdf-view-goto-page) #'pdf-view-goto-page #'ignore)
+         :menu (delq nil
+                     (list (and (fboundp 'pdf-view-goto-page) (cons "Go to page…" #'pdf-view-goto-page))
+                           (and (fboundp 'pdf-view-first-page) (cons "First page" #'pdf-view-first-page))
+                           (and (fboundp 'pdf-view-last-page) (cons "Last page" #'pdf-view-last-page))))))))
    (t "")))
 
 (defun zetta-modeline-svg--point ()
-  (format-mode-line "%l:%c"))
+  (zetta-svg-seg
+   (format-mode-line "%l:%c") 'ml-point
+   :help "line:column"
+   :action-help "go to line"
+   :action #'goto-line
+   :menu (list (cons "Go to line…" #'goto-line)
+               (cons "What cursor position" #'what-cursor-position)
+               (cons "Go to char…" #'goto-char))))
 
 ;;; header-line breadcrumb content
 (defvar zetta-header-line-svg-line1-format
@@ -249,8 +489,18 @@ where no local thing has been set via `treesit-tap-set-local'."
     (:eval (when (fboundp 'spinner-print) (spinner-print spinner-current)))
     " "
     (:eval
-     (let ((path (abbreviate-file-name default-directory)))
-       (if (> (length path) 30) (zetta-minify-path default-directory) path)))
+     (let* ((dir default-directory)
+            (path (abbreviate-file-name dir))
+            (disp (if (> (length path) 30) (zetta-minify-path dir) path)))
+       ;; clickable: a keymap (which the header-line harvester picks up) that
+       ;; opens dired on the directory; no breadcrumb target prop, so the
+       ;; harvester keeps this handler rather than building a jump.
+       (propertize disp
+                   'keymap (let ((m (make-sparse-keymap)))
+                             (define-key m [header-line mouse-1]
+                               (lambda () (interactive) (dired dir)))
+                             m)
+                   'help-echo (format "mouse-1: dired %s" dir))))
     " "
     "%c|%l(%p)")
   "Mode-line construct for header-line row 1 (path / position).")
@@ -260,10 +510,15 @@ where no local thing has been set via `treesit-tap-set-local'."
      (cond
       ((and (boundp 'lsp-mode) lsp-mode)
        (window-parameter nil 'lsp-headerline--string))
-      ((string= major-mode "org-mode")
-       (propertize
-        (or (ignore-errors (org-display-outline-path nil t "/" t)) "/")
-        'face '(:height 0.8)))
+      ((derived-mode-p 'org-mode)
+       ;; Prefer breadcrumb's imenu crumbs (each carries a clickable keymap our
+       ;; header-line harvests) over `org-display-outline-path' (no per-crumb
+       ;; keymap, so it would render as plain, non-clickable text).
+       (if (fboundp 'breadcrumb-imenu-crumbs)
+           (breadcrumb-imenu-crumbs)
+         (propertize
+          (or (ignore-errors (org-display-outline-path nil t "/" t)) "/")
+          'face '(:height 0.8))))
       ((or (equal major-mode 'jsonian-mode))
        (concat (jsonian--display-path (jsonian-path))))
       ((or (equal major-mode 'docker-compose-mode)
@@ -273,12 +528,14 @@ where no local thing has been set via `treesit-tap-set-local'."
   "Mode-line construct for header-line row 2 (lsp / org / imenu crumbs).")
 
 (defun zetta-header-line-svg--line1 ()
-  "Render the first breadcrumb row (path / position)."
-  (format-mode-line zetta-header-line-svg-line1-format))
+  "Render the first breadcrumb row (path / position), crumbs clickable."
+  (zetta-svg-segs-from-propertized
+   (format-mode-line zetta-header-line-svg-line1-format) 'hl1))
 
 (defun zetta-header-line-svg--line2 ()
-  "Render the second breadcrumb row (lsp / org / imenu crumbs)."
-  (format-mode-line zetta-header-line-svg-line2-format))
+  "Render the second breadcrumb row (lsp / org / imenu crumbs), crumbs clickable."
+  (zetta-svg-segs-from-propertized
+   (format-mode-line zetta-header-line-svg-line2-format) 'hl2))
 
 ;;;; Nerd-font glyph icons for the SVG bars
 ;; ----------------------------------------------------------------
@@ -318,10 +575,20 @@ keep their own font (`zetta-font').")
   (zetta-line-buffer-glyph))
 
 (defun zetta-modeline-svg--copilot-icon ()
-  "GitHub Copilot glyph, shown when `copilot-mode' is on."
+  "GitHub Copilot glyph, shown when `copilot-mode' is on.  Click toggles it."
   (when (bound-and-true-p copilot-mode)
-    (and (featurep 'nerd-icons)
-         (zetta-line--glyph (ignore-errors (nerd-icons-octicon "nf-oct-copilot"))))))
+    (let ((g (and (featurep 'nerd-icons)
+                  (zetta-line--glyph (ignore-errors (nerd-icons-octicon "nf-oct-copilot"))))))
+      (when g
+        (zetta-svg-seg
+         g 'ml-copilot
+         :help "GitHub Copilot (on)"
+         :action-help "toggle Copilot"
+         :action (if (fboundp 'copilot-mode) #'copilot-mode #'ignore)
+         :menu (delq nil
+                     (list (and (fboundp 'copilot-mode) (cons "Toggle Copilot" #'copilot-mode))
+                           (and (fboundp 'copilot-complete) (cons "Complete now" #'copilot-complete))
+                           (and (fboundp 'copilot-diagnose) (cons "Diagnose" #'copilot-diagnose)))))))))
 
 (defun zetta-modeline-svg--vc-icon ()
   "Git glyph, shown when the file is under git version control."
@@ -400,5 +667,136 @@ a bare variable segment would not be evaluated)."
   "Spotify glyph, sits to the left of the spot mode-line string."
   (and (featurep 'nerd-icons)
        (zetta-line--glyph (ignore-errors (nerd-icons-faicon "nf-fa-spotify")))))
+
+;;; tab-bar interactive (svg-only) wrappers
+;; ----------------------------------------------------------------
+;; The base tab-bar segments above are shared with the *text* `tab-bar-format'
+;; fallback, so they must keep returning plain strings.  These wrappers add
+;; click/hover/menu for the SVG tab bar only; `zetta-tab-bar-svg-lines' uses
+;; them in place of the plain segments (and folds in adjacent glyph icons).
+
+(defun zetta-tab-bar-svg--buffer ()
+  "Clickable tab-bar buffer name (switch buffer; menu of buffer/file actions)."
+  (zetta-svg-seg
+   (zetta-buffer-name) 'tb-buffer
+   :help (format "buffer: %s" (buffer-name))
+   :action-help "switch buffer"
+   :action (if (fboundp 'consult-buffer) #'consult-buffer #'switch-to-buffer)
+   :menu (delq nil
+               (list (cons "Switch buffer…" (if (fboundp 'consult-buffer)
+                                                #'consult-buffer #'switch-to-buffer))
+                     (cons "Find file…" #'find-file)
+                     (and (fboundp 'consult-recent-file)
+                          (cons "Recent files…" #'consult-recent-file))
+                     (cons "Save buffer" #'save-buffer)))))
+
+(defun zetta-tab-bar-svg--modal ()
+  "Clickable tab-bar modal-system indicator (describe bindings; menu)."
+  (zetta-svg-seg
+   (zetta-tab-bar-modal) 'tb-modal
+   :help "modal system"
+   :action-help "describe bindings"
+   :action #'describe-bindings
+   :menu (list (cons "Describe bindings" #'describe-bindings)
+               (cons "Command (M-x)" #'execute-extended-command))))
+
+(defun zetta-tab-bar-svg--spotify ()
+  "Clickable Spotify cluster (glyph + spot string): play/pause; transport menu."
+  (let* ((icon (ignore-errors (zetta-tab-bar-spotify-icon)))
+         (txt  (zetta-tab-bar-spot-mode-line-string))
+         (label (concat (and icon (concat icon " ")) txt)))
+    (zetta-svg-seg
+     label 'tb-spotify
+     :help "Spotify"
+     :action-help "pause/play"
+     :action (cond ((fboundp 'spot-player-pause) #'spot-player-pause)
+                   ((fboundp 'spot-player-play) #'spot-player-play)
+                   (t #'ignore))
+     :menu (delq nil
+                 (list (and (fboundp 'spot-player-play) (cons "Play" #'spot-player-play))
+                       (and (fboundp 'spot-player-pause) (cons "Pause" #'spot-player-pause))
+                       (and (fboundp 'spot-player-next) (cons "Next" #'spot-player-next))
+                       (and (fboundp 'spot-player-previous) (cons "Previous" #'spot-player-previous))
+                       (and (fboundp 'spot-consult-search) (cons "Search…" #'spot-consult-search))
+                       (and (fboundp 'spot-add-current-track-to-playlist)
+                            (cons "Add to playlist…" #'spot-add-current-track-to-playlist)))))))
+
+(defun zetta-tab-bar-svg--mu4e ()
+  "Clickable mail cluster (glyph + counts): open mu4e; mail menu."
+  (let* ((icon (ignore-errors (zetta-tab-bar-mu4e-icon)))
+         (txt  (zetta-tab-bar-mu4e-text))
+         (label (concat (and icon (concat icon " ")) txt)))
+    (when (and label (> (length (string-trim label)) 0))
+      (zetta-svg-seg
+       label 'tb-mu4e
+       :help "email (mu4e)"
+       :action-help "open mail"
+       :action (if (fboundp 'mu4e) #'mu4e #'ignore)
+       :menu (delq nil
+                   (list (and (fboundp 'mu4e) (cons "Open mu4e" #'mu4e))
+                         (and (fboundp 'mu4e-update-mail-and-index)
+                              (cons "Update mail"
+                                    (lambda () (interactive) (mu4e-update-mail-and-index t))))
+                         (and (fboundp 'mu4e-compose-new) (cons "Compose" #'mu4e-compose-new))))))))
+
+(defun zetta-tab-bar-svg--clock ()
+  "Clickable clock: world clock; calendar menu."
+  (let ((txt (zetta-tab-bar-clock)))
+    (when (and txt (> (length (string-trim txt)) 0))
+      (zetta-svg-seg
+       txt 'tb-clock
+       :help "time"
+       :action-help "world clock"
+       :action (if (fboundp 'world-clock) #'world-clock #'display-time-world)
+       :menu (delq nil
+                   (list (and (fboundp 'world-clock) (cons "World clock" #'world-clock))
+                         (cons "Calendar" #'calendar)
+                         (and (fboundp 'org-agenda) (cons "Agenda" #'org-agenda))))))))
+
+(defun zetta-tab-bar-svg--battery ()
+  "Clickable battery cluster (glyph + percent): show status; toggle display."
+  (let* ((icon (ignore-errors (zetta-tab-bar-battery-icon)))
+         (txt  (zetta-tab-bar-battery-text))
+         (label (concat (and icon (concat icon " ")) txt)))
+    (when (and label (> (length (string-trim label)) 0))
+      (zetta-svg-seg
+       label 'tb-battery
+       :help "battery"
+       :action-help "battery status"
+       :action (lambda () (interactive)
+                 (message "%s" (if (boundp 'battery-mode-line-string)
+                                   (string-trim (or battery-mode-line-string "")) "n/a")))
+       :menu (list (cons "Battery status"
+                         (lambda () (interactive)
+                           (message "%s" (if (boundp 'battery-mode-line-string)
+                                             (string-trim (or battery-mode-line-string "")) "n/a"))))
+                   (cons "Toggle battery display" #'display-battery-mode))))))
+
+(defun zetta-tab-bar-svg--workspace ()
+  "Clickable workspace cluster (glyph + name): switch space; space-tree menu."
+  (let* ((icon (ignore-errors (zetta-tab-bar-workspace-icon)))
+         (txt  (zetta-tab-bar-workspace-text))
+         (label (concat (and icon (concat icon " ")) (and (stringp txt) txt))))
+    (when (and label (> (length (string-trim label)) 0))
+      (zetta-svg-seg
+       label 'tb-workspace
+       :help "workspace"
+       :action-help "switch workspace"
+       :action (cond ((fboundp 'space-tree-switch-space-by-name) #'space-tree-switch-space-by-name)
+                     ((fboundp 'space-tree-switch-current-level) #'space-tree-switch-current-level)
+                     (t #'ignore))
+       :menu (delq nil
+                   (list (and (fboundp 'space-tree-switch-space-by-name)
+                              (cons "Switch by name…" #'space-tree-switch-space-by-name))
+                         (and (fboundp 'space-tree-go-left) (cons "Previous space" #'space-tree-go-left))
+                         (and (fboundp 'space-tree-go-right) (cons "Next space" #'space-tree-go-right))
+                         (and (fboundp 'space-tree-create-space-current-level)
+                              (cons "New space (here)" #'space-tree-create-space-current-level))
+                         (and (fboundp 'space-tree-create-space-top-level)
+                              (cons "New space (top)" #'space-tree-create-space-top-level))
+                         (and (fboundp 'space-tree-name-current-space)
+                              (cons "Rename space…" #'space-tree-name-current-space))
+                         (and (fboundp 'space-tree-delete-space)
+                              (cons "Delete space" #'space-tree-delete-space))))))))
 
 ;;; line-utils.el ends here

--- a/modules/ui/header-line-svg.el
+++ b/modules/ui/header-line-svg.el
@@ -43,6 +43,9 @@
   :font (lambda () zetta-svg-line-font)
   :font-size (lambda () zetta-header-line-svg-font-size)
   :line-pad (lambda () zetta-header-line-svg-line-pad)
+  ;; breadcrumb rows are laid out by run (clickable crumb segments), so match
+  ;; the glyph width like the other bars (see `zetta-modeline-svg-char-advance')
+  :char-advance 8
   :foreground (lambda () (or (bound-and-true-p brushup-fg-3)
                              (face-foreground 'default nil t) "#cccccc")))
 

--- a/modules/ui/modeline-svg.el
+++ b/modules/ui/modeline-svg.el
@@ -29,11 +29,14 @@
   "Font size (px) for SVG mode-line text." :type 'integer :group 'zetta)
 (defcustom zetta-modeline-svg-line-pad 4
   "Extra vertical padding (px) per SVG mode-line line." :type 'integer :group 'zetta)
-(defcustom zetta-modeline-svg-char-advance 7
-  "Per-character advance (px) for rows containing a progress pie/bar.
-Match it to the SVG font's real glyph width as Emacs renders it (~7 for the
-bitmap Terminess Nerd Font Mono at 15px).  Glyph icons are plain text and
-need no estimation; only the geometric pie/bar uses this."
+(defcustom zetta-modeline-svg-char-advance 8
+  "Per-character advance (px) for rows laid out by run (pies/bars/segments).
+Match it to the SVG font's real glyph width as librsvg renders it (~8 for the
+bitmap Terminess Nerd Font Mono at 15px scaled).  Used to position progress
+pies/bars and interactive segments (clickable indicators) and to right-align
+their rows; plain all-text rows use exact font anchoring and ignore it.  If a
+clickable indicator's hover box sits too far left (overlapping the previous
+text) raise this; if it sits too far right (a gap before the text) lower it."
   :type 'number :group 'zetta)
 (defcustom zetta-modeline-svg-right-margin 8
   "Pixels of inset kept between right-aligned text and the window edge."
@@ -67,10 +70,10 @@ A barely-there light tint."
            zetta-modeline-svg--modal " " zetta-modeline-svg--ace " "
            zetta-modeline-svg--buffer)
          '(zetta-modeline-svg--mode "  " zetta-modeline-svg--point))
-   ;; line 2:  [git] [branch] vc | [copilot] checkers | flycheck | flags
+   ;; line 2:  git:branch (clickable -> magit) | [copilot] lsp | flycheck | flags
    ;;          ......   doc-position | <progress pie>
-   (cons '(zetta-modeline-svg--vc-icon " " zetta-modeline-svg--branch-icon " "
-           zetta-modeline-svg--vc " "
+   ;; (the git + branch glyphs are folded into the clickable vc segment)
+   (cons '(zetta-modeline-svg--vc " "
            zetta-modeline-svg--copilot-icon " " zetta-modeline-svg--checkers
            zetta-modeline-svg--flycheck " " zetta-modeline-svg--indicators)
          '(zetta-modeline-svg--docpos " " zetta-modeline-svg--file-progress))))

--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -34,6 +34,7 @@
 (declare-function global-evil-fringe-mark-mode "evil-fringe-mark")
 (declare-function bookmark-get-filename "bookmark")
 (declare-function bookmark-get-position "bookmark")
+(declare-function bookmark-jump "bookmark")
 (declare-function flycheck-error-line "flycheck")
 (declare-function flycheck-error-level "flycheck")
 (declare-function flycheck-error-message "flycheck")
@@ -105,9 +106,11 @@
           (let ((bmfile (ignore-errors (bookmark-get-filename bm)))
                 (pos (ignore-errors (bookmark-get-position bm))))
             (when (and bmfile pos (string= (file-truename bmfile) file))
-              (push (list :pos pos :shape 'bookmark :color "#7d5bed"
-                          :help (format "bookmark: %s" (car bm)))
-                    out))))
+              (let ((name (car bm)))
+                (push (list :pos pos :shape 'bookmark :color "#7d5bed"
+                            :help (format "bookmark: %s (click to jump)" name)
+                            :action (lambda () (interactive) (bookmark-jump name)))
+                      out)))))
         out))))
 
 (defun zetta-svg-margin-evil-marks (buffer)

--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -35,6 +35,39 @@
 (declare-function bookmark-get-filename "bookmark")
 (declare-function bookmark-get-position "bookmark")
 (declare-function bookmark-jump "bookmark")
+(declare-function bookmark-rename "bookmark")
+(declare-function bookmark-delete "bookmark")
+(declare-function evil-goto-mark "evil-commands")
+(declare-function evil-delete-marks "evil-commands")
+(declare-function git-gutter:next-hunk "git-gutter")
+(declare-function git-gutter:previous-hunk "git-gutter")
+(declare-function git-gutter:stage-hunk "git-gutter")
+(declare-function git-gutter:revert-hunk "git-gutter")
+(declare-function git-gutter:popup-hunk "git-gutter")
+(declare-function flycheck-next-error "flycheck")
+(declare-function flycheck-previous-error "flycheck")
+(declare-function flycheck-list-errors "flycheck")
+(declare-function flycheck-explain-error-at-point "flycheck")
+(declare-function flycheck-display-error-at-point "flycheck")
+(declare-function org-cycle "org")
+(declare-function org-narrow-to-subtree "org")
+
+(defun zetta-svg-margin--goto-line (n)
+  "Move point to the start of line N (absolute) in the current buffer."
+  (goto-char (point-min))
+  (forward-line (1- n)))
+
+(defun zetta-svg-margin--gg-action (line cmd)
+  "Return a command that moves to LINE then runs git-gutter CMD on that hunk."
+  (lambda () (interactive) (zetta-svg-margin--goto-line line) (call-interactively cmd)))
+
+(defun zetta-svg-margin--gg-menu (line)
+  "Return a context-menu alist for the git-gutter hunk at LINE."
+  (list (cons "Show hunk diff" (zetta-svg-margin--gg-action line #'git-gutter:popup-hunk))
+        (cons "Stage hunk"     (zetta-svg-margin--gg-action line #'git-gutter:stage-hunk))
+        (cons "Revert hunk"    (zetta-svg-margin--gg-action line #'git-gutter:revert-hunk))
+        (cons "Next hunk"      #'git-gutter:next-hunk)
+        (cons "Previous hunk"  #'git-gutter:previous-hunk)))
 (declare-function flycheck-error-line "flycheck")
 (declare-function flycheck-error-level "flycheck")
 (declare-function flycheck-error-message "flycheck")
@@ -69,11 +102,18 @@
       (save-excursion
         (goto-char (point-min))
         (while (re-search-forward "\\_<\\(TODO\\|FIXME\\|HACK\\)\\_>" nil t)
-          (push (list :pos (match-beginning 0) :shape 'dot
-                      :color (pcase (match-string 1)
-                               ("TODO" "#d29922") ("FIXME" "#f85149") (_ "#a371f7"))
-                      :help (match-string 1))
-                out)))
+          (let ((p (match-beginning 0)) (kw (match-string 1)))
+            (push (list :pos p :shape 'dot
+                        :color (pcase kw
+                                 ("TODO" "#d29922") ("FIXME" "#f85149") (_ "#a371f7"))
+                        :help kw
+                        :action (lambda () (interactive) (goto-char p))
+                        :menu (list (cons "Go to keyword"
+                                          (lambda () (interactive) (goto-char p)))
+                                    (cons "List TODO/FIXME/HACK"
+                                          (lambda () (interactive)
+                                            (occur "\\_<\\(TODO\\|FIXME\\|HACK\\)\\_>")))))
+                  out))))
       out)))
 
 (defun zetta-svg-margin-git-gutter (buffer)
@@ -88,13 +128,20 @@
             (pcase type
               ((or 'added 'modified)
                (cl-loop for ln from start to (min end (+ start 1000)) do
-                        (push (list :line ln :shape 'bar
-                                    :color (if (eq type 'added) "#3fb950" "#d29922")
-                                    :help (symbol-name type))
-                              out)))
+                        (let ((l ln) (ty type))
+                          (push (list :line l :shape 'bar
+                                      :color (if (eq ty 'added) "#3fb950" "#d29922")
+                                      :help (format "git: %s hunk" ty)
+                                      :action (zetta-svg-margin--gg-action l #'git-gutter:popup-hunk)
+                                      :menu (zetta-svg-margin--gg-menu l))
+                                out))))
               ('deleted
-               (push (list :line start :shape 'triangle :color "#f85149" :help "deleted")
-                     out)))))
+               (let ((l start))
+                 (push (list :line l :shape 'triangle :color "#f85149"
+                             :help "git: deleted hunk"
+                             :action (zetta-svg-margin--gg-action l #'git-gutter:popup-hunk)
+                             :menu (zetta-svg-margin--gg-menu l))
+                       out))))))
         out))))
 
 (defun zetta-svg-margin-bookmarks (buffer)
@@ -108,8 +155,14 @@
             (when (and bmfile pos (string= (file-truename bmfile) file))
               (let ((name (car bm)))
                 (push (list :pos pos :shape 'bookmark :color "#7d5bed"
-                            :help (format "bookmark: %s (click to jump)" name)
-                            :action (lambda () (interactive) (bookmark-jump name)))
+                            :help (format "bookmark: %s" name)
+                            :action (lambda () (interactive) (bookmark-jump name))
+                            :menu (list (cons "Jump to bookmark"
+                                              (lambda () (interactive) (bookmark-jump name)))
+                                        (cons "Rename bookmark…"
+                                              (lambda () (interactive) (bookmark-rename name)))
+                                        (cons "Delete bookmark"
+                                              (lambda () (interactive) (bookmark-delete name)))))
                       out)))))
         out))))
 
@@ -123,7 +176,14 @@
             (when (and (markerp val) (eq (marker-buffer val) buffer)
                        (>= char ?a) (<= char ?z))
               (push (list :pos (marker-position val) :text (char-to-string char)
-                          :face 'warning :help (format "evil mark `%c'" char))
+                          :face 'warning
+                          :help (format "evil mark `%c'" char)
+                          :action (lambda () (interactive) (evil-goto-mark char))
+                          :menu (list (cons (format "Jump to mark `%c'" char)
+                                            (lambda () (interactive) (evil-goto-mark char)))
+                                      (cons (format "Delete mark `%c'" char)
+                                            (lambda () (interactive)
+                                              (evil-delete-marks (char-to-string char))))))
                     out))))
         out))))
 
@@ -136,11 +196,26 @@
           (let ((line (flycheck-error-line err))
                 (level (flycheck-error-level err)))
             (when line
-              (push (list :line line :shape 'dot
-                          :color (pcase level
-                                   ('error "#f85149") ('warning "#d29922") (_ "#3fb950"))
-                          :help (ignore-errors (flycheck-error-message err)))
-                    out))))
+              (let ((l line))
+                (push (list :line l :shape 'dot
+                            :color (pcase level
+                                     ('error "#f85149") ('warning "#d29922") (_ "#3fb950"))
+                            :help (ignore-errors (flycheck-error-message err))
+                            :action (lambda () (interactive)
+                                      (zetta-svg-margin--goto-line l)
+                                      (flycheck-display-error-at-point))
+                            :menu (list (cons "Show error"
+                                              (lambda () (interactive)
+                                                (zetta-svg-margin--goto-line l)
+                                                (flycheck-display-error-at-point)))
+                                        (cons "Explain error"
+                                              (lambda () (interactive)
+                                                (zetta-svg-margin--goto-line l)
+                                                (flycheck-explain-error-at-point)))
+                                        (cons "List all errors" #'flycheck-list-errors)
+                                        (cons "Next error" #'flycheck-next-error)
+                                        (cons "Previous error" #'flycheck-previous-error)))
+                      out)))))
         out))))
 
 (defun zetta-svg-margin-long-lines (buffer)
@@ -153,9 +228,11 @@
           (while (not (eobp))
             (end-of-line)
             (when (> (current-column) col)
-              (push (list :pos (line-beginning-position) :shape 'bar :color "#b08800"
-                          :help (format "line exceeds %d columns" col))
-                    out))
+              (let ((bol (line-beginning-position)))
+                (push (list :pos bol :shape 'bar :color "#b08800"
+                            :help (format "line exceeds %d columns" col)
+                            :action (lambda () (interactive) (goto-char bol) (end-of-line)))
+                      out)))
             (forward-line 1)))
         out))))
 
@@ -166,9 +243,18 @@
       (save-excursion
         (goto-char (point-min))
         (while (re-search-forward "[ \t]+$" nil t)
-          (push (list :pos (line-beginning-position) :shape 'dot :color "#8b949e"
-                      :help "trailing whitespace")
-                out)
+          (let ((bol (line-beginning-position)))
+            (push (list :pos bol :shape 'dot :color "#8b949e"
+                        :help "trailing whitespace"
+                        :action (lambda () (interactive) (goto-char bol) (end-of-line))
+                        :menu (list (cons "Clear on this line"
+                                          (lambda () (interactive)
+                                            (goto-char bol)
+                                            (when (re-search-forward "[ \t]+$" (line-end-position) t)
+                                              (replace-match ""))))
+                                    (cons "Clear in whole buffer"
+                                          #'delete-trailing-whitespace)))
+                  out))
           (forward-line 1)))
       out)))
 
@@ -182,9 +268,18 @@
           (while (re-search-forward "^\\(\\*+\\) " nil t)
             (let* ((level (length (match-string 1)))
                    (face (intern (format "org-level-%d" (1+ (mod (1- level) 8)))))
-                   (color (or (face-foreground face nil 'default) "#888888")))
-              (push (list :pos (line-beginning-position) :color color
+                   (color (or (face-foreground face nil 'default) "#888888"))
+                   (p (line-beginning-position)))
+              (push (list :pos p :color color
                           :help (format "heading level %d" level)
+                          :action (lambda () (interactive) (goto-char p))
+                          :menu (list (cons "Go to heading"
+                                            (lambda () (interactive) (goto-char p)))
+                                      (cons "Toggle fold"
+                                            (lambda () (interactive) (goto-char p) (org-cycle)))
+                                      (cons "Narrow to subtree"
+                                            (lambda () (interactive)
+                                              (goto-char p) (org-narrow-to-subtree))))
                           :draw (lambda (svg x y w h c)
                                   (let* ((frac (/ (max 1 (- 7 level)) 6.0))
                                          (bh (max 3 (round (* h frac))))
@@ -213,9 +308,16 @@
               (let ((bol (line-beginning-position)))
                 (unless (gethash bol seen)
                   (puthash bol t seen)
-                  (push (list :pos bol :shape 'dot :color "#58a6ff"
-                              :help (format "occurrence of `%s'" sym))
-                        out)))))
+                  (let ((p bol) (s sym))
+                    (push (list :pos p :shape 'dot :color "#58a6ff"
+                                :help (format "occurrence of `%s'" s)
+                                :action (lambda () (interactive) (goto-char p))
+                                :menu (list (cons "Go to occurrence"
+                                                  (lambda () (interactive) (goto-char p)))
+                                            (cons (format "Occur `%s'" s)
+                                                  (lambda () (interactive)
+                                                    (occur (concat "\\_<" (regexp-quote s) "\\_>"))))))
+                          out))))))
           out)))))
 
 ;;;; Refresh triggers

--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -107,6 +107,7 @@
                         :color (pcase kw
                                  ("TODO" "#d29922") ("FIXME" "#f85149") (_ "#a371f7"))
                         :help kw
+                        :action-help "go to keyword"
                         :action (lambda () (interactive) (goto-char p))
                         :menu (list (cons "Go to keyword"
                                           (lambda () (interactive) (goto-char p)))
@@ -132,6 +133,7 @@
                           (push (list :line l :shape 'bar
                                       :color (if (eq ty 'added) "#3fb950" "#d29922")
                                       :help (format "git: %s hunk" ty)
+                                      :action-help "show hunk diff"
                                       :action (zetta-svg-margin--gg-action l #'git-gutter:popup-hunk)
                                       :menu (zetta-svg-margin--gg-menu l))
                                 out))))
@@ -139,6 +141,7 @@
                (let ((l start))
                  (push (list :line l :shape 'triangle :color "#f85149"
                              :help "git: deleted hunk"
+                             :action-help "show hunk diff"
                              :action (zetta-svg-margin--gg-action l #'git-gutter:popup-hunk)
                              :menu (zetta-svg-margin--gg-menu l))
                        out))))))
@@ -156,6 +159,7 @@
               (let ((name (car bm)))
                 (push (list :pos pos :shape 'bookmark :color "#7d5bed"
                             :help (format "bookmark: %s" name)
+                            :action-help "jump to bookmark"
                             :action (lambda () (interactive) (bookmark-jump name))
                             :menu (list (cons "Jump to bookmark"
                                               (lambda () (interactive) (bookmark-jump name)))
@@ -178,6 +182,7 @@
               (push (list :pos (marker-position val) :text (char-to-string char)
                           :face 'warning
                           :help (format "evil mark `%c'" char)
+                          :action-help (format "jump to mark `%c'" char)
                           :action (lambda () (interactive) (evil-goto-mark char))
                           :menu (list (cons (format "Jump to mark `%c'" char)
                                             (lambda () (interactive) (evil-goto-mark char)))
@@ -201,6 +206,7 @@
                             :color (pcase level
                                      ('error "#f85149") ('warning "#d29922") (_ "#3fb950"))
                             :help (ignore-errors (flycheck-error-message err))
+                            :action-help "show error"
                             :action (lambda () (interactive)
                                       (zetta-svg-margin--goto-line l)
                                       (flycheck-display-error-at-point))
@@ -231,6 +237,7 @@
               (let ((bol (line-beginning-position)))
                 (push (list :pos bol :shape 'bar :color "#b08800"
                             :help (format "line exceeds %d columns" col)
+                            :action-help "go to overflow"
                             :action (lambda () (interactive) (goto-char bol) (end-of-line)))
                       out)))
             (forward-line 1)))
@@ -246,6 +253,7 @@
           (let ((bol (line-beginning-position)))
             (push (list :pos bol :shape 'dot :color "#8b949e"
                         :help "trailing whitespace"
+                        :action-help "go to line"
                         :action (lambda () (interactive) (goto-char bol) (end-of-line))
                         :menu (list (cons "Clear on this line"
                                           (lambda () (interactive)
@@ -272,6 +280,7 @@
                    (p (line-beginning-position)))
               (push (list :pos p :color color
                           :help (format "heading level %d" level)
+                          :action-help "go to heading"
                           :action (lambda () (interactive) (goto-char p))
                           :menu (list (cons "Go to heading"
                                             (lambda () (interactive) (goto-char p)))
@@ -311,6 +320,7 @@
                   (let ((p bol) (s sym))
                     (push (list :pos p :shape 'dot :color "#58a6ff"
                                 :help (format "occurrence of `%s'" s)
+                                :action-help "go to occurrence"
                                 :action (lambda () (interactive) (goto-char p))
                                 :menu (list (cons "Go to occurrence"
                                                   (lambda () (interactive) (goto-char p)))

--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -409,8 +409,11 @@ the recompute yields the same hunks we skip, breaking the cycle."
   "The `show-help-function' in effect before svg-margin wrapped it.")
 
 (defun zetta-svg-margin--show-help (help)
-  "Track the hovered indicator (`svg-margin--note-help'), then show HELP as before."
+  "Track hover for svg-margin and svg-line, then show HELP as before.
+Both note-help functions key off their own text property and hover custom, so
+calling both is safe; this is the single `show-help-function' both hook into."
   (svg-margin--note-help help)
+  (when (fboundp 'svg-line--note-help) (svg-line--note-help help))
   (when (functionp zetta-svg-margin--orig-show-help)
     (funcall zetta-svg-margin--orig-show-help help)))
 

--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -82,6 +82,7 @@
     (let* ((bw (max 4 (round (* w 0.52))))
            (bx (+ x (/ (- w bw) 2)))
            (top (+ y (round (* h 0.16))))
+
            (bot (+ y (round (* h 0.84))))
            (notch (+ y (round (* h 0.6)))))
       (svg-polygon svg
@@ -143,6 +144,7 @@
                              :help "git: deleted hunk"
                              :action-help "show hunk diff"
                              :action (zetta-svg-margin--gg-action l #'git-gutter:popup-hunk)
+
                              :menu (zetta-svg-margin--gg-menu l))
                        out))))))
         out))))
@@ -311,6 +313,7 @@
               (seen (make-hash-table :test 'eql)) out)
           (save-excursion
             (goto-char (point-min))
+
             (while (re-search-forward re nil t)
               ;; one indicator per LINE, not per occurrence -- several matches
               ;; on the same line must not each claim a column.
@@ -402,6 +405,15 @@ the recompute yields the same hunks we skip, breaking the cycle."
 ;; Runs after init, when the packages svg-margin replaces are loaded: turn
 ;; off their fringe drawing, then enable the gutter everywhere.
 
+(defvar zetta-svg-margin--orig-show-help nil
+  "The `show-help-function' in effect before svg-margin wrapped it.")
+
+(defun zetta-svg-margin--show-help (help)
+  "Track the hovered indicator (`svg-margin--note-help'), then show HELP as before."
+  (svg-margin--note-help help)
+  (when (functionp zetta-svg-margin--orig-show-help)
+    (funcall zetta-svg-margin--orig-show-help help)))
+
 (defun zetta-svg-margin-activate ()
   "Disable the fringe drawers svg-margin replaces and enable the gutter."
   ;; evil marks now come from the margin provider, not the fringe.
@@ -411,6 +423,14 @@ the recompute yields the same hunks we skip, breaking the cycle."
   (when (and (fboundp 'git-gutter:view-diff-infos)
              (not (advice-member-p #'zetta-svg-margin--gg-feed 'git-gutter:view-diff-infos)))
     (advice-add 'git-gutter:view-diff-infos :override #'zetta-svg-margin--gg-feed))
+  ;; Hover background: route help display through `svg-margin--note-help' so the
+  ;; hovered indicator gets a drawn background (works because show-help-function
+  ;; fires on mouse enter, move AND leave).  Done here (after init) so it sits
+  ;; on top of whatever tooltip.el left in `show-help-function'.
+  (setq svg-margin-hover-highlight t)
+  (unless (eq show-help-function #'zetta-svg-margin--show-help)
+    (setq zetta-svg-margin--orig-show-help show-help-function
+          show-help-function #'zetta-svg-margin--show-help))
   (global-svg-margin-mode 1)
   (svg-margin-refresh-all))
 

--- a/modules/ui/tab-bar-svg.el
+++ b/modules/ui/tab-bar-svg.el
@@ -24,10 +24,11 @@
   "Extra vertical padding (px) added to each SVG tab-bar line."
   :type 'integer :group 'zetta)
 
-(defcustom zetta-tab-bar-svg-char-advance 7.5
-  "Per-character advance (px) used to lay out rows containing inline icons.
-Match it to the monospace SVG font's glyph width (Terminus at 15px = 7.5)
-so iconned rows stay as tight as the plain-text rows."
+(defcustom zetta-tab-bar-svg-char-advance 8
+  "Per-character advance (px) used to lay out rows containing pies/bars/segments.
+Match it to the monospace SVG font's glyph width as librsvg renders it (~8 for
+Terminess at 15px scaled) so a clickable indicator's hover box lands snugly on
+its text.  Plain all-text rows use exact font anchoring and ignore this."
   :type 'number :group 'zetta)
 
 (defcustom zetta-tab-bar-svg-image-cache-eviction-delay 30
@@ -62,9 +63,9 @@ Icons are nerd-font glyphs (plain text in `zetta-svg-line-font'), so every
 side is one font-accurate text run -- no char-advance estimation, nothing
 jitters as keycast changes width."
   (list
-   ;; line 1 -- file-type glyph + buffer name
+   ;; line 1 -- file-type glyph + buffer name (buffer name is clickable)
    (cons '(zetta-tab-bar-file-icon " "
-                                   zetta-buffer-name
+                                   zetta-tab-bar-svg--buffer
                                    zmc-modeline-indicator
                                    zetta-pyvenv-activate-poetry-modeline)
          ;; TEMP right-aligned probe (remove for an empty right side)
@@ -74,24 +75,19 @@ jitters as keycast changes width."
            " "
            recursion-indicator--string
            ))
-   ;; line 2
-   (cons '(zetta-tab-bar-spotify-icon " " zetta-tab-bar-spot-mode-line-string)
-         '(
-           ;; mu4e / clock / battery, each with its glyph (was bundled in
-           ;; tab-bar-format-global; rendered explicitly so a mail glyph
-           ;; sits by the unread count and a battery glyph by the level)
-           zetta-tab-bar-mu4e-icon " " zetta-tab-bar-mu4e-text
-           ))
-   ;; line 3
-   (cons '(zetta-tab-bar-modal
+   ;; line 2 -- Spotify (clickable) left; mail (clickable) right
+   (cons '(zetta-tab-bar-svg--spotify)
+         '(zetta-tab-bar-svg--mu4e))
+   ;; line 3 -- modal (clickable) left; clock/battery/workspace (clickable) right
+   (cons '(zetta-tab-bar-svg--modal
            zetta-gptel-processes
            blinker-tab-bar)
          '(
            zetta-tab-bar-current-thing
-           zetta-tab-bar-clock " "
-           zetta-tab-bar-battery-icon " " zetta-tab-bar-battery-text " "
+           zetta-tab-bar-svg--clock " "
+           zetta-tab-bar-svg--battery " "
            zetta-current-prefix " "
-           zetta-tab-bar-workspace-icon " " zetta-tab-bar-workspace-text))))
+           zetta-tab-bar-svg--workspace))))
 
 (svg-line-define 'zetta-tab-bar
                  :target 'tab-bar
@@ -116,24 +112,28 @@ jitters as keycast changes width."
 (defun new-line () "\n")
 (defun zetta-insert-space () " ")
 
-(setq tab-bar-format
-      '(
-        ;; line 1
-        zetta-buffer-name zmc-modeline-indicator
-        zetta-pyvenv-activate-poetry-modeline
-        ;; line 2
-        new-line zetta-tab-bar-spot-mode-line-string
-        ;; line 3 left-aligned
-        new-line zetta-tab-bar-modal zetta-gptel-processes
-        blinker-tab-bar
-        ;; line 3 right-aligned
-        tab-bar-format-align-right tab-bar-keycast zetta-insert-space
-        zetta-tab-bar-current-thing zetta-tab-bar-recursion-level
-        recursion-indicator--string tab-bar-format-global
-        internal-echo-keystrokes-prefix
-        zetta-insert-space zetta-current-prefix zetta-insert-space
-        space-tree-modeline-lighter
-        ))
+;; Guard so RE-loading this file (with the SVG renderer already active)
+;; doesn't clobber the live `tab-bar-format' the renderer is installed on --
+;; svg-line saved this built-in value at activation and restores it itself.
+(unless (and (fboundp 'svg-line-active-p) (svg-line-active-p 'zetta-tab-bar))
+  (setq tab-bar-format
+        '(
+          ;; line 1
+          zetta-buffer-name zmc-modeline-indicator
+          zetta-pyvenv-activate-poetry-modeline
+          ;; line 2
+          new-line zetta-tab-bar-spot-mode-line-string
+          ;; line 3 left-aligned
+          new-line zetta-tab-bar-modal zetta-gptel-processes
+          blinker-tab-bar
+          ;; line 3 right-aligned
+          tab-bar-format-align-right tab-bar-keycast zetta-insert-space
+          zetta-tab-bar-current-thing zetta-tab-bar-recursion-level
+          recursion-indicator--string tab-bar-format-global
+          internal-echo-keystrokes-prefix
+          zetta-insert-space zetta-current-prefix zetta-insert-space
+          space-tree-modeline-lighter
+          )))
 
 (add-to-list 'brushup-styles
              '(set-face-attribute 'tab-bar nil :box nil :inherit nil :background brushup-bg)
@@ -159,6 +159,7 @@ jitters as keycast changes width."
       (setq zetta-tab-bar--saved-eviction-delay image-cache-eviction-delay
             image-cache-eviction-delay zetta-tab-bar-svg-image-cache-eviction-delay)))
   (svg-line-activate 'zetta-tab-bar)
+  (zetta-tab-bar--hover-start)
   (message "tab-bar: SVG renderer active (M-x zetta-tab-bar-use-builtin to revert)"))
 
 ;;;###autoload
@@ -166,6 +167,7 @@ jitters as keycast changes width."
   "Restore the built-in (text) tab-bar format and the image-cache window."
   (interactive)
   (svg-line-deactivate 'zetta-tab-bar)
+  (zetta-tab-bar--hover-stop)
   (when zetta-tab-bar--saved-eviction-delay
     (setq image-cache-eviction-delay zetta-tab-bar--saved-eviction-delay
           zetta-tab-bar--saved-eviction-delay nil))
@@ -178,6 +180,97 @@ jitters as keycast changes width."
   (if (zetta-tab-bar-using-svg-p)
       (zetta-tab-bar-use-builtin)
     (zetta-tab-bar-use-svg)))
+
+;;; ------------------------------------------------------------------
+;;; Clickable SVG tab-bar indicators.
+;;; The tab bar (unlike the mode/header/tab line) ignores a string's
+;;; `keymap'/`help-echo' text properties: it routes mouse events through
+;;; `tab-bar-map' -> `tab-bar-mouse-*', which read a `menu-item' property
+;;; and select tabs.  So we advise those commands to first hit-test our
+;;; segment placements (via the svg-line engine) and dispatch the
+;;; indicator's :action (left click) or :menu (right click); off our
+;;; indicators they fall through to the default tab-bar behaviour.
+;;; ------------------------------------------------------------------
+(declare-function svg-line--seg-at-posn "svg-line")
+(declare-function svg-line--popup-menu "svg-line")
+
+(defun zetta-tab-bar--svg-item-at (event)
+  "Return the svg-line tab-bar item (LABEL . PLIST) under EVENT, or nil."
+  (and (fboundp 'svg-line--seg-at-posn)
+       (svg-line-active-p 'zetta-tab-bar)
+       (let ((it (svg-line--seg-at-posn 'zetta-tab-bar (event-start event))))
+         (and (consp it) (consp (cdr it)) it))))
+
+(defun zetta-tab-bar--mouse-down-1-advice (orig event &rest args)
+  "Run an svg-line indicator's :action on click, else the default tab-bar action."
+  (let* ((it (zetta-tab-bar--svg-item-at event))
+         (cmd (and it (plist-get (cdr it) :action))))
+    (if cmd (call-interactively cmd)
+      (apply orig event args))))
+
+(defun zetta-tab-bar--context-menu-advice (orig event &rest args)
+  "Pop an svg-line indicator's :menu on right-click, else the default context menu."
+  (let* ((it (zetta-tab-bar--svg-item-at event))
+         (menu (and it (plist-get (cdr it) :menu))))
+    (if menu (svg-line--popup-menu (car it) menu)
+      (apply orig event args))))
+
+(with-eval-after-load 'tab-bar
+  (advice-add 'tab-bar-mouse-down-1 :around #'zetta-tab-bar--mouse-down-1-advice)
+  (advice-add 'tab-bar-mouse-context-menu :around #'zetta-tab-bar--context-menu-advice))
+
+;;; ------------------------------------------------------------------
+;;; Hover for the SVG tab-bar.
+;;; The mode/header/tab line re-evaluate a string's `help-echo' FUNCTION
+;;; as the mouse moves over their image, which both shows the echo help
+;;; and drives the hover box (via `svg-line--note-help').  The tab bar
+;;; does NOT -- it treats the whole image as one item and never calls our
+;;; help-echo per position.  So we poll the mouse with a short timer while
+;;; the SVG tab bar is active: when the pointer is over one of our
+;;; indicators, feed its (tagged) help through `show-help-function' -- the
+;;; same path the other bars use -- which shows the echo help AND sets the
+;;; hovered id so the box is drawn.
+;;; ------------------------------------------------------------------
+(defvar zetta-tab-bar--hover-timer nil
+  "Repeating timer that drives SVG tab-bar hover; nil when not running.")
+(defvar zetta-tab-bar--hover-was-over nil
+  "Non-nil if the last poll found the pointer over an SVG tab-bar indicator.")
+
+(defun zetta-tab-bar--hover-poll ()
+  "Drive hover help/highlight for the SVG tab bar from the mouse position."
+  (when (and (bound-and-true-p svg-line-hover-highlight)
+             (fboundp 'svg-line--seg-at-posn)
+             (svg-line-active-p 'zetta-tab-bar)
+             (functionp show-help-function))
+    (let* ((mp (mouse-pixel-position))
+           (frame (car mp)) (mx (cadr mp)) (my (cddr mp))
+           (posn (and (framep frame) (integerp mx) (integerp my)
+                      (ignore-errors (posn-at-x-y mx my frame))))
+           (over (and posn (eq (posn-area posn) 'tab-bar)))
+           (item (and over (svg-line--seg-at-posn 'zetta-tab-bar posn)))
+           (help (and item (fboundp 'svg-line--tab-help) (svg-line--tab-help item))))
+      ;; Only touch the help machinery while over the tab bar, or on the one
+      ;; poll right after leaving it (to clear) -- so we never fight the other
+      ;; bars' own help-echo for the shared hovered state.
+      (cond
+       (over
+        (ignore-errors (funcall show-help-function help))
+        (setq zetta-tab-bar--hover-was-over t))
+       (zetta-tab-bar--hover-was-over
+        (ignore-errors (funcall show-help-function nil))
+        (setq zetta-tab-bar--hover-was-over nil))))))
+
+(defun zetta-tab-bar--hover-start ()
+  "Start the SVG tab-bar hover poll timer (idempotent)."
+  (unless (timerp zetta-tab-bar--hover-timer)
+    (setq zetta-tab-bar--hover-timer
+          (run-with-timer 0.12 0.12 #'zetta-tab-bar--hover-poll))))
+
+(defun zetta-tab-bar--hover-stop ()
+  "Stop the SVG tab-bar hover poll timer."
+  (when (timerp zetta-tab-bar--hover-timer)
+    (cancel-timer zetta-tab-bar--hover-timer))
+  (setq zetta-tab-bar--hover-timer nil zetta-tab-bar--hover-was-over nil))
 
 ;;; ------------------------------------------------------------------
 ;;; Startup default (opt-out).  Runs from `emacs-startup-hook' so it

--- a/modules/ui/tab-line-svg.el
+++ b/modules/ui/tab-line-svg.el
@@ -407,12 +407,37 @@ Because the glyph is part of the label text it needs no separate icon."
              for short = (if (> (length name) zetta-tab-line-svg-max-name)
                              (concat (substring name 0 (1- zetta-tab-line-svg-max-name)) "…")
                            name)
-             collect (cons (format "%d %s%s%s"
-                                   i
-                                   (if glyph (concat glyph " ") "")
-                                   short
-                                   (if modifiedp zetta-tab-line-svg-modified-marker ""))
-                           (list :current currentp :modified modifiedp)))))
+             ;; capture the buffer in a fresh binding -- cl-loop reuses one
+             ;; binding for `real', so action/menu closures must not close over
+             ;; it directly (they would all see the last tab's buffer).
+             collect (let ((b real) (nm name))
+                       (cons (format "%d %s%s%s"
+                                     i
+                                     (if glyph (concat glyph " ") "")
+                                     short
+                                     (if modifiedp zetta-tab-line-svg-modified-marker ""))
+                             (list :current currentp :modified modifiedp
+                                   :id b
+                                   :help (format "buffer: %s" nm)
+                                   :action-help "switch to this buffer"
+                                   :action (lambda () (interactive)
+                                             (when (buffer-live-p b) (switch-to-buffer b)))
+                                   :menu
+                                   (delq nil
+                                         (list (cons "Switch to buffer"
+                                                     (lambda () (interactive)
+                                                       (when (buffer-live-p b) (switch-to-buffer b))))
+                                               (and (buffer-file-name b)
+                                                    (cons "Save buffer"
+                                                          (lambda () (interactive)
+                                                            (when (buffer-live-p b)
+                                                              (with-current-buffer b (save-buffer))))))
+                                               (cons "Kill buffer"
+                                                     (lambda () (interactive)
+                                                       (when (buffer-live-p b) (kill-buffer b))))
+                                               (cons "Copy buffer name"
+                                                     (lambda () (interactive)
+                                                       (kill-new (buffer-name b))))))))))))
 
 (svg-line-define 'zetta-tab-line
   :target 'tab-line
@@ -454,6 +479,7 @@ Because the glyph is part of the label text it needs no separate icon."
 (defun zetta-tab-line-use-svg ()
   "Switch the tab line to the wrapping SVG renderer."
   (interactive)
+  (setq svg-line-hover-highlight t)   ; highlight the tab under the mouse
   (svg-line-activate 'zetta-tab-line)
   (message "tab-line: wrapping SVG renderer active (M-x zetta-tab-line-use-default to revert)"))
 

--- a/modules/ui/tooltip.el
+++ b/modules/ui/tooltip.el
@@ -1,0 +1,24 @@
+;;; tooltip.el --- Show help-echo in the echo area, not a tooltip frame -*- lexical-binding: t; -*-
+
+;; Display `help-echo' (hover help) in the echo area instead of a pop-up
+;; tooltip.  Why:
+;;
+;; - Emacs's own tooltips (`use-system-tooltips' nil) honour `tooltip-delay'
+;;   and are fast, but each is a separate top-level FRAME -- which a tiling
+;;   window manager (aerospace) treats as a window and tiles, snapping the
+;;   Emacs frame to half the screen.
+;; - macOS native tooltips (`use-system-tooltips' t) don't get tiled, but
+;;   their delay is system-controlled (~1s) and ignores `tooltip-delay', so
+;;   they feel sluggish.
+;;
+;; Echo-area help sidesteps both: no frame (nothing for the WM to tile) and
+;; it appears instantly -- a stronger "this is interactive" cue.  The
+;; svg-margin gutter shows its hover help with a contrasting background
+;; (`svg-margin-help-face'), which stands out well in the echo area.
+;;
+;; This is global: ALL help-echo now shows in the echo area rather than a
+;; tooltip.  To restore pop-up tooltips, (tooltip-mode 1).
+
+(tooltip-mode -1)
+
+;;; tooltip.el ends here

--- a/source/zettapkg/svg-line/svg-line.el
+++ b/source/zettapkg/svg-line/svg-line.el
@@ -727,18 +727,27 @@ ITEMS is an alist of (LABEL . COMMAND); TITLE labels the menu."
     (when choice
       (if (commandp choice) (call-interactively choice) (funcall choice)))))
 
+(defvar svg-line--hover-timer nil
+  "Idle timer that applies a hover re-render off the redisplay path.")
+
 ;;;###autoload
 (defun svg-line--note-help (help)
   "Update the hovered wrap item from HELP and re-render if it changed.
 Wire `show-help-function' to call this (then display HELP): it fires on mouse
 enter, move AND leave (leave with nil), so the hovered item's `:id' -- carried
-in HELP's `svg-line-tab' text property -- can be tracked and a hover box drawn."
+in HELP's `svg-line-tab' text property -- can be tracked and a hover box drawn.
+The re-render is DEFERRED to an idle timer: this runs during the help-echo
+display (itself during redisplay), and forcing a redisplay synchronously here
+would re-enter the renderer and degrade the other lines (the safety guard
+returns a stale value)."
   (when svg-line-hover-highlight
     (let ((id (and (stringp help) (> (length help) 0)
                    (get-text-property 0 'svg-line-tab help))))
       (unless (equal id svg-line--hovered)
         (setq svg-line--hovered id)
-        (force-mode-line-update t)))))
+        (when (timerp svg-line--hover-timer) (cancel-timer svg-line--hover-timer))
+        (setq svg-line--hover-timer
+              (run-with-idle-timer 0 nil (lambda () (force-mode-line-update t))))))))
 
 (defun svg-line--wrap-params (spec)
   "Resolve the wrap layout params from SPEC (matching `svg-line--build-wrap')."

--- a/source/zettapkg/svg-line/svg-line.el
+++ b/source/zettapkg/svg-line/svg-line.el
@@ -749,27 +749,44 @@ in HELP's `svg-line-tab' text property -- can be tracked and a hover box drawn."
           :lh (+ (svg-line--scaled (svg-line--opt spec :font-size svg-line-font-size))
                  (svg-line--scaled (svg-line--opt spec :line-pad svg-line-line-pad))))))
 
+(defun svg-line--wrap-tab-at-xy (name win x y)
+  "Return the wrap item of line NAME at image pixel (X, Y) in WIN, or nil.
+Recomputes the layout in WIN (so it matches that window's render) and
+hit-tests (X, Y) against the placements."
+  (when (and (windowp win) (numberp x) (numberp y))
+    (with-selected-window win
+      (let* ((spec (svg-line--spec name))
+             (p (svg-line--wrap-params spec))
+             (items (ignore-errors (funcall (plist-get spec :content))))
+             (lh (plist-get p :lh)))
+        (when items
+          ;; NB: use `tab', not `it' -- in cl-loop `when ... return it' the
+          ;; symbol `it' is anaphoric (the `when' value), not our variable.
+          (cl-loop for (px top cw tab) in
+                   (svg-line--wrap-place items (plist-get p :width)
+                                         (plist-get p :char-advance) (plist-get p :gap) lh)
+                   when (and (<= px x) (< x (+ px cw)) (<= top y) (< y (+ top lh)))
+                   return tab))))))
+
 (defun svg-line--wrap-tab-at (name posn)
-  "Return the wrap item of line NAME under POSN, or nil.
-Recomputes the layout in POSN's window (so it matches that window's render)
-and hit-tests the click's pixel position against the placements."
-  (let ((win (posn-window posn)))
-    (when (windowp win)
-      (with-selected-window win
-        (let* ((spec (svg-line--spec name))
-               (p (svg-line--wrap-params spec))
-               (items (ignore-errors (funcall (plist-get spec :content))))
-               (lh (plist-get p :lh))
-               (xy (posn-object-x-y posn))
-               (cx (and xy (car xy))) (cy (and xy (cdr xy))))
-          (when (and cx cy items)
-            ;; NB: use `tab', not `it' -- in cl-loop `when ... return it' the
-            ;; symbol `it' is anaphoric (the `when' value), not our variable.
-            (cl-loop for (px top cw tab) in
-                     (svg-line--wrap-place items (plist-get p :width)
-                                           (plist-get p :char-advance) (plist-get p :gap) lh)
-                     when (and (<= px cx) (< cx (+ px cw)) (<= top cy) (< cy (+ top lh)))
-                     return tab)))))))
+  "Return the wrap item of line NAME under POSN (a click), or nil."
+  (let ((xy (posn-object-x-y posn)))
+    (svg-line--wrap-tab-at-xy name (posn-window posn) (car-safe xy) (cdr-safe xy))))
+
+(defun svg-line--wrap-help-fn (name)
+  "Return a `help-echo' FUNCTION for wrap line NAME.
+A special area (e.g. the tab line) does not fire image map *area* help-echo,
+but it does call a STRING-level help-echo function on mouse move -- so we use
+the mouse pixel position to find the item under the pointer and return its
+help (which is tagged so `svg-line--note-help' tracks the hover)."
+  (lambda (win _obj _pos)
+    (let* ((mp (mouse-pixel-position))
+           (mx (cadr mp)) (my (cddr mp))
+           (tab (and (windowp win) (numberp mx) (numberp my)
+                     (svg-line--wrap-tab-at-xy name win
+                                               (- mx (window-pixel-left win))
+                                               (- my (window-pixel-top win))))))
+      (and tab (svg-line--tab-help tab)))))
 
 (defun svg-line--wrap-make-click-map (name)
   "Return a keymap dispatching tab-line clicks for line NAME.
@@ -802,12 +819,17 @@ resolves whether or not the special area prepends an event prefix."
    (lambda ()
      (let ((spec (svg-line--spec name)))
        (if (eq (or (plist-get spec :layout) 'lines) 'wrap)
-           ;; wrap returns (SVG . MAP); display with the map and attach the
-           ;; click keymap so tabs are clickable.
-           (let* ((built (svg-line--build-wrap spec))
-                  (str (svg-line-display (car built)
-                                         (when (cdr built) (list :map (cdr built))))))
-             (propertize str 'keymap (svg-line--wrap-make-click-map name)))
+           ;; A special area (tab line) honours STRING-level keymap/help-echo
+           ;; but not image-map *area* properties, so drive clicks and hover
+           ;; from the string: a click keymap (dispatched by pixel position),
+           ;; a help-echo FUNCTION (mouse-move hover + tooltip), and a hand
+           ;; pointer.  (The hover BOX itself is drawn into the SVG by
+           ;; `svg-line--build-wrap' from `svg-line--hovered'.)
+           (let ((str (svg-line-display (car (svg-line--build-wrap spec)))))
+             (propertize str
+                         'keymap (svg-line--wrap-make-click-map name)
+                         'help-echo (svg-line--wrap-help-fn name)
+                         'pointer 'hand))
          (svg-line-display (svg-line--build-lines spec)))))))
 
 (defun svg-line--renderer (name)

--- a/source/zettapkg/svg-line/svg-line.el
+++ b/source/zettapkg/svg-line/svg-line.el
@@ -394,6 +394,70 @@ Returns an svg object (see `svg-create')."
     svg))
 
 ;;;###autoload
+;;;; wrap-layout interactivity (clicks, menus, hover) -- see also `svg-line-define'
+;; ----------------------------------------------------------------
+
+(defcustom svg-line-hover-highlight nil
+  "When non-nil, draw a background behind the wrap item under the mouse.
+Needs `show-help-function' wired to call `svg-line--note-help' (the package
+can't change that global itself); the mouse enter/move/leave signal arrives
+through the help-echo machinery.  See the tab-line config."
+  :type 'boolean)
+
+(defcustom svg-line-help-face 'svg-line-help
+  "Face applied to a wrap item's hover help, or nil to leave it unstyled."
+  :type '(choice (const :tag "No face" nil) face))
+
+(defface svg-line-help '((t :inherit highlight))
+  "Face for a wrap item's hover help (its `help-echo').
+With tooltips off the help shows in the echo area, where this contrasting
+background makes the cue stand out; the face is preserved into the echo area.")
+
+(defvar svg-line--hovered nil
+  "Id of the wrap item under the mouse (its STATE `:id'), or nil.
+Set by `svg-line--note-help'; the renderer draws a hover box behind the item
+whose `:id' matches.")
+
+(defvar svg-line--wrap-map nil
+  "Image map built by the last `svg-line-wrap-image' call, or nil.
+A side channel so `svg-line-wrap-image' keeps returning a plain svg object
+\(its documented contract) while `svg-line--build-wrap' can still pick up the
+per-item hot-spots to put on the image descriptor.")
+
+(defun svg-line--wrap-place (items width char-advance gap lh)
+  "Return placements (X TOP CW ITEM) for ITEMS in a `wrap' layout.
+Shared by drawing (`svg-line-wrap-image') and click hit-testing
+\(`svg-line--wrap-tab-at') so both agree on where each item sits."
+  (let ((x 0) (row 0) (out nil))
+    (dolist (it items)
+      (let* ((label (car it))
+             (cw (* (length label) char-advance))
+             (w  (+ cw (* gap char-advance))))
+        (when (and (> x 0) (> (+ x w) width))
+          (setq x 0 row (1+ row)))
+        (push (list x (* row lh) cw it) out)
+        (setq x (+ x w))))
+    (nreverse out)))
+
+(defun svg-line--tab-help (item)
+  "Compose, face and tag the hover help for wrap ITEM, or nil.
+The string is tagged with the item's STATE `:id' in the `svg-line-tab' text
+property so `svg-line--note-help' can track which item the mouse is over."
+  (let ((state (cdr item)))
+    (when (consp state)
+      (let* ((help (plist-get state :help))
+             (ah   (plist-get state :action-help))
+             (parts (delq nil
+                          (list help
+                                (and (plist-get state :action) ah (concat "click to " ah))
+                                (and (plist-get state :menu) "right-click for menu")))))
+        (when parts
+          (let ((s (string-join parts "  ·  ")))
+            (when svg-line-help-face
+              (setq s (propertize s 'face svg-line-help-face)))
+            (setq s (propertize s 'svg-line-tab (plist-get state :id)))
+            s))))))
+
 (cl-defun svg-line-wrap-image (items &key
                                      (width 100)
                                      (font (or svg-line-font (face-attribute 'default :family nil t)))
@@ -406,7 +470,9 @@ Returns an svg object (see `svg-create')."
                                      (current-foreground nil)
                                      (current-background nil)
                                      (modified-foreground nil)
-                                     (modified-background nil))
+                                     (modified-background nil)
+                                     (hovered nil)
+                                     (hover-color nil))
   "Build a `wrap'-layout SVG from ITEMS, a list of (LABEL . STATE).
 Items flow left-to-right and wrap onto new rows at WIDTH.  GAP is the
 inter-item gap in character widths.  FONT, FONT-SIZE, LINE-PAD,
@@ -414,68 +480,74 @@ CHAR-ADVANCE, FOREGROUND and BACKGROUND set the text family, size,
 per-row padding, character advance and base colours.  Returns an svg
 object.
 
-STATE selects how each item is styled:
+STATE selects how each item is styled and made interactive:
   - nil / non-nil atom  -- treated as CURRENTP (backward compatible);
-  - a plist             -- recognised keys `:current' and `:modified'.
+  - a plist             -- `:current' / `:modified' for styling, plus the
+    optional `:id' `:help' `:action' `:action-help' `:menu' for hover/click
+    (see `svg-line-define').
 
-A current item is drawn bold, in CURRENT-FOREGROUND, over a
-CURRENT-BACKGROUND box.  A (non-current) modified item is drawn in
-MODIFIED-FOREGROUND, over a MODIFIED-BACKGROUND box when set.  When an
-item is BOTH current and modified, its box is tinted with
-MODIFIED-FOREGROUND (the readable current label stays, but the unsaved
-state remains visible behind the highlight).
-
-A per-item icon, if wanted, is just a Nerd-Font glyph at the start of
-LABEL (it is plain text and flows with the label)."
+A current item is drawn bold over CURRENT-BACKGROUND; a modified item uses
+MODIFIED-FOREGROUND (and MODIFIED-BACKGROUND when set); an ordinary item whose
+`:id' equals HOVERED gets a HOVER-COLOR box.  Items with `:help'/`:action'/
+`:menu' become image map hot-spots (per-item help-echo + hand pointer)."
   (let* ((foreground (svg-line--color foreground))
          (background (svg-line--color background))
          (current-foreground (svg-line--color current-foreground))
          (current-background (svg-line--color current-background))
          (modified-foreground (svg-line--color modified-foreground))
          (modified-background (svg-line--color modified-background))
+         (hover-color (svg-line--color hover-color))
          (fz font-size)
          (lh (+ fz line-pad))
-         (x 0) (row 0) (placements nil))
-    (dolist (it items)
-      (let* ((label (car it))
-             (state (cdr it))
-             (currentp  (if (consp state) (plist-get state :current) state))
-             (modifiedp (and (consp state) (plist-get state :modified)))
-             (cw (* (length label) char-advance))    ; item (box) width
-             (w  (+ cw (* gap char-advance))))        ; + inter-item gap
-        (when (and (> x 0) (> (+ x w) width))
-          (setq x 0 row (1+ row)))
-        (push (list x (* row lh) cw label currentp modifiedp) placements)
-        (setq x (+ x w))))
-    (let* ((height (max 1 (* (1+ row) lh)))
-           (svg (svg-create width height)))
-      (when background (svg-rectangle svg 0 0 width height :fill background))
-      (dolist (p (nreverse placements))
-        (cl-destructuring-bind (px top cw label currentp modifiedp) p
-          (let ((box  (cond ;; current AND modified: tint the current box with the
-                            ;; modified accent so "unsaved" stays visible behind
-                            ;; the current highlight (the label stays readable).
-                            ((and currentp modifiedp) (or modified-foreground current-background))
-                            (currentp  current-background)
-                            (modifiedp modified-background)))
-                (fill (cond (currentp  (or current-foreground foreground))
-                            (modifiedp (or modified-foreground foreground))
-                            (t foreground))))
-            (when box
-              (svg-rectangle svg px top cw lh :fill box :rx 3))
-            (svg-line--add-text svg label :x px :y (+ top fz)
-                                :font font :font-size fz :fill fill
-                                :weight (if currentp "bold" "normal")))))
-      svg)))
+         (placements (svg-line--wrap-place items width char-advance gap lh))
+         (height (max 1 (apply #'max lh (mapcar (lambda (p) (+ (nth 1 p) lh)) placements))))
+         (svg (svg-create width height))
+         (map nil))
+    (when background (svg-rectangle svg 0 0 width height :fill background))
+    (dolist (p placements)
+      (cl-destructuring-bind (px top cw it) p
+        (let* ((label (car it))
+               (state (cdr it))
+               (currentp  (if (consp state) (plist-get state :current) state))
+               (modifiedp (and (consp state) (plist-get state :modified)))
+               (hoveredp  (and hover-color (consp state) hovered
+                               (equal (plist-get state :id) hovered)))
+               (box  (cond ((and currentp modifiedp) (or modified-foreground current-background))
+                           (currentp  current-background)
+                           (modifiedp modified-background)
+                           (hoveredp  hover-color)))
+               (fill (cond (currentp  (or current-foreground foreground))
+                           (modifiedp (or modified-foreground foreground))
+                           (t foreground))))
+          (when box
+            (svg-rectangle svg px top cw lh :fill box :rx 3))
+          (svg-line--add-text svg label :x px :y (+ top fz)
+                              :font font :font-size fz :fill fill
+                              :weight (if currentp "bold" "normal"))
+          ;; image-map hot-spot for hover/click
+          (let ((eh (svg-line--tab-help it)))
+            (when (and (consp state)
+                       (or eh (plist-get state :action) (plist-get state :menu)))
+              (let ((props (list 'pointer 'hand)))
+                (when eh (setq props (append props (list 'help-echo eh))))
+                (push (list (cons 'rect (cons (cons px top) (cons (+ px cw) (+ top lh))))
+                            (make-symbol (format "svg-line-tab-%d-%d" px top))
+                            props)
+                      map)))))))
+    ;; Stash the hot-spot map in the side channel (nil when no interactive
+    ;; items) and return the svg object, per this function's contract.
+    (setq svg-line--wrap-map (nreverse map))
+    svg))
 
 ;;;###autoload
-(defun svg-line-display (svg)
+(defun svg-line-display (svg &optional props)
   "Wrap SVG object as a one-space string carrying it as a display image.
+PROPS, if given, are extra `svg-image' keywords (e.g. (:map MAP)).
 Pinned to `:scale' 1.0: the image IS the line at its exact target pixel
 width, so it must NOT inherit `image-scaling-factor' (auto), which would
 scale it with the default font and overflow the frame.  Scale the line by
 scaling its `:font-size'/`:char-advance' instead, not the image."
-  (propertize " " 'display (svg-image svg :ascent 'center :scale 1.0)))
+  (propertize " " 'display (apply #'svg-image svg :ascent 'center :scale 1.0 props)))
 
 ;;;; Safety wrapper
 ;; ----------------------------------------------------------------
@@ -611,7 +683,8 @@ Sizes scale with the default font (see `svg-line-scale-with-text-scale')."
      :background bg)))
 
 (defun svg-line--build-wrap (spec)
-  "Build the `wrap' SVG for SPEC.
+  "Build the `wrap' layout for SPEC, returning (SVG . MAP).
+MAP is the per-item image-map hot-spots (nil when no interactive items).
 When SPEC has an `:active' predicate that is false, the inactive variant
 of each colour applies (falling back to the active colour when unset),
 mirroring the `lines' layout."
@@ -621,7 +694,8 @@ mirroring the `lines' layout."
                  (if active
                      (svg-line--opt spec key default)
                    (or (svg-line--opt spec inactive-key)
-                       (svg-line--opt spec key default))))))
+                       (svg-line--opt spec key default)))))
+         (svg
     (svg-line-wrap-image (funcall (plist-get spec :content))
                          :width (svg-line--width spec)
                          :font (svg-line--opt spec :font
@@ -635,18 +709,106 @@ mirroring the `lines' layout."
                          :current-foreground (funcall pick :current-foreground :inactive-current-foreground)
                          :current-background (funcall pick :current-background :inactive-current-background)
                          :modified-foreground (funcall pick :modified-foreground :inactive-modified-foreground)
-                         :modified-background (funcall pick :modified-background :inactive-modified-background))))
+                         :modified-background (funcall pick :modified-background :inactive-modified-background)
+                         :hovered svg-line--hovered
+                         :hover-color (or (svg-line--opt spec :hover-color)
+                                          (face-background 'highlight nil 'default)
+                                          "#444466"))))
+    (cons svg svg-line--wrap-map)))
+
+;;;; wrap interactivity: hover tracking + click/menu dispatch
+;; ----------------------------------------------------------------
+
+(defun svg-line--popup-menu (title items)
+  "Pop up a menu of ITEMS at the current event and run the chosen command.
+ITEMS is an alist of (LABEL . COMMAND); TITLE labels the menu."
+  (let ((choice (x-popup-menu last-input-event
+                              (list (or title "svg-line") (cons "" items)))))
+    (when choice
+      (if (commandp choice) (call-interactively choice) (funcall choice)))))
+
+;;;###autoload
+(defun svg-line--note-help (help)
+  "Update the hovered wrap item from HELP and re-render if it changed.
+Wire `show-help-function' to call this (then display HELP): it fires on mouse
+enter, move AND leave (leave with nil), so the hovered item's `:id' -- carried
+in HELP's `svg-line-tab' text property -- can be tracked and a hover box drawn."
+  (when svg-line-hover-highlight
+    (let ((id (and (stringp help) (> (length help) 0)
+                   (get-text-property 0 'svg-line-tab help))))
+      (unless (equal id svg-line--hovered)
+        (setq svg-line--hovered id)
+        (force-mode-line-update t)))))
+
+(defun svg-line--wrap-params (spec)
+  "Resolve the wrap layout params from SPEC (matching `svg-line--build-wrap')."
+  (let ((sc (svg-line--text-scale)))
+    (list :width (svg-line--width spec)
+          :char-advance (* (or (svg-line--opt spec :char-advance nil) svg-line-char-advance) sc)
+          :gap (svg-line--opt spec :gap 3)
+          :lh (+ (svg-line--scaled (svg-line--opt spec :font-size svg-line-font-size))
+                 (svg-line--scaled (svg-line--opt spec :line-pad svg-line-line-pad))))))
+
+(defun svg-line--wrap-tab-at (name posn)
+  "Return the wrap item of line NAME under POSN, or nil.
+Recomputes the layout in POSN's window (so it matches that window's render)
+and hit-tests the click's pixel position against the placements."
+  (let ((win (posn-window posn)))
+    (when (windowp win)
+      (with-selected-window win
+        (let* ((spec (svg-line--spec name))
+               (p (svg-line--wrap-params spec))
+               (items (ignore-errors (funcall (plist-get spec :content))))
+               (lh (plist-get p :lh))
+               (xy (posn-object-x-y posn))
+               (cx (and xy (car xy))) (cy (and xy (cdr xy))))
+          (when (and cx cy items)
+            ;; NB: use `tab', not `it' -- in cl-loop `when ... return it' the
+            ;; symbol `it' is anaphoric (the `when' value), not our variable.
+            (cl-loop for (px top cw tab) in
+                     (svg-line--wrap-place items (plist-get p :width)
+                                           (plist-get p :char-advance) (plist-get p :gap) lh)
+                     when (and (<= px cx) (< cx (+ px cw)) (<= top cy) (< cy (+ top lh)))
+                     return tab)))))))
+
+(defun svg-line--wrap-make-click-map (name)
+  "Return a keymap dispatching tab-line clicks for line NAME.
+Left/middle click runs the item's STATE `:action'; right click pops its
+`:menu'.  Bindings are duplicated under a catch-all default so the click
+resolves whether or not the special area prepends an event prefix."
+  (let* ((run (lambda ()
+                (interactive)
+                (let* ((it (svg-line--wrap-tab-at name (event-start last-input-event)))
+                       (cmd (and (consp (cdr-safe it)) (plist-get (cdr it) :action))))
+                  (when cmd (call-interactively cmd)))))
+         (menu (lambda ()
+                 (interactive)
+                 (let* ((it (svg-line--wrap-tab-at name (event-start last-input-event)))
+                        (items (and (consp (cdr-safe it)) (plist-get (cdr it) :menu))))
+                   (when items (svg-line--popup-menu (car it) items)))))
+         (sub (make-sparse-keymap)) (km (make-sparse-keymap)))
+    (dolist (k (list [mouse-1] [mouse-2]))
+      (define-key km k run) (define-key sub k run))
+    (define-key km [down-mouse-3] menu) (define-key sub [down-mouse-3] menu)
+    (dolist (k (list [down-mouse-1] [down-mouse-2] [mouse-3]))
+      (define-key km k #'ignore) (define-key sub k #'ignore))
+    (define-key km [t] sub)
+    km))
 
 (defun svg-line--render (name)
   "Render line NAME to a display string (error/loop guarded)."
   (svg-line-safe
    name
    (lambda ()
-     (let* ((spec (svg-line--spec name))
-            (svg (pcase (or (plist-get spec :layout) 'lines)
-                   ('wrap (svg-line--build-wrap spec))
-                   (_     (svg-line--build-lines spec)))))
-       (svg-line-display svg)))))
+     (let ((spec (svg-line--spec name)))
+       (if (eq (or (plist-get spec :layout) 'lines) 'wrap)
+           ;; wrap returns (SVG . MAP); display with the map and attach the
+           ;; click keymap so tabs are clickable.
+           (let* ((built (svg-line--build-wrap spec))
+                  (str (svg-line-display (car built)
+                                         (when (cdr built) (list :map (cdr built))))))
+             (propertize str 'keymap (svg-line--wrap-make-click-map name)))
+         (svg-line-display (svg-line--build-lines spec)))))))
 
 (defun svg-line--renderer (name)
   "Return (creating if needed) the named renderer function symbol for NAME."

--- a/source/zettapkg/svg-line/svg-line.el
+++ b/source/zettapkg/svg-line/svg-line.el
@@ -256,20 +256,34 @@ this function is provided for callers that just want the flattened text."
 
 (defun svg-line--render-runs (segments)
   "Lower SEGMENTS to a list of runs, each segment evaluated exactly once.
-Run forms: (:text STR), (:bar FRACTION WIDTH FILL BG), (:pie FRACTION FILL BG)."
+Run forms: (:text STR), (:bar FRACTION WIDTH FILL BG), (:pie FRACTION FILL BG),
+or (:seg STR PLIST) for an interactive text run (see `svg-line-seg').
+A segment value of (:svg-segs ITEM ...) is spliced (each ITEM processed as a
+sub-value), so one segment function can emit several interactive runs (e.g.
+per-crumb breadcrumbs)."
   (let ((runs '()) (buf ""))
-    (cl-flet ((flush () (when (> (length buf) 0)
-                          (push (list :text buf) runs) (setq buf ""))))
+    (cl-labels
+        ((flush () (when (> (length buf) 0)
+                     (push (list :text buf) runs) (setq buf "")))
+         (add (v)
+           (cond
+            ((null v))
+            ((and (consp v) (eq (car v) :svg-bar)) (flush) (push (cons :bar (cdr v)) runs))
+            ((and (consp v) (eq (car v) :svg-pie)) (flush) (push (cons :pie (cdr v)) runs))
+            ((and (consp v) (eq (car v) :svg-seg))
+             (let ((txt (svg-line--item->string (cadr v))))
+               (when (> (length txt) 0)
+                 (flush) (push (list :seg txt (cddr v)) runs))))
+            ((and (consp v) (eq (car v) :svg-segs))
+             (dolist (c (cdr v)) (add c)))
+            (t (setq buf (concat buf (svg-line--item->string v)))))))
       (dolist (s segments)
         (let ((v (cond ((stringp s) s)
-                       ((and (consp s) (memq (car s) '(:svg-bar :svg-pie))) s)
+                       ((and (consp s) (memq (car s) '(:svg-bar :svg-pie :svg-seg :svg-segs))) s)
                        ((functionp s) (funcall s))
                        ((and (symbolp s) (boundp s)) (symbol-value s))
                        (t nil))))
-          (cond
-           ((and (consp v) (eq (car v) :svg-bar)) (flush) (push (cons :bar (cdr v)) runs))
-           ((and (consp v) (eq (car v) :svg-pie)) (flush) (push (cons :pie (cdr v)) runs))
-           (t (setq buf (concat buf (svg-line--item->string v)))))))
+          (add v)))
       (flush))
     (nreverse runs)))
 
@@ -277,12 +291,34 @@ Run forms: (:text STR), (:bar FRACTION WIDTH FILL BG), (:pie FRACTION FILL BG)."
   "Non-nil if RUNS are entirely text (so the side can use exact text anchoring)."
   (cl-every (lambda (r) (eq (car r) :text)) runs))
 
+(defun svg-line--runs-ltrim (runs)
+  "Drop leading blank `:text' RUNS and left-trim the first text run.
+Mirrors the exact-anchor path's leading trim so run-laid content (with inline
+pies/bars/segments) still starts flush at the left inset."
+  (while (and runs (eq (caar runs) :text) (string-blank-p (nth 1 (car runs))))
+    (setq runs (cdr runs)))
+  (if (and runs (eq (caar runs) :text))
+      (cons (list :text (string-trim-left (nth 1 (car runs)))) (cdr runs))
+    runs))
+
+(defun svg-line--runs-rtrim (runs)
+  "Drop trailing blank `:text' RUNS and right-trim the last text run.
+Mirrors the exact-anchor path's trailing trim so a run-laid right side stays
+flush at the right edge instead of leaving a gap from empty trailing segments."
+  (setq runs (nreverse runs))
+  (while (and runs (eq (caar runs) :text) (string-blank-p (nth 1 (car runs))))
+    (setq runs (cdr runs)))
+  (when (and runs (eq (caar runs) :text))
+    (setq runs (cons (list :text (string-trim-right (nth 1 (car runs)))) (cdr runs))))
+  (nreverse runs))
+
 (defun svg-line--run-width (run char-advance fz)
   "Advance width in pixels of a single RUN.
 Text advances by CHAR-ADVANCE per character; bars and pies derive their
 size from the font size FZ."
   (pcase (car run)
     (:text (* (length (nth 1 run)) char-advance))
+    (:seg  (* (length (nth 1 run)) char-advance))
     (:pie  (+ (round (* fz 0.76)) (round (* 0.3 fz))))   ; diameter + gap
     (:bar  (+ (nth 2 run) (round (* 0.3 fz))))
     (_ 0)))
@@ -295,16 +331,50 @@ CHAR-ADVANCE and font size FZ are passed through to `svg-line--run-width'."
 ;;;; Image builders (public, pure: data in, svg object out)
 ;; ----------------------------------------------------------------
 
-(defun svg-line--draw-runs (svg runs x top fz lh font char-advance foreground)
+(defvar svg-line--seg-acc nil
+  "Accumulator for interactive-run placements in the current `lines' render.
+Each entry is (X TOP W (TEXT . PLIST)), pushed by `svg-line--draw-runs' and
+harvested by `svg-line-image'.  A side channel so `svg-line--draw-runs' keeps
+its simple return contract (the ending x).")
+
+(defvar svg-line--lines-placements nil
+  "Interactive-segment placements from the last `svg-line-image' call.
+Each entry is (X TOP W (TEXT . PLIST)); a side channel like
+`svg-line--wrap-placements'.")
+(defvar svg-line--lines-lh 0
+  "Row height from the last `svg-line-image' call.  Side channel.")
+
+(defun svg-line--draw-runs (svg runs x top fz lh font char-advance foreground
+                                &optional hovered hover-color)
   "Draw RUNS left-to-right in SVG starting at X (row top at TOP).
 Text advances by CHAR-ADVANCE per character; bars and pies by their own
-width.  FOREGROUND is the fallback fill.  Returns the ending x."
+width.  FOREGROUND is the fallback fill.  An interactive (:seg STR PLIST)
+run is drawn like text, gets a HOVER-COLOR box when its `:id' equals HOVERED,
+and its placement (X TOP WIDTH (STR . PLIST)) is pushed onto
+`svg-line--seg-acc' for click/hover hit-testing.  Returns the ending x."
   (dolist (run runs)
     (pcase (car run)
       (:text (let ((str (nth 1 run)))
                (when (> (length str) 0)
                  (svg-line--add-text svg str :x x :y (+ top fz)
                                      :font font :font-size fz :fill foreground))))
+      (:seg  (let* ((str (nth 1 run))
+                    (plist (nth 2 run))
+                    (cw (* (length str) char-advance))
+                    (id (plist-get plist :id))
+                    (hov (and hover-color hovered id (equal id hovered)))
+                    (col (plist-get plist :color))
+                    (face (plist-get plist :face))
+                    (fill (cond (col (svg-line--color col))
+                                (face (svg-line--color
+                                       (face-foreground face nil 'default)))
+                                (t foreground))))
+               (when hov
+                 (svg-rectangle svg x top cw lh :fill hover-color :rx 3))
+               (when (> (length str) 0)
+                 (svg-line--add-text svg str :x x :y (+ top fz)
+                                     :font font :font-size fz :fill fill))
+               (push (list x top cw (cons str plist)) svg-line--seg-acc)))
       (:pie  (let* ((frac (max 0.0 (min 1.0 (float (nth 1 run)))))
                     (fill (svg-line--color (or (nth 2 run) foreground)))
                     (bg   (svg-line--color (or (nth 3 run) "#d4dcea")))
@@ -348,24 +418,32 @@ width.  FOREGROUND is the fallback fill.  Returns the ending x."
                                (right-margin 0)
                                (char-advance svg-line-char-advance)
                                (foreground "#000000")
-                               (background nil))
+                               (background nil)
+                               (hovered nil)
+                               (hover-color nil))
   "Build a `lines'-layout SVG from ROWS, a list of (LEFT . RIGHT).
 Each of LEFT and RIGHT is either:
   - a STRING, drawn with exact font anchoring (flush-left at PAD, or
     flush-right at WIDTH minus RIGHT-MARGIN); or
   - a list of RUNS, drawn with CHAR-ADVANCE spacing so it can carry inline
-    pies and progress bars.  A run is (:text STR), (:pie FRACTION FILL BG)
-    or (:bar FRACTION PIXELWIDTH FILL BG); see `svg-line--render-runs'.
+    pies, progress bars and interactive segments.  A run is (:text STR),
+    (:pie FRACTION FILL BG), (:bar FRACTION PIXELWIDTH FILL BG) or
+    (:seg STR PLIST); see `svg-line--render-runs'.
 FONT, FONT-SIZE, LINE-PAD, PAD, FOREGROUND and BACKGROUND set the text
-family, size, per-row vertical padding, left inset and colours.
+family, size, per-row vertical padding, left inset and colours.  An
+interactive (:seg ...) run whose `:id' equals HOVERED gets a HOVER-COLOR
+box; the placements of all such runs are left in `svg-line--lines-placements'
+\(with row height in `svg-line--lines-lh') for click/hover hit-testing.
 Returns an svg object (see `svg-create')."
   (let* ((foreground (svg-line--color foreground))
          (background (svg-line--color background))
+         (hover-color (svg-line--color hover-color))
          (fz font-size)
          (lh (+ fz line-pad))
          (rx (max 0 (- width right-margin)))
          (height (max 1 (* lh (length rows))))
-         (svg (svg-create width height)))
+         (svg (svg-create width height))
+         (svg-line--seg-acc nil))
     (when background (svg-rectangle svg 0 0 width height :fill background))
     (cl-loop for (l . r) in rows
              for i from 0
@@ -380,7 +458,9 @@ Returns an svg object (see `svg-create')."
                     (svg-line--add-text svg (string-trim-left l) :x pad :y y
                                         :font font :font-size fz :fill foreground))
                    ((consp l)
-                    (svg-line--draw-runs svg l pad top fz lh font char-advance foreground)))
+                    (svg-line--draw-runs svg (svg-line--runs-ltrim l) pad top fz lh
+                                         font char-advance foreground
+                                         hovered hover-color)))
                   ;; RIGHT: flush-right.  Trim trailing whitespace so the
                   ;; visible content reaches the edge (empty trailing segments
                   ;; or a datum's trailing space would otherwise push it left).
@@ -389,34 +469,45 @@ Returns an svg object (see `svg-create')."
                     (svg-line--add-text svg (string-trim-right r) :x rx :y y :anchor "end"
                                         :font font :font-size fz :fill foreground))
                    ((consp r)
-                    (svg-line--draw-runs svg r (max pad (- rx (svg-line--runs-width r char-advance fz)))
-                                         top fz lh font char-advance foreground)))))
+                    (let ((rr (svg-line--runs-rtrim r)))
+                      (svg-line--draw-runs svg rr (max pad (- rx (svg-line--runs-width rr char-advance fz)))
+                                           top fz lh font char-advance foreground
+                                           hovered hover-color))))))
+    (setq svg-line--lines-placements (nreverse svg-line--seg-acc)
+          svg-line--lines-lh lh)
     svg))
 
 ;;;###autoload
-;;;; wrap-layout interactivity (clicks, menus, hover) -- see also `svg-line-define'
+;;;; line interactivity (clicks, menus, hover) -- see also `svg-line-define'
 ;; ----------------------------------------------------------------
+;; Shared by both layouts: `wrap' items (LABEL . STATE) and `lines'
+;; interactive segments (TEXT . PLIST) both reduce to placements
+;; (X TOP W (LABEL . PLIST)), so one set of hit-test / help / click
+;; functions drives clicks, hover boxes and echo help for every bar.
 
 (defcustom svg-line-hover-highlight nil
-  "When non-nil, draw a background behind the wrap item under the mouse.
-Needs `show-help-function' wired to call `svg-line--note-help' (the package
-can't change that global itself); the mouse enter/move/leave signal arrives
-through the help-echo machinery.  See the tab-line config."
+  "When non-nil, draw a background behind the interactive item under the mouse.
+Applies to `wrap' items (tab-line tabs) and `lines' interactive segments
+\(mode-line / header-line / tab-bar indicators).  Needs `show-help-function'
+wired to call `svg-line--note-help' (the package can't change that global
+itself); the mouse enter/move/leave signal arrives through the help-echo
+machinery.  See the tab-line config."
   :type 'boolean)
 
 (defcustom svg-line-help-face 'svg-line-help
-  "Face applied to a wrap item's hover help, or nil to leave it unstyled."
+  "Face applied to an interactive item's hover help, or nil to leave it unstyled."
   :type '(choice (const :tag "No face" nil) face))
 
 (defface svg-line-help '((t :inherit highlight))
-  "Face for a wrap item's hover help (its `help-echo').
+  "Face for an interactive item's hover help (its `help-echo').
 With tooltips off the help shows in the echo area, where this contrasting
 background makes the cue stand out; the face is preserved into the echo area.")
 
 (defvar svg-line--hovered nil
-  "Id of the wrap item under the mouse (its STATE `:id'), or nil.
+  "Id of the interactive item under the mouse (its `:id'), or nil.
 Set by `svg-line--note-help'; the renderer draws a hover box behind the item
-whose `:id' matches.")
+whose `:id' matches.  Ids must be unique per item across all visible windows
+\(e.g. include the buffer for a per-window bar), or several boxes would draw.")
 
 (defvar svg-line--wrap-map nil
   "Image map built by the last `svg-line-wrap-image' call, or nil.
@@ -424,10 +515,70 @@ A side channel so `svg-line-wrap-image' keeps returning a plain svg object
 \(its documented contract) while `svg-line--build-wrap' can still pick up the
 per-item hot-spots to put on the image descriptor.")
 
+(defvar svg-line--wrap-placements nil
+  "Placements (X TOP CW ITEM) from the last `svg-line-wrap-image' call.
+Side channel, like `svg-line--wrap-map'.")
+(defvar svg-line--wrap-lh 0
+  "Row height from the last `svg-line-wrap-image' call.  Side channel.")
+
+(defvar-local svg-line--placements nil
+  "Per-buffer alist (NAME . (LH . PLACEMENTS)) of each line's last hot-spots.
+PLACEMENTS are (X TOP W ITEM); ITEM is (LABEL . STATE) for `wrap' or
+\(TEXT . PLIST) for `lines'.  Keyed by line NAME so several bars in one buffer
+\(tab-line + header-line + mode-line) don't clobber each other.  Hit-tested on
+click/hover so the layout is never recomputed (which would need
+`with-selected-window' during redisplay -- unsafe).")
+
+(defvar svg-line--placements-global nil
+  "Global mirror of `svg-line--placements', keyed by NAME.
+The per-window bars (mode/header/tab line) hit-test the buffer-local copy via
+the window under the mouse, but the FRAME-level tab bar isn't tied to a buffer
+\(its mouse posn reports the frame, not a window), so it reads this mirror.")
+
+(defun svg-line--store-placements (name lh placements)
+  "Record PLACEMENTS (row height LH) for line NAME (buffer-local and global)."
+  (let ((entry (cons name (cons lh placements))))
+    (setq-local svg-line--placements
+                (cons entry (assq-delete-all name svg-line--placements)))
+    (setq svg-line--placements-global
+          (cons entry (assq-delete-all name svg-line--placements-global)))))
+
+(defun svg-line--placements-for (name)
+  "Return (LH . PLACEMENTS) recorded for line NAME in the current buffer, or nil."
+  (cdr (assq name svg-line--placements)))
+
+(defun svg-line--hit (pcons x y)
+  "Return the ITEM in PCONS (LH . PLACEMENTS) covering image pixel (X, Y), or nil."
+  (let ((lh (car pcons)))
+    ;; NB: `item', not `it' (the latter is anaphoric in `when ... return it').
+    (cl-loop for (px top cw item) in (cdr pcons)
+             when (and (<= px x) (< x (+ px cw)) (<= top y) (< y (+ top lh)))
+             return item)))
+
+;;;###autoload
+(defun svg-line-seg (text &rest plist)
+  "Return an interactive `lines' segment carrying TEXT and PLIST.
+PLIST keys: `:id' (unique hover/identity key), `:help', `:action' (a command
+run on left/middle click), `:action-help' (the \"click to ...\" hint), `:menu'
+\(an alist (LABEL . COMMAND) for right-click) and `:color'/`:face' (text fill).
+Use as a segment in a `lines' content side; the engine tracks its pixel extent
+and wires click/hover/menu just like a `wrap' tab.  Returns nil for empty TEXT
+\(so an absent indicator contributes nothing).  See `svg-line-define'."
+  (let ((s (svg-line--item->string text)))
+    (and (> (length s) 0) (cons :svg-seg (cons s plist)))))
+
+;;;###autoload
+(defun svg-line-segs (&rest items)
+  "Return a spliced group of ITEMS (strings or `svg-line-seg' forms).
+A single `lines' segment can thus emit several runs -- e.g. per-crumb
+breadcrumbs.  nil ITEMS are dropped."
+  (cons :svg-segs (delq nil items)))
+
 (defun svg-line--wrap-place (items width char-advance gap lh)
   "Return placements (X TOP CW ITEM) for ITEMS in a `wrap' layout.
-Shared by drawing (`svg-line-wrap-image') and click hit-testing
-\(`svg-line--wrap-tab-at') so both agree on where each item sits."
+WIDTH bounds each row; CHAR-ADVANCE, GAP and LH set per-item width and row
+height.  Shared by drawing (`svg-line-wrap-image') and click hit-testing
+\(`svg-line--seg-at') so both agree on where each item sits."
   (let ((x 0) (row 0) (out nil))
     (dolist (it items)
       (let* ((label (car it))
@@ -534,9 +685,11 @@ MODIFIED-FOREGROUND (and MODIFIED-BACKGROUND when set); an ordinary item whose
                             (make-symbol (format "svg-line-tab-%d-%d" px top))
                             props)
                       map)))))))
-    ;; Stash the hot-spot map in the side channel (nil when no interactive
-    ;; items) and return the svg object, per this function's contract.
-    (setq svg-line--wrap-map (nreverse map))
+    ;; Stash the hot-spot map and placements in side channels (so this fn keeps
+    ;; returning a plain svg object) and return the svg object.
+    (setq svg-line--wrap-map (nreverse map)
+          svg-line--wrap-placements placements
+          svg-line--wrap-lh lh)
     svg))
 
 ;;;###autoload
@@ -655,9 +808,10 @@ Returns 1.0 when scaling is disabled or unavailable."
 (defun svg-line--build-lines (spec)
   "Build the `lines' SVG for SPEC.
 Each content row is (LEFT-SEGMENTS . RIGHT-SEGMENTS).  A segment may emit
-a progress bar (:svg-bar ...) or pie (:svg-pie ...) token (see
-`svg-line--render-runs'); a side with any such token is laid out with
-CHAR-ADVANCE spacing, otherwise with exact text anchoring.
+a progress bar (:svg-bar ...), pie (:svg-pie ...) or interactive segment
+\(:svg-seg ...) token (see `svg-line--render-runs' and `svg-line-seg'); a side
+with any such token is laid out with CHAR-ADVANCE spacing, otherwise with
+exact text anchoring.  The hovered interactive segment gets a hover box.
 Sizes scale with the default font (see `svg-line-scale-with-text-scale')."
   (let* ((active (svg-line--active-p spec))
          (fg (or (and (not active) (svg-line--opt spec :inactive-foreground))
@@ -680,7 +834,10 @@ Sizes scale with the default font (see `svg-line-scale-with-text-scale')."
      :right-margin (svg-line--scaled (svg-line--opt spec :right-margin 0))
      :char-advance (* (or (svg-line--opt spec :char-advance nil) svg-line-char-advance) sc)
      :foreground fg
-     :background bg)))
+     :background bg
+     :hovered svg-line--hovered
+     :hover-color (or (svg-line--opt spec :hover-color)
+                      (face-background 'highlight nil 'default) "#444466"))))
 
 (defun svg-line--build-wrap (spec)
   "Build the `wrap' layout for SPEC, returning (SVG . MAP).
@@ -716,7 +873,7 @@ mirroring the `lines' layout."
                                           "#444466"))))
     (cons svg svg-line--wrap-map)))
 
-;;;; wrap interactivity: hover tracking + click/menu dispatch
+;;;; interactivity: hover tracking + click/menu dispatch (wrap + lines)
 ;; ----------------------------------------------------------------
 
 (defun svg-line--popup-menu (title items)
@@ -732,14 +889,15 @@ ITEMS is an alist of (LABEL . COMMAND); TITLE labels the menu."
 
 ;;;###autoload
 (defun svg-line--note-help (help)
-  "Update the hovered wrap item from HELP and re-render if it changed.
+  "Update the hovered item from HELP and re-render if it changed.
 Wire `show-help-function' to call this (then display HELP): it fires on mouse
 enter, move AND leave (leave with nil), so the hovered item's `:id' -- carried
 in HELP's `svg-line-tab' text property -- can be tracked and a hover box drawn.
-The re-render is DEFERRED to an idle timer: this runs during the help-echo
-display (itself during redisplay), and forcing a redisplay synchronously here
-would re-enter the renderer and degrade the other lines (the safety guard
-returns a stale value)."
+Works for both `wrap' tabs and `lines' interactive segments.  The re-render is
+DEFERRED to an idle timer: this runs during the help-echo display (itself
+during redisplay), and forcing a redisplay synchronously here would re-enter
+the renderer and degrade the other lines (the safety guard returns a stale
+value)."
   (when svg-line-hover-highlight
     (let ((id (and (stringp help) (> (length help) 0)
                    (get-text-property 0 'svg-line-tab help))))
@@ -749,67 +907,60 @@ returns a stale value)."
         (setq svg-line--hover-timer
               (run-with-idle-timer 0 nil (lambda () (force-mode-line-update t))))))))
 
-(defun svg-line--wrap-params (spec)
-  "Resolve the wrap layout params from SPEC (matching `svg-line--build-wrap')."
-  (let ((sc (svg-line--text-scale)))
-    (list :width (svg-line--width spec)
-          :char-advance (* (or (svg-line--opt spec :char-advance nil) svg-line-char-advance) sc)
-          :gap (svg-line--opt spec :gap 3)
-          :lh (+ (svg-line--scaled (svg-line--opt spec :font-size svg-line-font-size))
-                 (svg-line--scaled (svg-line--opt spec :line-pad svg-line-line-pad))))))
+(defun svg-line--seg-at-posn (name posn)
+  "Return line NAME's interactive item under POSN, or nil.
+Handles both bar kinds: a per-window bar (mode/header/tab line) reports a live
+window and IMAGE-relative `posn-object-x-y', so we hit-test that window's
+buffer-local placements; the FRAME-level tab bar reports the frame and nil
+object coords, so we use the area-relative `posn-x-y' against the global
+placement mirror.  No layout recompute and no `with-selected-window' (which
+would corrupt redisplay when called from a help-echo function)."
+  (let* ((win (and posn (posn-window posn)))
+         (obj (and posn (posn-object-x-y posn))))
+    (if (windowp win)
+        ;; per-window bar: image coords = object-x-y, placements = buffer-local
+        (let ((x (car-safe obj)) (y (cdr-safe obj)))
+          (when (and (numberp x) (numberp y))
+            (with-current-buffer (window-buffer win)
+              (svg-line--hit (svg-line--placements-for name) x y))))
+      ;; frame-level bar (tab-bar): image coords = posn-x-y, placements = global
+      (let* ((xy (and posn (posn-x-y posn)))
+             (x (car-safe xy)) (y (cdr-safe xy)))
+        (when (and (numberp x) (numberp y))
+          (svg-line--hit (cdr (assq name svg-line--placements-global)) x y))))))
 
-(defun svg-line--wrap-tab-at-xy (name win x y)
-  "Return the wrap item of line NAME at image pixel (X, Y) in WIN, or nil.
-Recomputes the layout in WIN (so it matches that window's render) and
-hit-tests (X, Y) against the placements."
-  (when (and (windowp win) (numberp x) (numberp y))
-    (with-selected-window win
-      (let* ((spec (svg-line--spec name))
-             (p (svg-line--wrap-params spec))
-             (items (ignore-errors (funcall (plist-get spec :content))))
-             (lh (plist-get p :lh)))
-        (when items
-          ;; NB: use `tab', not `it' -- in cl-loop `when ... return it' the
-          ;; symbol `it' is anaphoric (the `when' value), not our variable.
-          (cl-loop for (px top cw tab) in
-                   (svg-line--wrap-place items (plist-get p :width)
-                                         (plist-get p :char-advance) (plist-get p :gap) lh)
-                   when (and (<= px x) (< x (+ px cw)) (<= top y) (< y (+ top lh)))
-                   return tab))))))
+(defun svg-line--seg-at (name posn)
+  "Return line NAME's interactive item under POSN (a click), or nil."
+  (svg-line--seg-at-posn name posn))
 
-(defun svg-line--wrap-tab-at (name posn)
-  "Return the wrap item of line NAME under POSN (a click), or nil."
-  (let ((xy (posn-object-x-y posn)))
-    (svg-line--wrap-tab-at-xy name (posn-window posn) (car-safe xy) (cdr-safe xy))))
-
-(defun svg-line--wrap-help-fn (name)
-  "Return a `help-echo' FUNCTION for wrap line NAME.
-A special area (e.g. the tab line) does not fire image map *area* help-echo,
-but it does call a STRING-level help-echo function on mouse move -- so we use
-the mouse pixel position to find the item under the pointer and return its
-help (which is tagged so `svg-line--note-help' tracks the hover)."
-  (lambda (win _obj _pos)
+(defun svg-line--seg-help-fn (name)
+  "Return a `help-echo' FUNCTION for line NAME.
+A special area (tab line, header line, mode line, tab bar) does not fire image
+map *area* help-echo, but it does call a STRING-level help-echo function on
+mouse move.  We turn the frame-relative `mouse-pixel-position' into a posn with
+`posn-at-x-y' and hit-test it (see `svg-line--seg-at-posn'), then return the
+item's help (tagged, so `svg-line--note-help' tracks hover)."
+  (lambda (_win _obj _pos)
     (let* ((mp (mouse-pixel-position))
-           (mx (cadr mp)) (my (cddr mp))
-           (tab (and (windowp win) (numberp mx) (numberp my)
-                     (svg-line--wrap-tab-at-xy name win
-                                               (- mx (window-pixel-left win))
-                                               (- my (window-pixel-top win))))))
-      (and tab (svg-line--tab-help tab)))))
+           (frame (car mp)) (mx (cadr mp)) (my (cddr mp))
+           (posn (and (framep frame) (numberp mx) (numberp my)
+                      (ignore-errors (posn-at-x-y mx my frame))))
+           (item (and posn (svg-line--seg-at-posn name posn))))
+      (and item (svg-line--tab-help item)))))
 
-(defun svg-line--wrap-make-click-map (name)
-  "Return a keymap dispatching tab-line clicks for line NAME.
-Left/middle click runs the item's STATE `:action'; right click pops its
-`:menu'.  Bindings are duplicated under a catch-all default so the click
-resolves whether or not the special area prepends an event prefix."
+(defun svg-line--seg-make-click-map (name)
+  "Return a keymap dispatching clicks for line NAME.
+Left/middle click runs the item's `:action'; right click pops its `:menu'.
+Bindings are duplicated under a catch-all default so the click resolves
+whether or not the special area prepends an event prefix."
   (let* ((run (lambda ()
                 (interactive)
-                (let* ((it (svg-line--wrap-tab-at name (event-start last-input-event)))
+                (let* ((it (svg-line--seg-at name (event-start last-input-event)))
                        (cmd (and (consp (cdr-safe it)) (plist-get (cdr it) :action))))
                   (when cmd (call-interactively cmd)))))
          (menu (lambda ()
                  (interactive)
-                 (let* ((it (svg-line--wrap-tab-at name (event-start last-input-event)))
+                 (let* ((it (svg-line--seg-at name (event-start last-input-event)))
                         (items (and (consp (cdr-safe it)) (plist-get (cdr it) :menu))))
                    (when items (svg-line--popup-menu (car it) items)))))
          (sub (make-sparse-keymap)) (km (make-sparse-keymap)))
@@ -821,6 +972,20 @@ resolves whether or not the special area prepends an event prefix."
     (define-key km [t] sub)
     km))
 
+(defun svg-line--interactive (str name has-spots &optional pointer)
+  "Attach click/hover/help props to display STR for line NAME, when HAS-SPOTS.
+A special area honours STRING-level keymap/help-echo but not image map *area*
+properties, so clicks and hover are driven from the string: a click keymap
+\(dispatched by pixel position), a help-echo FUNCTION (mouse-move hover +
+tooltip) and, when POINTER is given, that mouse pointer.  (The hover BOX is
+drawn into the SVG itself from `svg-line--hovered'.)"
+  (if has-spots
+      (let ((s (propertize str
+                           'keymap (svg-line--seg-make-click-map name)
+                           'help-echo (svg-line--seg-help-fn name))))
+        (if pointer (propertize s 'pointer pointer) s))
+    str))
+
 (defun svg-line--render (name)
   "Render line NAME to a display string (error/loop guarded)."
   (svg-line-safe
@@ -828,18 +993,15 @@ resolves whether or not the special area prepends an event prefix."
    (lambda ()
      (let ((spec (svg-line--spec name)))
        (if (eq (or (plist-get spec :layout) 'lines) 'wrap)
-           ;; A special area (tab line) honours STRING-level keymap/help-echo
-           ;; but not image-map *area* properties, so drive clicks and hover
-           ;; from the string: a click keymap (dispatched by pixel position),
-           ;; a help-echo FUNCTION (mouse-move hover + tooltip), and a hand
-           ;; pointer.  (The hover BOX itself is drawn into the SVG by
-           ;; `svg-line--build-wrap' from `svg-line--hovered'.)
            (let ((str (svg-line-display (car (svg-line--build-wrap spec)))))
-             (propertize str
-                         'keymap (svg-line--wrap-make-click-map name)
-                         'help-echo (svg-line--wrap-help-fn name)
-                         'pointer 'hand))
-         (svg-line-display (svg-line--build-lines spec)))))))
+             (svg-line--store-placements name svg-line--wrap-lh svg-line--wrap-placements)
+             ;; the whole wrap line is tabs, so a hand pointer everywhere fits
+             (svg-line--interactive str name (and svg-line--wrap-placements t) 'hand))
+         (let ((svg (svg-line--build-lines spec)))
+           (svg-line--store-placements name svg-line--lines-lh svg-line--lines-placements)
+           ;; a lines bar has large non-interactive gaps, so no global pointer
+           (svg-line--interactive (svg-line-display svg) name
+                                  (and svg-line--lines-placements t))))))))
 
 (defun svg-line--renderer (name)
   "Return (creating if needed) the named renderer function symbol for NAME."

--- a/source/zettapkg/svg-line/test/svg-line-test.el
+++ b/source/zettapkg/svg-line/test/svg-line-test.el
@@ -167,6 +167,96 @@ with the modified accent so the unsaved state stays visible."
     (should (= (length (dom-by-tag svg 'circle)) 2))
     (should (= (length (dom-by-tag svg 'path)) 0))))
 
+;;;; interactive segments (lines layout)
+
+(ert-deftest svg-line/seg-constructor ()
+  "`svg-line-seg' builds a :svg-seg form, and returns nil for empty text."
+  (should (equal (svg-line-seg "hi" :id 'x :action #'ignore)
+                 '(:svg-seg "hi" :id x :action ignore)))
+  (should-not (svg-line-seg ""))
+  (should-not (svg-line-seg nil)))
+
+(ert-deftest svg-line/segs-splice-form ()
+  "`svg-line-segs' groups items and drops nils."
+  (should (equal (svg-line-segs (svg-line-seg "a" :id 1) nil " / "
+                                (svg-line-seg "b" :id 2))
+                 '(:svg-segs (:svg-seg "a" :id 1) " / " (:svg-seg "b" :id 2)))))
+
+(ert-deftest svg-line/render-runs-seg-and-splice ()
+  "A :svg-seg lowers to a :seg run (text + plist); :svg-segs splices; empty drops."
+  (let ((runs (svg-line--render-runs
+               (list "x"
+                     (svg-line-seg "B" :id 'b :action #'ignore)
+                     (svg-line-segs (svg-line-seg "c1" :id 'c1) "·"
+                                    (svg-line-seg "c2" :id 'c2))
+                     (lambda () (svg-line-seg "" :id 'empty))))))  ; empty -> dropped
+    (should (equal (mapcar #'car runs) '(:text :seg :seg :text :seg)))
+    ;; the leading literal text stays its own run; seg carries text + plist
+    (should (equal (nth 1 (nth 1 runs)) "B"))
+    (should (equal (plist-get (nth 2 (nth 1 runs)) :id) 'b))
+    ;; the "·" separator between c1 and c2 is plain text
+    (should (equal (nth 1 (nth 3 runs)) "·"))))
+
+(ert-deftest svg-line/seg-placements-recorded ()
+  "Drawing interactive segments records their placements (X TOP W ITEM)."
+  (let* ((svg-line--lines-placements nil)
+         (left (list (svg-line-seg "AA" :id 'a)))
+         (right (list (svg-line-seg "BB" :id 'b)))
+         (_ (svg-line-image (list (cons (svg-line--side left) (svg-line--side right)))
+                            :width 400 :font "Monospace" :font-size 10
+                            :char-advance 8))
+         (ps svg-line--lines-placements))
+    (should (= (length ps) 2))
+    ;; each placement is (X TOP W (TEXT . PLIST)); ids round-trip
+    (should (equal (sort (mapcar (lambda (p) (plist-get (cdr (nth 3 p)) :id)) ps)
+                         (lambda (x y) (string< (symbol-name x) (symbol-name y))))
+                   '(a b)))
+    ;; left seg sits at x=0; right seg is anchored further right
+    (let ((xa (car (cl-find 'a ps :key (lambda (p) (plist-get (cdr (nth 3 p)) :id)))))
+          (xb (car (cl-find 'b ps :key (lambda (p) (plist-get (cdr (nth 3 p)) :id))))))
+      (should (= xa 0))
+      (should (> xb xa)))))
+
+(ert-deftest svg-line/seg-hover-box ()
+  "An interactive seg whose :id equals HOVERED draws a hover box; none otherwise."
+  (let* ((side (svg-line--side (list (svg-line-seg "AA" :id 'a)
+                                     " " (svg-line-seg "BB" :id 'b))))
+         (rows (list (cons side nil))))
+    (should (= 1 (length (dom-by-tag
+                          (svg-line-image rows :width 400 :font "Monospace"
+                                          :font-size 10 :char-advance 8
+                                          :hovered 'a :hover-color "#445")
+                          'rect))))
+    (should (= 0 (length (dom-by-tag
+                          (svg-line-image rows :width 400 :font "Monospace"
+                                          :font-size 10 :char-advance 8
+                                          :hovered 'zzz :hover-color "#445")
+                          'rect))))))
+
+(ert-deftest svg-line/placements-per-name ()
+  "Placement storage is per-line-name and buffer-local (no cross-bar clobber)."
+  (with-temp-buffer
+    (svg-line--store-placements 'bar1 14 '((0 0 16 ("x" :id 1))))
+    (svg-line--store-placements 'bar2 14 '((0 0 24 ("y" :id 2))))
+    (should (equal (svg-line--placements-for 'bar1) '(14 (0 0 16 ("x" :id 1)))))
+    (should (equal (svg-line--placements-for 'bar2) '(14 (0 0 24 ("y" :id 2)))))
+    ;; updating one leaves the other intact
+    (svg-line--store-placements 'bar1 14 '((0 0 99 ("z" :id 3))))
+    (should (equal (svg-line--placements-for 'bar1) '(14 (0 0 99 ("z" :id 3)))))
+    (should (equal (svg-line--placements-for 'bar2) '(14 (0 0 24 ("y" :id 2)))))))
+
+(ert-deftest svg-line/seg-help-composed-and-tagged ()
+  "An item's help joins help/action-help/menu hints and is tagged with its :id."
+  (let* ((item (cons "buf.el" '(:id buf :help "buffer: buf.el"
+                                    :action ignore :action-help "switch to it"
+                                    :menu (("Kill" . ignore)))))
+         (svg-line-help-face nil)             ; isolate from face propertization
+         (h (svg-line--tab-help item)))
+    (should (string-match-p "buffer: buf.el" h))
+    (should (string-match-p "click to switch to it" h))
+    (should (string-match-p "right-click for menu" h))
+    (should (eq (get-text-property 0 'svg-line-tab h) 'buf))))
+
 ;;;; safety wrapper
 
 (ert-deftest svg-line/safe-error-fallback ()

--- a/source/zettapkg/svg-margin/CONFIGURATION.md
+++ b/source/zettapkg/svg-margin/CONFIGURATION.md
@@ -21,6 +21,16 @@ All are plain `defcustom`s (`M-x customize-group RET svg-margin`):
 | `svg-margin-provider-sides` | `nil` | alist `(PROVIDER . left|right)` forcing where a provider draws |
 | `svg-margin-debug` | `nil` | message indicators dropped for a missing/out-of-range position |
 | `svg-margin-idle-delay` | `0.1` | seconds to coalesce changes before re-rendering |
+| `svg-margin-help-face` | `svg-margin-help` | face for an indicator's hover help (or nil for none) |
+
+Indicators can be made interactive with `:action` (left/middle click),
+`:action-help` (the "click to …" hint), and `:menu` (right-click context
+menu); see the indicator keys in the [README](README.md). The hover help is
+shown with `svg-margin-help-face` (a contrasting background by default), which
+stands out especially when help is shown in the **echo area** rather than a
+tooltip — useful on tiling window managers, where Emacs's own tooltip *frame*
+can get tiled. To route help to the echo area, disable `tooltip-mode`
+(`(tooltip-mode -1)`), which also makes it instant.
 
 Enable per buffer with `svg-margin-mode`, or everywhere with
 `global-svg-margin-mode`. svg-margin needs a **graphical frame** (it draws SVG),

--- a/source/zettapkg/svg-margin/CONFIGURATION.md
+++ b/source/zettapkg/svg-margin/CONFIGURATION.md
@@ -22,6 +22,8 @@ All are plain `defcustom`s (`M-x customize-group RET svg-margin`):
 | `svg-margin-debug` | `nil` | message indicators dropped for a missing/out-of-range position |
 | `svg-margin-idle-delay` | `0.1` | seconds to coalesce changes before re-rendering |
 | `svg-margin-help-face` | `svg-margin-help` | face for an indicator's hover help (or nil for none) |
+| `svg-margin-hover-highlight` | `nil` | draw a background behind the indicator under the mouse |
+| `svg-margin-hover-color` | `nil` | that background's colour (nil = `highlight` face background) |
 
 Indicators can be made interactive with `:action` (left/middle click),
 `:action-help` (the "click to …" hint), and `:menu` (right-click context
@@ -31,6 +33,26 @@ stands out especially when help is shown in the **echo area** rather than a
 tooltip — useful on tiling window managers, where Emacs's own tooltip *frame*
 can get tiled. To route help to the echo area, disable `tooltip-mode`
 (`(tooltip-mode -1)`), which also makes it instant.
+
+### Background-on-hover
+
+A margin can't change the cursor or apply `mouse-face`, but the indicator's
+*background* can still react to the mouse — by re-rendering the line with a
+background drawn into the SVG. Enable `svg-margin-hover-highlight` and route the
+help machinery through `svg-margin--note-help` (it fires on mouse enter, move
+**and leave** — the leave signal is what makes this reliable):
+
+```elisp
+(setq svg-margin-hover-highlight t)
+(let ((inner show-help-function))           ; do this AFTER any tooltip-mode setup
+  (setq show-help-function
+        (lambda (help) (svg-margin--note-help help)
+          (when inner (funcall inner help)))))
+```
+
+The highlight (color `svg-margin-hover-color`, default the `highlight` face
+background) appears once the pointer settles on an indicator and clears on
+leave. Note: each hover change schedules a re-render of that buffer's gutter.
 
 Enable per buffer with `svg-margin-mode`, or everywhere with
 `global-svg-margin-mode`. svg-margin needs a **graphical frame** (it draws SVG),

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -70,7 +70,8 @@ Or manually, with `svg-margin.el` on your `load-path`:
 | `:draw`     | `(lambda (SVG X Y W H COLOR) ...)` for full control            |
 | `:color`/`:face` | fill colour, or a face whose foreground is used           |
 | `:help`     | tooltip string (per-indicator, shown on hover)                 |
-| `:action`   | a command run on click (mouse-1/mouse-2); gives a hand pointer. Each indicator is its own hot-spot via the image `:map` |
+| `:action`   | a command run on left/middle click; gives a hand pointer. Each indicator is its own hot-spot via the image `:map` |
+| `:menu`     | alist of `(LABEL . COMMAND)`; right-click pops up a context menu of these |
 
 Indicators sharing a `(line, side)` pack into adjacent columns; an explicit
 free `:column` is honoured, otherwise each takes the lowest free slot.

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -69,7 +69,8 @@ Or manually, with `svg-margin.el` on your `load-path`:
 | `:text`     | a short string drawn centred (e.g. an evil mark letter)        |
 | `:draw`     | `(lambda (SVG X Y W H COLOR) ...)` for full control            |
 | `:color`/`:face` | fill colour, or a face whose foreground is used           |
-| `:help`     | tooltip string                                                 |
+| `:help`     | tooltip string (per-indicator, shown on hover)                 |
+| `:action`   | a command run on click (mouse-1/mouse-2); gives a hand pointer. Each indicator is its own hot-spot via the image `:map` |
 
 Indicators sharing a `(line, side)` pack into adjacent columns; an explicit
 free `:column` is honoured, otherwise each takes the lowest free slot.

--- a/source/zettapkg/svg-margin/README.md
+++ b/source/zettapkg/svg-margin/README.md
@@ -71,6 +71,7 @@ Or manually, with `svg-margin.el` on your `load-path`:
 | `:color`/`:face` | fill colour, or a face whose foreground is used           |
 | `:help`     | tooltip string (per-indicator, shown on hover)                 |
 | `:action`   | a command run on left/middle click; gives a hand pointer. Each indicator is its own hot-spot via the image `:map` |
+| `:action-help` | short verb phrase for the click (e.g. `"jump"`); the hover tooltip reads `"…  click to jump"` |
 | `:menu`     | alist of `(LABEL . COMMAND)`; right-click pops up a context menu of these |
 
 Indicators sharing a `(line, side)` pack into adjacent columns; an explicit

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -55,6 +55,8 @@
 ;;   :help         tooltip string (shown when hovering just this indicator)
 ;;   :action       a command (symbol or interactive lambda) run when the
 ;;                 indicator is left/middle-clicked; also gives it a hand pointer.
+;;   :action-help  a short verb phrase for the click, e.g. \"jump\"; the hover
+;;                 tooltip then reads \"...  click to jump\".
 ;;   :menu         an alist of (LABEL . COMMAND); right-click (mouse-3) pops up
 ;;                 a context menu of these and runs the chosen command.
 ;;
@@ -135,6 +137,12 @@ A provider whose indicator has no `:pos'/`:line' (or an out-of-range one) has
 that indicator silently skipped; enable this to get a message naming the
 provider, which helps when writing one."
   :type 'boolean)
+
+(defface svg-margin-highlight '((t :inherit highlight))
+  "Face for a clickable gutter cell on mouse hover.
+Applied as `mouse-face' to the whole line's gutter image, so the background
+shows through transparent indicator SVGs while the pointer is over it.  Note
+this highlights the line's whole reserved strip, not a single column.")
 
 ;;;; Colour
 ;; ----------------------------------------------------------------
@@ -380,18 +388,29 @@ skipped so one bad indicator cannot blank the whole line."
       (when map (setq props (append props (list :map (nreverse map)))))
       (apply #'svg-image svg props))))
 
+(defun svg-margin--area-help (ind)
+  "Compose IND's hover tooltip: its `:help', the click action, and a menu hint."
+  (let ((parts (delq nil
+                     (list (plist-get ind :help)
+                           (and (plist-get ind :action) (plist-get ind :action-help)
+                                (concat "click to " (plist-get ind :action-help)))
+                           (and (plist-get ind :menu) "right-click for menu")))))
+    (and parts (string-join parts "  ·  "))))
+
 (defun svg-margin--cell-area (ind x cw h i)
   "Return an image map hot-spot for IND drawn at X (width CW, height H).
 I disambiguates the area id.  Returns nil unless IND has a `:help' or an
-`:action'.  Carries per-indicator `help-echo' and a hand `pointer' when the
-indicator is clickable.  The actual click is dispatched by the overlay
-keymap (see `svg-margin--make-click-map'), not here: in a margin the area
-keymap is not consulted -- the area id becomes an event prefix instead."
-  (let ((help (plist-get ind :help))
-        (action (or (plist-get ind :action) (plist-get ind :menu)))
+`:action'.  Carries the composed per-indicator `help-echo' (see
+`svg-margin--area-help') and a hand `pointer' when the indicator is
+clickable.  The actual click is dispatched by the overlay keymap (see
+`svg-margin--make-click-map'), not here: in a margin the area keymap is not
+consulted -- the area id becomes an event prefix instead."
+  (let ((action (or (plist-get ind :action) (plist-get ind :menu)))
+        (eh (svg-margin--area-help ind))
         (props nil))
     (when action (setq props (list 'pointer 'hand)))
-    (when help (setq props (append props (list 'help-echo help))))
+    (when (and eh (> (length eh) 0))
+      (setq props (append props (list 'help-echo eh))))
     (when props
       (list (cons 'rect (cons (cons x 0) (cons (+ x cw) h)))
             (intern (format "svg-margin--area-%d" i))
@@ -485,7 +504,9 @@ column pixel width and line height for the image."
     ;; put a keymap on the string with a t-default that catches the area
     ;; prefix and dispatches by click position -> column -> indicator.
     (when clickables
-      (setq str (propertize str 'keymap (svg-margin--make-click-map clickables side rcols cw))))
+      (setq str (propertize str
+                            'keymap (svg-margin--make-click-map clickables side rcols cw)
+                            'mouse-face 'svg-margin-highlight)))
     (overlay-put ov 'svg-margin t)
     (overlay-put ov 'before-string str)
     ;; NB: do NOT set `evaporate' -- these overlays are zero-length, and an

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -449,8 +449,13 @@ not consulted (the area id becomes an event prefix)."
       (put-text-property 0 (length eh) 'svg-margin-cell (list (current-buffer) pos side col) eh)
       (setq props (append props (list 'help-echo eh))))
     (when props
+      ;; A GLOBALLY-unique area id (per pos/side/col).  If two hot-spots in
+      ;; different line images shared an id (e.g. same-type indicators sit in
+      ;; the same column), Emacs's mouse-highlight would treat them as one and
+      ;; not re-fire help-echo when moving between them -- breaking hover
+      ;; tracking.  Uninterned so it does not accumulate in the obarray.
       (list (cons 'rect (cons (cons x 0) (cons (+ x cw) h)))
-            (intern (format "svg-margin--area-%d" col))
+            (make-symbol (format "svg-margin-area-%d-%s-%d" pos side col))
             props))))
 
 ;;;; Overlays

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -54,8 +54,9 @@
 ;;   :color/:face  fill colour, or a face whose foreground is used
 ;;   :help         tooltip string (shown when hovering just this indicator)
 ;;   :action       a command (symbol or interactive lambda) run when the
-;;                 indicator is clicked (mouse-1/mouse-2); also gives it a
-;;                 hand pointer.  Implemented via the image `:map' hot-spots.
+;;                 indicator is left/middle-clicked; also gives it a hand pointer.
+;;   :menu         an alist of (LABEL . COMMAND); right-click (mouse-3) pops up
+;;                 a context menu of these and runs the chosen command.
 ;;
 ;; Indicators sharing a (line, side) are packed into columns and drawn into
 ;; a single composite SVG; the margin width on that side grows to the widest
@@ -382,17 +383,15 @@ skipped so one bad indicator cannot blank the whole line."
 (defun svg-margin--cell-area (ind x cw h i)
   "Return an image map hot-spot for IND drawn at X (width CW, height H).
 I disambiguates the area id.  Returns nil unless IND has a `:help' or an
-`:action'.  `:action' (a command) runs on a click and adds a hand pointer."
+`:action'.  Carries per-indicator `help-echo' and a hand `pointer' when the
+indicator is clickable.  The actual click is dispatched by the overlay
+keymap (see `svg-margin--make-click-map'), not here: in a margin the area
+keymap is not consulted -- the area id becomes an event prefix instead."
   (let ((help (plist-get ind :help))
-        (action (plist-get ind :action))
+        (action (or (plist-get ind :action) (plist-get ind :menu)))
         (props nil))
-    (when action
-      (let ((km (make-sparse-keymap)))
-        (define-key km [mouse-1] action)
-        (define-key km [mouse-2] action)
-        (setq props (list 'keymap km 'pointer 'hand))))
-    (when help
-      (setq props (append props (list 'help-echo help))))
+    (when action (setq props (list 'pointer 'hand)))
+    (when help (setq props (append props (list 'help-echo help))))
     (when props
       (list (cons 'rect (cons (cons x 0) (cons (+ x cw) h)))
             (intern (format "svg-margin--area-%d" i))
@@ -409,6 +408,54 @@ I disambiguates the area id.  Returns nil unless IND has a `:help' or an
   (mapc #'delete-overlay svg-margin--overlays)
   (setq svg-margin--overlays nil))
 
+(defun svg-margin--click-column (posn side rcols cw)
+  "Return the indicator column clicked at POSN, given SIDE, RCOLS and CW.
+Uses the click's pixel x within the image; column 0 is nearest the text."
+  (let* ((xy (posn-object-x-y posn))
+         (x (and xy (car xy))))
+    (when (and x (> cw 0))
+      (let ((raw (/ x cw)))
+        (if (eq side 'left) (- rcols 1 raw) raw)))))
+
+(defun svg-margin--popup-menu (title items)
+  "Pop up a menu of ITEMS at the current event and run the chosen command.
+ITEMS is an alist of (LABEL . COMMAND); TITLE labels the menu."
+  (let ((choice (x-popup-menu last-input-event
+                              (list (or title "svg-margin")
+                                    (cons "" items)))))
+    (when choice
+      (if (commandp choice) (call-interactively choice) (funcall choice)))))
+
+(defun svg-margin--make-click-map (clickables side rcols cw)
+  "Build a keymap dispatching a margin click to one of CLICKABLES.
+CLICKABLES is an alist of (COLUMN . INDICATOR).  Left/middle click runs the
+indicator's `:action'; right click (`down-mouse-3') pops up a menu of its
+`:menu' items.  SIDE, RCOLS and CW locate the clicked column.  A default
+\(catch-all) binding absorbs the image map area-id prefix that a margin click
+prepends; the click position then selects the indicator."
+  (let* ((at (lambda ()
+               (let ((col (svg-margin--click-column
+                           (event-start last-input-event) side rcols cw)))
+                 (and col (cdr (assq col clickables))))))
+         (run (lambda ()
+                (interactive)
+                (let* ((ind (funcall at)) (cmd (and ind (plist-get ind :action))))
+                  (when cmd (call-interactively cmd)))))
+         (menu (lambda ()
+                 (interactive)
+                 (let* ((ind (funcall at)) (items (and ind (plist-get ind :menu))))
+                   (when items (svg-margin--popup-menu (plist-get ind :help) items)))))
+         (sub (make-sparse-keymap))
+         (km (make-sparse-keymap)))
+    (define-key sub [mouse-1] run)
+    (define-key sub [mouse-2] run)
+    (define-key sub [down-mouse-3] menu)
+    (define-key sub [down-mouse-1] #'ignore)
+    (define-key sub [down-mouse-2] #'ignore)
+    (define-key sub [mouse-3] #'ignore)
+    (define-key km [t] sub)
+    km))
+
 (defun svg-margin--place (pos side packed rcols cw lh)
   "Create an overlay at POS carrying the composite SIDE image for PACKED.
 RCOLS is the SIDE's reserved column count the image spans; CW and LH are the
@@ -423,8 +470,22 @@ column pixel width and line height for the image."
          ;; wrapping it in a string (((margin SIDE) STRING)) reserves the
          ;; margin space but does not render the nested image.
          (str (propertize " " 'display (list (list 'margin marg) img)))
+         ;; (COLUMN . INDICATOR) for indicators that are clickable (left-click
+         ;; `:action' and/or right-click `:menu').
+         (clickables (delq nil (mapcar (lambda (c)
+                                         (let ((ind (plist-get c :indicator)))
+                                           (and (or (plist-get ind :action)
+                                                    (plist-get ind :menu))
+                                                (cons (plist-get c :column) ind))))
+                                       packed)))
          (ov (make-overlay pos pos)))
     (when (> (length help) 0) (setq str (propertize str 'help-echo help)))
+    ;; A margin click on an image-map area arrives as [AREA-ID mouse-1] looked
+    ;; up in the active keymaps (the area's own keymap is NOT consulted), so we
+    ;; put a keymap on the string with a t-default that catches the area
+    ;; prefix and dispatches by click position -> column -> indicator.
+    (when clickables
+      (setq str (propertize str 'keymap (svg-margin--make-click-map clickables side rcols cw))))
     (overlay-put ov 'svg-margin t)
     (overlay-put ov 'before-string str)
     ;; NB: do NOT set `evaporate' -- these overlays are zero-length, and an

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -148,6 +148,23 @@ so it works there as well as in a tooltip.")
   "Face applied to the indicator hover help, or nil to leave it unstyled."
   :type '(choice (const :tag "No face" nil) face))
 
+(defcustom svg-margin-hover-highlight nil
+  "When non-nil, draw a background behind the indicator under the mouse.
+This needs `show-help-function' wired to call `svg-margin--note-help' (the
+package cannot change that global on its own -- see CONFIGURATION.md), since
+the mouse-enter/leave signal comes through the help-echo machinery."
+  :type 'boolean)
+
+(defcustom svg-margin-hover-color nil
+  "Background colour drawn behind the hovered indicator.
+nil uses the `highlight' face background."
+  :type '(choice (const :tag "highlight face" nil) color))
+
+(defvar svg-margin--hovered nil
+  "The cell under the mouse as (BUFFER POS SIDE COLUMN), or nil.
+Set by `svg-margin--note-help' from the help-echo of the indicator the mouse
+is over; consumed by the renderer to draw `svg-margin-hover-color' behind it.")
+
 ;;;; Colour
 ;; ----------------------------------------------------------------
 
@@ -361,33 +378,41 @@ A non-function `:draw' is ignored (falls through to `:text'/`:shape')."
       (funcall (gethash (plist-get ind :shape) svg-margin--shapes) svg x y w h color))
      (t (svg-margin--shape-dot svg x y w h color)))))
 
-(defun svg-margin--image (packed side rcols cw lh)
+(defun svg-margin--hover-color ()
+  "Return the background colour for the hovered indicator."
+  (svg-margin--color (or svg-margin-hover-color
+                         (face-background 'highlight nil 'default)
+                         "#444466")))
+
+(defun svg-margin--image (packed pos side rcols cw lh hovered-col)
   "Build the composite margin image for PACKED cells on SIDE.
-RCOLS is the SIDE's reserved column count (>= this line's own column count),
-so the image fills the whole margin and column 0 lands nearest the buffer text
-\(rightmost on the left margin, leftmost on the right).  CW is one column's
-pixel width and LH the line height (both passed in so they track the displaying
-window's frame, not just the selected one).  A cell whose draw signals is
-skipped so one bad indicator cannot blank the whole line."
+POS is the line's buffer position (for tagging each hot-spot's help with its
+cell identity).  RCOLS is the SIDE's reserved column count (>= this line's own
+column count), so the image fills the whole margin and column 0 lands nearest
+the buffer text (rightmost on the left margin, leftmost on the right).  CW is
+one column's pixel width and LH the line height (both passed in so they track
+the displaying window's frame, not just the selected one).  When HOVERED-COL is
+the column of a cell, a `svg-margin-hover-color' background is drawn behind it.
+A cell whose draw signals is skipped so one bad indicator cannot blank the line."
   (let* ((h (max 1 lh))
          (w (max 1 (* rcols cw)))
          (svg (svg-create w h))
-         (map nil) (i 0))
+         (map nil))
     (dolist (cell packed)
       (let* ((col (plist-get cell :column))
              (ind (plist-get cell :indicator))
              (x (if (eq side 'left) (* (- rcols 1 col) cw) (* col cw))))
+        ;; Hover background (drawn first, behind the indicator).
+        (when (and hovered-col (eql col hovered-col))
+          (svg-rectangle svg x 0 cw h :fill (svg-margin--hover-color)))
         (condition-case err
             (svg-margin--draw ind svg x 0 cw h)
           (error (message "svg-margin: drawing an indicator failed: %s"
                           (error-message-string err))))
-        ;; Per-cell image-map hot-spot: own help-echo, hand pointer, and a
-        ;; keymap running the indicator's `:action' on a click.  This makes
-        ;; each indicator individually hoverable and clickable within the one
-        ;; composite image.
-        (let ((area (svg-margin--cell-area ind x cw h i)))
-          (when area (push area map)))
-        (setq i (1+ i))))
+        ;; Per-cell image-map hot-spot: own help-echo (tagged with the cell
+        ;; identity for hover tracking), hand pointer, and the click keymap.
+        (let ((area (svg-margin--cell-area ind x cw h pos side col)))
+          (when area (push area map)))))
     (let ((props (list :ascent 'center :scale 1.0)))
       (when map (setq props (append props (list :map (nreverse map)))))
       (apply #'svg-image svg props))))
@@ -401,14 +426,15 @@ skipped so one bad indicator cannot blank the whole line."
                            (and (plist-get ind :menu) "right-click for menu")))))
     (and parts (string-join parts "  ·  "))))
 
-(defun svg-margin--cell-area (ind x cw h i)
+(defun svg-margin--cell-area (ind x cw h pos side col)
   "Return an image map hot-spot for IND drawn at X (width CW, height H).
-I disambiguates the area id.  Returns nil unless IND has a `:help' or an
-`:action'.  Carries the composed per-indicator `help-echo' (see
-`svg-margin--area-help') and a hand `pointer' when the indicator is
-clickable.  The actual click is dispatched by the overlay keymap (see
-`svg-margin--make-click-map'), not here: in a margin the area keymap is not
-consulted -- the area id becomes an event prefix instead."
+POS, SIDE and COL identify the cell; its `help-echo' is tagged with
+\(BUFFER POS SIDE COL) in the `svg-margin-cell' text property so that
+`show-help-function' (via `svg-margin--note-help') can track the hovered
+indicator.  Returns nil unless IND has a `:help' or an `:action'; carries the
+composed help and a hand `pointer' when clickable.  The click itself is
+dispatched by the overlay keymap, not here -- in a margin the area keymap is
+not consulted (the area id becomes an event prefix)."
   (let ((action (or (plist-get ind :action) (plist-get ind :menu)))
         (eh (svg-margin--area-help ind))
         (props nil))
@@ -418,11 +444,13 @@ consulted -- the area id becomes an event prefix instead."
       ;; `svg-margin--place'): a margin honours image-map area help-echo when
       ;; the pointer is directly over the indicator, and that path would
       ;; otherwise show the help without the contrasting background.
-      (when svg-margin-help-face (setq eh (propertize eh 'face svg-margin-help-face)))
+      (setq eh (copy-sequence eh))
+      (when svg-margin-help-face (put-text-property 0 (length eh) 'face svg-margin-help-face eh))
+      (put-text-property 0 (length eh) 'svg-margin-cell (list (current-buffer) pos side col) eh)
       (setq props (append props (list 'help-echo eh))))
     (when props
       (list (cons 'rect (cons (cons x 0) (cons (+ x cw) h)))
-            (intern (format "svg-margin--area-%d" i))
+            (intern (format "svg-margin--area-%d" col))
             props))))
 
 ;;;; Overlays
@@ -488,7 +516,12 @@ prepends; the click position then selects the indicator."
   "Create an overlay at POS carrying the composite SIDE image for PACKED.
 RCOLS is the SIDE's reserved column count the image spans; CW and LH are the
 column pixel width and line height for the image."
-  (let* ((img (svg-margin--image packed side rcols cw lh))
+  (let* ((hovered-col (and svg-margin-hover-highlight svg-margin--hovered
+                           (eq (nth 0 svg-margin--hovered) (current-buffer))
+                           (eql (nth 1 svg-margin--hovered) pos)
+                           (eq (nth 2 svg-margin--hovered) side)
+                           (nth 3 svg-margin--hovered)))
+         (img (svg-margin--image packed pos side rcols cw lh hovered-col))
          (marg (if (eq side 'left) 'left-margin 'right-margin))
          ;; Compose the line's tooltip from each indicator's full hint (label +
          ;; "click to ..." + menu).  Done at the STRING level because a margin
@@ -654,6 +687,23 @@ before first being zeroed, so they can be restored exactly -- including when
         (setq svg-margin--timer
               (run-with-idle-timer svg-margin-idle-delay nil
                                    #'svg-margin--render buf))))))
+
+;;;###autoload
+(defun svg-margin--note-help (help)
+  "Update the hovered cell from HELP and re-render if it changed.
+Wire `show-help-function' to call this (then display HELP as usual): it fires
+on mouse enter, move AND leave (leave calls it with nil), so the hovered cell
+can be tracked and `svg-margin-hover-highlight' drawn behind it.  HELP carries
+the cell identity in its `svg-margin-cell' text property (see
+`svg-margin--cell-area')."
+  (when svg-margin-hover-highlight
+    (let ((cell (and (stringp help) (> (length help) 0)
+                     (get-text-property 0 'svg-margin-cell help))))
+      (unless (equal cell svg-margin--hovered)
+        (let ((old svg-margin--hovered))
+          (setq svg-margin--hovered cell)
+          (dolist (c (delq nil (list (car-safe old) (car-safe cell))))
+            (when (buffer-live-p c) (svg-margin--schedule c))))))))
 
 (defun svg-margin--after-change (&rest _)
   "Schedule a re-render after a buffer change."

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -52,7 +52,10 @@
 ;;   :text         a short string drawn centred (e.g. an evil mark letter)
 ;;   :draw         a function (SVG X Y W H COLOR) for full control
 ;;   :color/:face  fill colour, or a face whose foreground is used
-;;   :help         tooltip string
+;;   :help         tooltip string (shown when hovering just this indicator)
+;;   :action       a command (symbol or interactive lambda) run when the
+;;                 indicator is clicked (mouse-1/mouse-2); also gives it a
+;;                 hand pointer.  Implemented via the image `:map' hot-spots.
 ;;
 ;; Indicators sharing a (line, side) are packed into columns and drawn into
 ;; a single composite SVG; the margin width on that side grows to the widest
@@ -355,7 +358,8 @@ window's frame, not just the selected one).  A cell whose draw signals is
 skipped so one bad indicator cannot blank the whole line."
   (let* ((h (max 1 lh))
          (w (max 1 (* rcols cw)))
-         (svg (svg-create w h)))
+         (svg (svg-create w h))
+         (map nil) (i 0))
     (dolist (cell packed)
       (let* ((col (plist-get cell :column))
              (ind (plist-get cell :indicator))
@@ -363,8 +367,36 @@ skipped so one bad indicator cannot blank the whole line."
         (condition-case err
             (svg-margin--draw ind svg x 0 cw h)
           (error (message "svg-margin: drawing an indicator failed: %s"
-                          (error-message-string err))))))
-    (svg-image svg :ascent 'center :scale 1.0)))
+                          (error-message-string err))))
+        ;; Per-cell image-map hot-spot: own help-echo, hand pointer, and a
+        ;; keymap running the indicator's `:action' on a click.  This makes
+        ;; each indicator individually hoverable and clickable within the one
+        ;; composite image.
+        (let ((area (svg-margin--cell-area ind x cw h i)))
+          (when area (push area map)))
+        (setq i (1+ i))))
+    (let ((props (list :ascent 'center :scale 1.0)))
+      (when map (setq props (append props (list :map (nreverse map)))))
+      (apply #'svg-image svg props))))
+
+(defun svg-margin--cell-area (ind x cw h i)
+  "Return an image map hot-spot for IND drawn at X (width CW, height H).
+I disambiguates the area id.  Returns nil unless IND has a `:help' or an
+`:action'.  `:action' (a command) runs on a click and adds a hand pointer."
+  (let ((help (plist-get ind :help))
+        (action (plist-get ind :action))
+        (props nil))
+    (when action
+      (let ((km (make-sparse-keymap)))
+        (define-key km [mouse-1] action)
+        (define-key km [mouse-2] action)
+        (setq props (list 'keymap km 'pointer 'hand))))
+    (when help
+      (setq props (append props (list 'help-echo help))))
+    (when props
+      (list (cons 'rect (cons (cons x 0) (cons (+ x cw) h)))
+            (intern (format "svg-margin--area-%d" i))
+            props))))
 
 ;;;; Overlays
 ;; ----------------------------------------------------------------

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -414,6 +414,11 @@ consulted -- the area id becomes an event prefix instead."
         (props nil))
     (when action (setq props (list 'pointer 'hand)))
     (when (and eh (> (length eh) 0))
+      ;; Face the per-area help too (not just the string-level help in
+      ;; `svg-margin--place'): a margin honours image-map area help-echo when
+      ;; the pointer is directly over the indicator, and that path would
+      ;; otherwise show the help without the contrasting background.
+      (when svg-margin-help-face (setq eh (propertize eh 'face svg-margin-help-face)))
       (setq props (append props (list 'help-echo eh))))
     (when props
       (list (cons 'rect (cons (cons x 0) (cons (+ x cw) h)))

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -475,8 +475,11 @@ RCOLS is the SIDE's reserved column count the image spans; CW and LH are the
 column pixel width and line height for the image."
   (let* ((img (svg-margin--image packed side rcols cw lh))
          (marg (if (eq side 'left) 'left-margin 'right-margin))
+         ;; Compose the line's tooltip from each indicator's full hint (label +
+         ;; "click to ..." + menu).  Done at the STRING level because a margin
+         ;; honours the string `help-echo' but not image-map area properties.
          (help (string-join
-                (delq nil (mapcar (lambda (c) (plist-get (plist-get c :indicator) :help))
+                (delq nil (mapcar (lambda (c) (svg-margin--area-help (plist-get c :indicator)))
                                   packed))
                 "\n"))
          ;; Put the image descriptor DIRECTLY as the margin spec's element;
@@ -497,6 +500,9 @@ column pixel width and line height for the image."
     ;; up in the active keymaps (the area's own keymap is NOT consulted), so we
     ;; put a keymap on the string with a t-default that catches the area
     ;; prefix and dispatches by click position -> column -> indicator.
+    ;; NB: a margin honours `help-echo' and click keymaps but NOT `pointer' or
+    ;; `mouse-face' (verified) -- so the only hover affordance here is the
+    ;; tooltip; the cursor shape cannot be changed over margin content.
     (when clickables
       (setq str (propertize str 'keymap (svg-margin--make-click-map clickables side rcols cw))))
     (overlay-put ov 'svg-margin t)

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -138,6 +138,16 @@ that indicator silently skipped; enable this to get a message naming the
 provider, which helps when writing one."
   :type 'boolean)
 
+(defface svg-margin-help '((t :inherit highlight))
+  "Face for an indicator's hover help (its `help-echo').
+With tooltips off the help shows in the echo area, where this contrasting
+background makes the cue stand out; the face is carried into the echo area,
+so it works there as well as in a tooltip.")
+
+(defcustom svg-margin-help-face 'svg-margin-help
+  "Face applied to the indicator hover help, or nil to leave it unstyled."
+  :type '(choice (const :tag "No face" nil) face))
+
 ;;;; Colour
 ;; ----------------------------------------------------------------
 
@@ -495,7 +505,10 @@ column pixel width and line height for the image."
                                                 (cons (plist-get c :column) ind))))
                                        packed)))
          (ov (make-overlay pos pos)))
-    (when (> (length help) 0) (setq str (propertize str 'help-echo help)))
+    (when (> (length help) 0)
+      (when svg-margin-help-face
+        (setq help (propertize help 'face svg-margin-help-face)))
+      (setq str (propertize str 'help-echo help)))
     ;; A margin click on an image-map area arrives as [AREA-ID mouse-1] looked
     ;; up in the active keymaps (the area's own keymap is NOT consulted), so we
     ;; put a keymap on the string with a t-default that catches the area

--- a/source/zettapkg/svg-margin/svg-margin.el
+++ b/source/zettapkg/svg-margin/svg-margin.el
@@ -138,12 +138,6 @@ that indicator silently skipped; enable this to get a message naming the
 provider, which helps when writing one."
   :type 'boolean)
 
-(defface svg-margin-highlight '((t :inherit highlight))
-  "Face for a clickable gutter cell on mouse hover.
-Applied as `mouse-face' to the whole line's gutter image, so the background
-shows through transparent indicator SVGs while the pointer is over it.  Note
-this highlights the line's whole reserved strip, not a single column.")
-
 ;;;; Colour
 ;; ----------------------------------------------------------------
 
@@ -504,9 +498,7 @@ column pixel width and line height for the image."
     ;; put a keymap on the string with a t-default that catches the area
     ;; prefix and dispatches by click position -> column -> indicator.
     (when clickables
-      (setq str (propertize str
-                            'keymap (svg-margin--make-click-map clickables side rcols cw)
-                            'mouse-face 'svg-margin-highlight)))
+      (setq str (propertize str 'keymap (svg-margin--make-click-map clickables side rcols cw))))
     (overlay-put ov 'svg-margin t)
     (overlay-put ov 'before-string str)
     ;; NB: do NOT set `evaporate' -- these overlays are zero-length, and an


### PR DESCRIPTION
Make individual indicators in the SVG bars (tab-bar, tab-line, header-line,
mode-line) and the svg-margin gutter **interactive**: hover highlight, echo
help, left-click action and right-click context menu — instead of each bar/
margin being one inert image.

## svg-line engine
- `svg-line-seg` / `svg-line-segs` build interactive `lines`-layout segments
  carrying `:id/:help/:action/:action-help/:menu/:color` (and spliced groups,
  e.g. per-crumb breadcrumbs); new `:svg-seg`/`:svg-segs` tokens.
- Per-segment pixel extents are tracked while drawing; the hovered segment gets
  a hover box. Unified hit-testing (`svg-line--seg-at-posn`) serves both layouts
  — per-window bars via image-relative `posn-object-x-y` + buffer-local
  placements, the frame-level tab-bar via `posn-x-y` + a global mirror, keyed
  per line name so multiple bars in a buffer don't clobber each other.
- Hover help-echo derives the mouse position with `posn-at-x-y` (works wherever
  the bar sits); run sides are trimmed so content stays flush.
- Earlier in the branch: interactive tab-line (click-to-switch, menu, hover),
  with the deferred-render fix that stopped hover degrading the other lines.

## Config wiring
- **mode-line**: modal, buffer, major-mode, vc→magit (icons folded in), lsp,
  flycheck, R/T/D/N/H flags, copilot, PDF docpos, line:col.
- **tab-bar**: buffer, Spotify, mail, modal, clock, battery, workspace. The tab
  bar ignores string keymaps/help-echo, so clicks/menus dispatch via advice on
  `tab-bar-mouse-down-1`/`tab-bar-mouse-context-menu`, and hover is driven by a
  short mouse-position poll. The built-in `tab-bar-format` is guarded so
  reloading the module doesn't clobber the live renderer.
- **header-line**: each breadcrumb crumb is click-to-jump — harvests the
  keymap/local-map handlers breadcrumb.el/lsp-headerline attach; jumps directly
  when a crumb exposes its own target (org-imenu-marker / breadcrumb-region /
  siblings), else falls back to the package handler (so lsp keeps working). The
  line-1 path is clickable (dired); org uses `breadcrumb-imenu-crumbs`.

## svg-margin
- Per-indicator clickability via image map: `:action` (left/middle click),
  `:menu` (right click), `:action-help` ("click to …"), background-on-hover via
  `show-help-function`, contrasting echo-area help, unique hot-spot ids.

## Other
- `tooltip.el`: echo-area help (`tooltip-mode -1`) so cues don't open a tooltip
  frame (which tiling WMs snap).
- Docs updated (svg-margin README/CONFIGURATION).

Engine: clean byte-compile, 28 ERT tests, 0 checkdoc warnings. All verified live.