### PR TITLE
chore(ui): remove dead code from tab-line-svg.el

### DIFF
--- a/modules/ui/tab-line-svg.el
+++ b/modules/ui/tab-line-svg.el
@@ -38,89 +38,6 @@
   :hook (elpaca-after-init . global-tab-line-mode)
 
   :config
-  (defun is-buffer (buffer)
-    (bufferp buffer))
-
-  (defun is-occur (buffer)
-    (member (with-current-buffer buffer (symbol-name major-mode)) '("occur-mode")))
-
-  (defun is-grep (buffer)
-    (member (with-current-buffer buffer (symbol-name major-mode)) '("grep-mode")))
-
-  (defun is-terminal-application (buffer)
-    (member (with-current-buffer buffer (symbol-name major-mode)) '("shell-command-mode" "compilation-mode" "vterm-mode")))
-
-  (defun is-magit (buffer)
-    (member (with-current-buffer buffer (symbol-name major-mode)) '("magit-status-mode")))
-
-  (defun is-helpful (buffer)
-    (member (with-current-buffer buffer (symbol-name major-mode)) '("helpful-mode")))
-
-  (defun is-current-major-mode (buffer)
-    (equal major-mode (with-current-buffer buffer major-mode)))
-
-  (defun is-project-buffer (buffer)
-    (and
-     ;;(boundp 'projectile-mode)
-     (cdr (project-current nil))
-     (or ;; need both conditions as they don't all add to
-      (member buffer (project-buffers (project-current nil default-directory)))
-      (string-match
-       ;; remove trailing / from project root
-       (substring (project-root (project-current nil default-directory)) 0 -1)
-       (with-current-buffer buffer default-directory)))))
-
-  ;; CONDITIONS (for use in zetta-project-mode-buffers)
-  (setq is-grep-or-occur '(is-grep is-occur))
-  (setq is-magit-or-helpful '(is-magit is-helpful))
-  (setq is-terminal-application '(is-terminal-application))
-
-  ;; HELPERS
-  (defun zetta-tab-line-test-buffer (buffer conditions)
-    (seq-some (lambda (condition) (funcall condition buffer)) conditions))
-
-  (defun zetta-tab-line-filter-buffers (buffers conditions)
-    (seq-sort-by
-     #'buffer-name #'string<
-     (seq-filter
-      (lambda (buffer)
-        (and ;; make sure it isn't a closed tab
-         (not (member buffer (window-parameter (selected-window) 'closed-tabs)))
-         (zetta-tab-line-test-buffer buffer conditions)))
-      buffers)))
-
-  ;; BUFER SCOPES
-  ;; local variable for scope; enables toggling between different scopes
-  ;; create a buffer local variable
-
-  ;; Create a hook to set a window parameter anytime a window is created
-  ;; (set-window-parameter (selected-window) 'zetta-tab-line-scope 'zetta-tab-line-scope-project-buffers)
-
-  ;; scopes == each scope is a function that returns a list of buffers
-  (defun zetta-tab-line-scope-all-buffers ()
-    ;; todo implement all buffers (not just recently visited)?
-    ;;(buffer-list)
-    (zetta-tab-line-filter-buffers (tab-line-tabs-window-buffers) '(is-buffer)))
-
-  (defun zetta-tab-line-scope-all-buffers-same-mode ()
-    (zetta-tab-line-filter-buffers (zetta-tab-line-scope-all-buffers) '(is-current-major-mode)))
-
-  (defun zetta-tab-line-scope-project-buffers ()
-    (zetta-tab-line-filter-buffers (zetta-tab-line-scope-all-buffers) '(is-project-buffer)))
-
-  (defun zetta-tab-line-scope-project-buffers-same-mode ()
-    (zetta-tab-line-filter-buffers (zetta-tab-line-scope-project-buffers) '(is-current-major-mode)))
-
-  ;; UI for setting scope
-  (defun zetta-tab-line-toggle-scope ()
-    (interactive)
-    (let ((scopes
-           '(zetta-tab-line-scope-all-buffers
-             zetta-tab-line-scope-all-buffers-same-mode
-             zetta-tab-line-scope-project-buffers
-             zetta-tab-line-scope-project-buffers-same-mode)))
-      (set-window-parameter (selected-window) 'zetta-tab-line-scope
-                            (intern (completing-read "Scope: " scopes)))))
 
   (setq tab-line-switch-cycling t tab-line-close-button-show t)
   (setq tab-line-exclude-modes '(minibuffer-mode minibuffer-inactive-mode))
@@ -154,47 +71,6 @@ Lastly, if no tabs are left in the window, it is deleted with the `delete-window
                    (ignore-errors (delete-window window)))))))
       (force-mode-line-update)))
 
-  (defun zetta-tab-line-close-tab ()
-    (interactive)
-    (let ((closed-tabs (window-parameter (selected-window) 'closed-tabs)))
-      (set-window-parameter
-       (selected-window)
-       'closed-tabs
-       (append closed-tabs (list (current-buffer))))
-      (bury-buffer)))
-
-  ;; so this configuration really should look like a list of groups,
-  ;; with each group defined by a predicate
-
-  ;; left off write a macro which returns a cond statement.  The macro
-  ;; should take as input a list of predicates.  whatever it is, the
-  ;; interface should be supplying a group of predicates, not a pair of
-  ;; condition, function that returns buffer list.  before this,
-  ;; refactor the below functions as so we can at least see the pattern
-  ;; in action -- but the semantics are simply listing groups in order
-  ;; of precedence
-
-  (defun zetta-tab-line-get-scope ()
-    (or
-     (window-parameter (selected-window) 'zetta-tab-line-scope)
-     'zetta-tab-line-scope-project-buffers))
-
-  (defun zetta-project-mode-buffers ()
-    ;; should be project buffers, for window (union of prev and next)
-    (let ((buffers (funcall (zetta-tab-line-get-scope))))
-      (cond
-       ((and (zetta-tab-line-test-buffer (current-buffer) is-magit-or-helpful)
-             (window-parameter (selected-window) 'window-side))
-        (zetta-tab-line-filter-buffers buffers is-magit-or-helpful))
-       ((and (zetta-tab-line-test-buffer (current-buffer) is-grep-or-occur)
-             (window-parameter (selected-window) 'window-side))
-        (zetta-tab-line-filter-buffers buffers is-grep-or-occur))
-       ((and (zetta-tab-line-test-buffer (current-buffer) is-terminal-application)
-             (window-parameter (selected-window) 'window-side))
-        (zetta-tab-line-filter-buffers buffers is-terminal-application))
-       (t (seq-sort-by #'buffer-name #'string< buffers)))))
-
-  ;; buffers in projectile projects, show other project buffers
   (defvar ct/circle-numbers-alist
     '(
       ;;(0 . "⓪")
@@ -255,7 +131,6 @@ Lastly, if no tabs are left in the window, it is deleted with the `delete-window
                    'face '(:height 1.0)))))
 
   (setq tab-line-tab-name-function 'zetta-tab-line-tab-name-buffer)
-  ;;(setq tab-line-tabs-function 'zetta-project-mode-buffers)
 
   (setq tab-line-tabs-function 'tab-line-tabs-window-buffers)
 
@@ -306,8 +181,6 @@ Lastly, if no tabs are left in the window, it is deleted with the `delete-window
 
   (
    :keymaps 'override
-   ;; closes tab, doesn't kill buffer
-   ;;"s-w" 'zetta-tab-line-close-tab
    "s-w" 'tab-line-close-tab-1
    )
 


### PR DESCRIPTION
Removes truly-unused code from `modules/ui/tab-line-svg.el` (514 → 397 lines). Verified every removed symbol had no live reference (only commented-out lines or other removed symbols); the file's only external references live in the unloaded `modules/ui/disabled/tab-line.el`.

### Removed
- `zetta-project-mode-buffers` (only set as `tab-line-tabs-function` in a commented-out line) and its entire scope subsystem: the `is-*` predicates, the condition vars, `zetta-tab-line-test-buffer`, `zetta-tab-line-filter-buffers`, the four `zetta-tab-line-scope-*` functions, `zetta-tab-line-toggle-scope`, `zetta-tab-line-get-scope`.
- `zetta-tab-line-close-tab` (only referenced by a commented-out `s-w` binding).
- The stale commented-out lines referencing the above.

### Kept (still in use — *not* removed despite being on the candidate list)
- `tab-line-close-tab-1` — actively bound to `s-w`.
- `ct/circle-numbers-alist` and `zetta-tab-line-tab-name-buffer` — the live `tab-line-tab-name-function` for the built-in/default tab line.

No behaviour change. Loads cleanly in the running daemon.