### PR TITLE
fix(ui): clear buffer-local SVG mode line when reverting to telephone-line

### DIFF
--- a/modules/ui/modeline-svg.el
+++ b/modules/ui/modeline-svg.el
@@ -130,9 +130,20 @@ A barely-there light tint."
   "Restore the telephone-line mode line."
   (interactive)
   (svg-line-deactivate 'zetta-mode-line)
-  (if (fboundp 'telephone-line-mode)
-      (telephone-line-mode 1)
-    (force-mode-line-update t))
+  ;; svg-line installs its renderer as the DEFAULT `mode-line-format', but some
+  ;; buffers carry a buffer-local copy of it (so the restored default does not
+  ;; reach them and they keep showing the SVG image).  Drop those leftovers --
+  ;; the mirror of the telephone-line cleanup in `zetta-modeline-use-svg' -- so
+  ;; they fall back to the telephone-line default.
+  (dolist (buf (buffer-list))
+    (with-current-buffer buf
+      (when (and (local-variable-p 'mode-line-format)
+                 (string-match-p "svg-line--render-zetta-mode-line"
+                                 (format "%S" mode-line-format)))
+        (kill-local-variable 'mode-line-format))))
+  (when (fboundp 'telephone-line-mode)
+    (telephone-line-mode 1))
+  (force-mode-line-update t)
   (message "modeline: telephone-line active"))
 
 ;;;###autoload


### PR DESCRIPTION
`zetta-modeline-toggle` messaged the switch but the mode line didn't change.

**Root cause:** svg-line installs its renderer as the *default* `mode-line-format`, but some buffers carry a **buffer-local** copy of it (`(:eval (svg-line--render-zetta-mode-line))`). Restoring the telephone-line default never reached those buffers, so they kept rendering the SVG image.

**Fix:** `zetta-modeline-use-telephone-line` now kills buffer-local `mode-line-format` values that reference the SVG renderer — the mirror of the telephone-line cleanup already in `zetta-modeline-use-svg` — and calls `force-mode-line-update` unconditionally.

### Verified live
Full cycle in the running daemon:
- → telephone-line: `telephone-line-mode` on, default is the telephone format, file buffers (`foo.el`, `post-svg-line.org`) drop their stale SVG locals and follow the default.
- → SVG: renderer active, telephone off, buffers follow the SVG default again.

Completes the demo trio with the header-line (#37) and tab-bar (#39) toggles.