### PR TITLE
feat(svg-bench): self-contained SVG-vs-native render benchmark

### DIFF
--- a/svg-bench/README.md
+++ b/svg-bench/README.md
@@ -1,0 +1,135 @@
+# svg-bench — how fast is SVG rendering in Emacs?
+
+A self-contained benchmark (`svg-bench.el`, only built-in `svg` + `cl-lib`, no
+packages, no I/O) for the cost of rendering a status bar in Emacs two ways — as
+an **SVG image** (`svg.el` → `create-image` → librsvg → redisplay) versus the
+**native text engine** — plus a circle animation that shows where SVG size
+starts to bite.
+
+It backs a blog post, so it has both **live, recordable demos** and **headless
+data gatherers**.
+
+> The thesis: SVG raster cost scales with image **pixel area**. A status bar is
+> *short*, so even a very wide (ultrawide-monitor) SVG bar — and even a thin
+> inline animation re-rendering every frame — stays comfortably above the 60 fps
+> that high-frame-rate applications target.
+
+Everything needs a **graphical** frame — raster and fps are meaningless under
+`--batch` or `-nw`.
+
+## Usage
+
+```sh
+emacs -Q ~/.zetta.d/svg-bench/svg-bench.el
+```
+
+Then `M-x eval-buffer`, and:
+
+**Demos** (record these — each shows a `[type] [data]` label, the rendered data,
+and a live fps counter):
+
+| command | what it renders |
+|---|---|
+| `M-x svg-perf-text` | an SVG bar drawing text |
+| `M-x svg-perf-icons` | an SVG bar drawing Nerd-Font icon glyphs |
+| `M-x builtin-perf-text` | the native text engine drawing text |
+| `M-x svg-perf-animation` | three circles bouncing in a thin inline bar (optional width arg) |
+
+**Data tables:**
+
+| command | output |
+|---|---|
+| `M-x svg-perf-benchmark` | three tables — SVG-text / SVG-icons / built-in-text, each across the narrow/medium/large bar widths |
+| `M-x svg-perf-animation-benchmark` | one table — the line animation across small/medium/large bar widths |
+
+Both gather **20 trials × 100 frames** per cell and report mean / median / sd /
+min / max ms, **mean fps**, and **min fps** (the worst trial — the number that
+matters for "is it *always* above 60?").
+
+## Methodology
+
+The per-update cost splits into stages, and a naive benchmark hides the
+interesting one:
+
+1. **Generation** — build the `svg.el` DOM and serialise it to the XML string
+   (pure Lisp; does *not* rasterise).
+2. **Rasterisation** — librsvg paints the bitmap. This happens during
+   *redisplay*, not at `create-image`, and is cached by the data string.
+3. **Composite** — Emacs draws the bitmap into the frame.
+
+So timing only the render call misses rasterisation entirely. Instead the
+harness re-renders into a displayed buffer and forces `(redisplay t)` in a loop,
+measuring wall-clock ms per frame. Care taken so the numbers are honest:
+
+- **GUI only.** Under `--batch` there is no display and rasterisation is
+  skipped; it would look infinitely fast.
+- **Every frame is a unique image.** A 2px per-frame colour marker at the bar's
+  edge guarantees a distinct SVG data string, so each frame is an Emacs
+  image-cache *miss* and is genuinely re-rasterised. (Verified: an *identical*
+  image is a cache hit at ~0.3 ms; the benchmark runs 10–40× slower, so the
+  cache is not helping it. Rotating through a small content pool, by contrast,
+  repeats frames and silently hits the cache — which is why we mark instead.)
+  Glyph *colour* stays fixed, so librsvg's internal glyph cache behaves as in a
+  real re-render and text vs icons is a fair, like-for-like comparison.
+- **Full-image raster regardless of window.** librsvg rasterises the whole
+  W×H image even if the window clips it, so a wide SVG bar genuinely pays for
+  its full width. The native engine, by contrast, only pays for the glyphs it
+  draws — which is why the two diverge so sharply as the bar widens.
+- **`gc-cons-threshold` pinned**, a **warm-up frame** discarded, and the image
+  **cache cleared** before each trial.
+
+The three bar widths are the size axis: SVG raster scales with width; the native
+engine scales with the glyph count that width implies. The line animation uses
+the same thin bar shape across three widths, so it scales the same gentle way.
+
+## Results
+
+Measured on Emacs 31.0.50 (native-comp, librsvg, macOS Retina), 20 trials × 100
+frames per cell.
+
+### Status bars (`svg-perf-benchmark`)
+
+```
+SVG / text             | mean ms | min ms | max ms | mean fps | min fps
+narrow  800px,  65c    |   3.55  |  3.13  |  3.93  |     282  |    254
+medium  1800px, 149c   |   7.74  |  7.34  |  8.08  |     129  |    124
+large   3000px, 249c   |  13.07  | 12.37  | 13.59  |      76  |     74
+
+SVG / icons            | mean ms | min ms | max ms | mean fps | min fps
+narrow  800px,  65c    |   3.61  |  3.28  |  3.83  |     277  |    261
+medium  1800px, 149c   |   7.77  |  7.13  |  8.30  |     129  |    121
+large   3000px, 249c   |  13.10  | 12.63  | 13.72  |      76  |     73
+
+BUILT-IN / text        | mean ms | min ms | max ms | mean fps | min fps
+narrow  800px,  65c    |   0.16  |  0.14  |  0.18  |    6414  |   5574
+medium  1800px, 149c   |   0.22  |  0.18  |  0.65  |    4506  |   1527
+large   3000px, 249c   |   0.25  |  0.22  |  0.28  |    3967  |   3604
+```
+
+Even the **large** (3000px, ultrawide-monitor-width) SVG bar stays **>60 fps**:
+mean 76, and the *worst of 20 trials* is still **73–74 fps**. Text and icons
+land on essentially the same numbers — with a fixed glyph colour the cost is
+canvas-area-bound, so glyph *type* barely matters. The native engine is
+~30–80× cheaper because it never rasterises empty pixels.
+
+### Line animation (`svg-perf-animation-benchmark`)
+
+```
+animation width        | mean ms | min ms | max ms | mean fps | min fps
+small   300x40px        |   1.31  |  1.13  |  1.78  |     762  |    561
+medium  700x40px        |   2.57  |  2.31  |  2.95  |     389  |    339
+large   1400x40px       |   4.75  |  4.29  |  5.01  |     211  |    199
+```
+
+A thin inline animation that re-rasterises a fresh SVG **every frame** runs at
+**200–760 fps** across these widths — the worst trial is still ~200 fps. So an
+SVG animation you'd actually drop into a status line is silky, not just "fast
+enough."
+
+## Conclusion
+
+An SVG status bar costs several times more than the native text engine, and is
+still far faster than 60 fps — even at ultrawide widths, and even when it is a
+*live, every-frame animation* — because a bar is short and raster cost is
+area-bound. The text engine remains an order of magnitude cheaper, but SVG has
+ample headroom for the job.

--- a/svg-bench/svg-bench.el
+++ b/svg-bench/svg-bench.el
@@ -1,0 +1,353 @@
+;;; svg-bench.el --- SVG vs native rendering benchmark + demos -*- lexical-binding: t; -*-
+
+;; A self-contained benchmark for the cost of rendering a status bar in Emacs
+;; two ways -- as an SVG image (svg.el -> create-image -> librsvg -> redisplay)
+;; versus the native text engine.  No packages, no I/O.  It backs a blog post,
+;; so it has both live, recordable DEMOS and headless DATA gatherers.
+;;
+;; The thesis: SVG raster cost scales with image PIXEL AREA.  A status bar is
+;; short, so even a very wide (ultrawide-monitor) SVG bar stays well above the
+;; 60 fps that high-frame-rate apps target; only a large 2-D image (the circle
+;; animation) pushes past it.
+;;
+;; Everything needs a GRAPHICAL frame -- raster and fps are meaningless under
+;; --batch or -nw.
+;;
+;; USAGE
+;;   emacs -Q svg-bench/svg-bench.el ; then M-x eval-buffer
+;;   Demos (record these):  M-x svg-perf-text / svg-perf-icons /
+;;                          builtin-perf-text / svg-perf-animation
+;;   Data tables:           M-x svg-perf-benchmark
+;;                          M-x svg-perf-animation-benchmark
+
+;;; Code:
+
+(require 'svg)
+(require 'cl-lib)
+
+;;;; --------------------------------------------------------------------------
+;;;; Configuration
+;;;; --------------------------------------------------------------------------
+
+(defvar svg-bench-bar-height 30
+  "Height in pixels of the benchmarked status bar (short, like a mode line).")
+
+(defvar svg-bench-bar-widths '(("narrow" . 800) ("medium" . 1800) ("large" . 3000))
+  "Alist of (NAME . WIDTH-PX) status-bar widths for `svg-perf-benchmark'.
+Width is the axis of size variance: SVG raster scales with it, and the native
+engine scales with the glyph count it implies.")
+
+(defvar svg-bench-anim-widths '(("small" . 300) ("medium" . 700) ("large" . 1400))
+  "Alist of (NAME . WIDTH-PX) for the line animation, `svg-perf-animation'.
+The animation is a thin mode-line-sized bar (height `svg-bench-anim-height')
+with circles bouncing horizontally -- representative of an inline SVG animation
+you might actually put in a status line -- so its cost scales with width like
+the status-bar benchmarks.")
+(defvar svg-bench-anim-height 40 "Height in px of the line animation bar.")
+(defvar svg-bench-anim-speed 1.2
+  "Angular speed of the bouncing circles, in radians/second (wall-clock).
+A full there-and-back bounce takes 2*pi / this many seconds (~5.2s at 1.2);
+lower is slower and smoother.")
+
+(defvar svg-bench-trials 20 "Trials per (benchmark, size) cell.")
+(defvar svg-bench-reps 100 "Forced-redisplay frames timed per trial.")
+
+(defvar svg-bench-icons
+  '(#xf017 #xf0e7 #xf02d #xf015 #xf121 #xf188 #xf073 #xf02b #xf0e0 #xf02c)
+  "Nerd-Font (Font-Awesome range) icon codepoints for the glyph benchmark.")
+
+(defconst svg-bench--alphabet
+  "abcdefghijklmnopqrstuvwxyz 0123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ .,;:-+=/ "
+  "Pool the text content is drawn from; rotated per frame so every cell changes.")
+
+(defun svg-bench--color (kind)
+  "Accent colour for KIND."
+  (pcase kind ('svg-text "#2f6fd0") ('svg-icons "#8a5cf0") ('builtin-text "#2f8f4f")))
+
+(defun svg-bench--glyph-font ()
+  "A Nerd Font librsvg can resolve for icon glyphs, or nil."
+  (cl-find-if (lambda (f) (find-font (font-spec :family f)))
+              '("Symbols Nerd Font Mono" "Symbols Nerd Font"
+                "Terminess Nerd Font Mono" "Terminess Nerd Font")))
+
+;;;; --------------------------------------------------------------------------
+;;;; Content (fully changes every frame, so the native engine can't reuse glyphs)
+;;;; --------------------------------------------------------------------------
+
+(defun svg-bench--ncells (width)
+  "Number of character cells that fill WIDTH px in the benchmark's SVG font."
+  (max 1 (floor (/ (- width 12) (* (- svg-bench-bar-height 10) 0.6)))))
+
+(defun svg-bench--cells (n seed)
+  "An N-character ASCII string, rotated by SEED so every position differs frame
+to frame (forcing a full re-render in both engines)."
+  (let* ((a svg-bench--alphabet) (la (length a)) (off (mod seed la)))
+    (apply #'string (cl-loop for i below n collect (aref a (mod (+ i off) la))))))
+
+(defun svg-bench--icon-cells (n seed)
+  "An N-glyph Nerd-Font icon string, rotated by SEED for per-frame variation."
+  (apply #'string (cl-loop for i below n
+                           collect (nth (mod (+ i seed) (length svg-bench-icons))
+                                        svg-bench-icons))))
+
+;;;; --------------------------------------------------------------------------
+;;;; Images
+;;;; --------------------------------------------------------------------------
+
+(defun svg-bench--bar-image (kind width height seed)
+  "SVG status bar WIDTH x HEIGHT for KIND (`svg-text' or `svg-icons'), per SEED.
+The whole canvas is filled, so raster cost tracks WIDTH x HEIGHT; the content
+changes each frame (text rotates; icon fill cycles) so every frame is a cache
+miss and is rasterised afresh."
+  (let* ((svg (svg-create width height))
+         (fs (max 8 (- height 10)))
+         (n (svg-bench--ncells width))
+         (y (- height (max 4 (round (/ height 4.0))))))
+    (svg-rectangle svg 0 0 width height :fill (svg-bench--color kind))
+    (if (eq kind 'svg-icons)
+        (svg-text svg (svg-bench--icon-cells n seed)
+                  :x 6 :y y :font-size fs
+                  :font-family (or (svg-bench--glyph-font) "Monospace")
+                  :fill "#ffffff")
+      (svg-text svg (svg-bench--cells n seed)
+                :x 6 :y y :font-size fs :font-family "Monospace" :fill "#ffffff"))
+    ;; A 2px seed-coloured marker at the right edge makes every frame a UNIQUE
+    ;; image -> always an Emacs image-cache MISS, genuinely re-rasterised.  We
+    ;; vary this marker rather than the glyph colour, so glyph colour stays
+    ;; fixed: cost reflects a realistic re-render (canvas raster + reused
+    ;; glyphs), and the cache cannot serve a repeated frame.
+    (svg-rectangle svg (- width 2) 0 2 height
+                   :fill (format "#%06x" (logand (* (1+ seed) 2654435761) #xffffff)))
+    (svg-image svg :scale 1.0 :ascent 'center)))
+
+(defun svg-bench--anim-image (width frame)
+  "Thin WIDTH x `svg-bench-anim-height' bar with circles bouncing left-right.
+Representative of an inline status-line animation; cost scales with WIDTH."
+  (let* ((h svg-bench-anim-height)
+         (svg (svg-create width h))
+         (r (max 4 (round (/ h 3.0))))
+         (cy (/ h 2))
+         (span (max 1 (- width (* 2 (+ r 4))))))
+    (svg-rectangle svg 0 0 width h :fill "#0d1117")
+    ;; Position from wall-clock (not the frame index) so the motion is the same
+    ;; smooth, slow speed regardless of how many fps we render at.
+    (let ((t* (* (float-time) svg-bench-anim-speed)))
+      (dolist (c (list (cons 0.0 "#f25c54") (cons 1.9 "#58a6ff") (cons 3.8 "#3fb950")))
+        (let* ((ph (+ (car c) t*))
+               ;; sine oscillation -> smooth back-and-forth across the bar
+               (x (+ r 4 (round (* (/ span 2.0) (1+ (sin ph)))))))
+          (svg-circle svg x cy r :fill (cdr c)))))
+    ;; per-frame marker so each frame is a unique image (no cache hits)
+    (svg-rectangle svg (- width 2) 0 2 2
+                   :fill (format "#%06x" (logand (* (1+ frame) 2654435761) #xffffff)))
+    (svg-image svg :scale 1.0 :ascent 'center)))
+
+;;;; --------------------------------------------------------------------------
+;;;; Measurement core
+;;;; --------------------------------------------------------------------------
+
+(defun svg-bench--time (render-fn reps)
+  "Call RENDER-FN with frame indices and time forced redisplay, ms/frame.
+RENDER-FN updates the current (displayed) buffer for a given frame index.  GC is
+pinned and the cache cleared so each trial starts clean; the first frame is a
+warm-up and is not timed."
+  (let ((gc-cons-threshold most-positive-fixnum))
+    (clear-image-cache)
+    (funcall render-fn 0) (redisplay t)            ; warm up (untimed)
+    (let ((t0 (float-time)))
+      (dotimes (i reps) (funcall render-fn (1+ i)) (redisplay t))
+      (/ (* 1e3 (- (float-time) t0)) reps))))
+
+(defun svg-bench--bar-render-fn (kind width)
+  "A render function drawing KIND at WIDTH into the current buffer."
+  (let ((n (svg-bench--ncells width)) (h svg-bench-bar-height))
+    (if (eq kind 'builtin-text)
+        (lambda (f) (let ((inhibit-read-only t))
+                      (erase-buffer) (insert (svg-bench--cells n f))))
+      (lambda (f) (let ((inhibit-read-only t))
+                    (erase-buffer)
+                    (insert-image (svg-bench--bar-image kind width h f)))))))
+
+(defun svg-bench--anim-render-fn (width)
+  "A render function drawing the line animation at WIDTH into the current buffer."
+  (lambda (f) (let ((inhibit-read-only t))
+                (erase-buffer) (insert-image (svg-bench--anim-image width f)))))
+
+;;;; --------------------------------------------------------------------------
+;;;; Statistics + table formatting
+;;;; --------------------------------------------------------------------------
+
+(defun svg-bench--stats (xs)
+  "Summary statistics for the list of ms samples XS."
+  (let* ((n (length xs)) (s (sort (copy-sequence xs) #'<))
+         (mean (/ (apply #'+ xs) n))
+         (median (if (cl-oddp n) (nth (/ n 2) s)
+                   (/ (+ (nth (1- (/ n 2)) s) (nth (/ n 2) s)) 2.0)))
+         (mn (car s)) (mx (car (last s)))
+         (sd (sqrt (/ (apply #'+ (mapcar (lambda (x) (* (- x mean) (- x mean))) xs)) n))))
+    (list :n n :mean mean :median median :min mn :max mx :sd sd)))
+
+(defun svg-bench--table-header (title)
+  (concat (format "%-22s | %3s | %7s | %7s | %6s | %6s | %6s | %8s | %7s\n"
+                  title "n" "mean ms" "med ms" "sd ms" "min ms" "max ms"
+                  "mean fps" "min fps")
+          (make-string 92 ?-) "\n"))
+
+(defun svg-bench--table-row (label st)
+  ;; mean fps = 1000/mean ; min fps = 1000/max (the worst trial)
+  (format "%-22s | %3d | %7.2f | %7.2f | %6.2f | %6.2f | %6.2f | %8.0f | %7.0f\n"
+          label (plist-get st :n) (plist-get st :mean) (plist-get st :median)
+          (plist-get st :sd) (plist-get st :min) (plist-get st :max)
+          (/ 1000.0 (plist-get st :mean)) (/ 1000.0 (plist-get st :max))))
+
+;;;; --------------------------------------------------------------------------
+;;;; Data gatherers
+;;;; --------------------------------------------------------------------------
+
+;;;###autoload
+(defun svg-perf-benchmark (&optional trials reps)
+  "Benchmark svg-text vs svg-icons vs builtin-text across the three bar widths.
+TRIALS (default `svg-bench-trials') trials of REPS (default `svg-bench-reps')
+frames each.  Emits three tables (one per render kind), each row a width, with
+full statistics; fps is the headline (mean fps, and min fps = the worst trial)."
+  (interactive)
+  (unless (display-graphic-p) (user-error "svg-bench needs a graphical frame"))
+  (let* ((trials (or trials svg-bench-trials)) (reps (or reps svg-bench-reps))
+         (work (get-buffer-create "*svg-bench-work*"))
+         (out (get-buffer-create "*svg-bench*")))
+    (with-current-buffer out (let ((inhibit-read-only t)) (erase-buffer))
+      (insert (format "Status-bar rendering: SVG vs native text engine\n"))
+      (insert (format "Emacs %s | bar height %dpx | %d trials x %d frames | glyph font: %s\n\n"
+                      emacs-version svg-bench-bar-height trials reps
+                      (or (svg-bench--glyph-font) "none"))))
+    (with-current-buffer work (setq truncate-lines nil) (buffer-disable-undo))
+    (switch-to-buffer work) (delete-other-windows)
+    (dolist (kind '(svg-text svg-icons builtin-text))
+      (with-current-buffer out (goto-char (point-max))
+        (insert (svg-bench--table-header
+                 (pcase kind ('svg-text "SVG / text")
+                             ('svg-icons "SVG / icons")
+                             ('builtin-text "BUILT-IN / text")))))
+      (dolist (wspec svg-bench-bar-widths)
+        (let* ((wname (car wspec)) (w (cdr wspec)) (n (svg-bench--ncells w))
+               (rf (svg-bench--bar-render-fn kind w))
+               (samples (with-current-buffer work
+                          (cl-loop repeat trials collect (svg-bench--time rf reps))))
+               (st (svg-bench--stats samples)))
+          (with-current-buffer out (goto-char (point-max))
+            (insert (svg-bench--table-row (format "%-7s %dpx, %dc" wname w n) st))
+            (redisplay t))))
+      (with-current-buffer out (goto-char (point-max)) (insert "\n")))
+    (switch-to-buffer out) (delete-other-windows) (goto-char (point-min))
+    (message "svg-perf-benchmark done")))
+
+;;;###autoload
+(defun svg-perf-animation-benchmark (&optional trials reps)
+  "Benchmark the line animation across the three bar widths.
+One table, a row per width, same statistics as `svg-perf-benchmark'."
+  (interactive)
+  (unless (display-graphic-p) (user-error "svg-bench needs a graphical frame"))
+  (let* ((trials (or trials svg-bench-trials)) (reps (or reps svg-bench-reps))
+         (work (get-buffer-create "*svg-bench-work*"))
+         (out (get-buffer-create "*svg-bench*")))
+    (with-current-buffer out (let ((inhibit-read-only t)) (erase-buffer))
+      (insert (format "Line animation (3 circles bouncing in a bar): SVG width vs fps\n"))
+      (insert (format "Emacs %s | bar height %dpx | %d trials x %d frames\n\n"
+                      emacs-version svg-bench-anim-height trials reps))
+      (insert (svg-bench--table-header "animation width")))
+    (with-current-buffer work (buffer-disable-undo))
+    (switch-to-buffer work) (delete-other-windows)
+    (dolist (wspec svg-bench-anim-widths)
+      (let* ((wname (car wspec)) (w (cdr wspec))
+             (rf (svg-bench--anim-render-fn w))
+             (samples (with-current-buffer work
+                        (cl-loop repeat trials collect (svg-bench--time rf reps))))
+             (st (svg-bench--stats samples)))
+        (with-current-buffer out (goto-char (point-max))
+          (insert (svg-bench--table-row (format "%-7s %dx%dpx" wname w svg-bench-anim-height) st))
+          (redisplay t))))
+    (switch-to-buffer out) (delete-other-windows) (goto-char (point-min))
+    (message "svg-perf-animation-benchmark done")))
+
+;;;; --------------------------------------------------------------------------
+;;;; Live visual demos (record these)
+;;;; --------------------------------------------------------------------------
+
+(defvar svg-bench-demo-seconds 12 "Default demo duration; any key stops early.")
+(defun svg-bench--demo (kind label)
+  "Run a live, labelled demo of KIND with a running fps counter.
+Renders at the benchmark's `narrow' bar size, so the live fps matches the
+narrow row of the data table; LABEL names the engine and data on screen."
+  (unless (display-graphic-p) (user-error "svg-bench needs a graphical frame"))
+  (let* ((buf (get-buffer-create "*svg-bench-demo*"))
+         (col (svg-bench--color kind))
+         (w (cdr (assoc "narrow" svg-bench-bar-widths)))   ; match the table's narrow row
+         (h svg-bench-bar-height)
+         (n (svg-bench--ncells w))
+         (frames 0) (t0 (float-time)) (fps 0) (endt (+ (float-time) svg-bench-demo-seconds)))
+    (switch-to-buffer buf) (delete-other-windows)
+    (buffer-disable-undo) (setq-local cursor-type nil)
+    (setq-local face-remapping-alist (list (list 'default :background "white" :foreground "black")))
+    (while (and (< (float-time) endt) (not (input-pending-p)))
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "\n\n  "
+                (propertize label
+                            'face (list :foreground col :weight 'bold :height 2.4))
+                "    "
+                (propertize (format "%d fps" fps)
+                            'face (list :foreground "gray40" :height 1.8))
+                "\n\n\n  ")
+        (if (eq kind 'builtin-text)
+            ;; the changing text IS the benchmarked thing -> colour its background
+            (insert (propertize (svg-bench--cells n frames)
+                                'face (list :background col :foreground "white")))
+          (insert-image (svg-bench--bar-image kind w h frames))))
+      (cl-incf frames) (redisplay t)
+      (when (>= frames 6) (setq fps (round (/ frames (- (float-time) t0))))))
+    (message "%s: %d frames, %.0f fps" label frames
+             (/ frames (max 1e-6 (- (float-time) t0))))))
+
+;;;###autoload
+(defun svg-perf-text () "Live demo: SVG rendering text." (interactive)
+  (svg-bench--demo 'svg-text "SVG  /  text"))
+
+;;;###autoload
+(defun svg-perf-icons () "Live demo: SVG rendering icon glyphs." (interactive)
+  (svg-bench--demo 'svg-icons "SVG  /  icons"))
+
+;;;###autoload
+(defun builtin-perf-text () "Live demo: the native text engine rendering text."
+  (interactive)
+  (svg-bench--demo 'builtin-text "BUILT-IN  /  text"))
+
+;;;###autoload
+(defun svg-perf-animation (&optional width)
+  "Live demo: three circles bouncing in a thin SVG bar of WIDTH (default 460).
+Representative of an inline status-line animation; shows a running fps counter;
+any key stops it."
+  (interactive)
+  (unless (display-graphic-p) (user-error "svg-bench needs a graphical frame"))
+  (let* ((width (or width 460)) (h svg-bench-anim-height)
+         (buf (get-buffer-create "*svg-bench-demo*"))
+         (frames 0) (t0 (float-time)) (fps 0) (endt (+ (float-time) svg-bench-demo-seconds)))
+    (switch-to-buffer buf) (delete-other-windows)
+    (buffer-disable-undo) (setq-local cursor-type nil)
+    (setq-local face-remapping-alist (list (list 'default :background "white" :foreground "black")))
+    (while (and (< (float-time) endt) (not (input-pending-p)))
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "\n\n  " (propertize "SVG  /  line animation"
+                                     'face (list :foreground "#1f6feb"
+                                                 :weight 'bold :height 2.4))
+                "    " (propertize (format "%d fps" fps)
+                                   'face (list :foreground "gray40" :height 1.8))
+                "\n\n\n  ")
+        (insert-image (svg-bench--anim-image width frames)))
+      (cl-incf frames) (redisplay t)
+      (when (>= frames 6) (setq fps (round (/ frames (- (float-time) t0))))))
+    (message "line animation %dx%d: %d frames, %.0f fps" width h frames
+             (/ frames (max 1e-6 (- (float-time) t0))))))
+
+(provide 'svg-bench)
+;;; svg-bench.el ends here


### PR DESCRIPTION
Adds `svg-bench/` — a self-contained benchmark harness referenced by the upcoming blog post on SVG status-bar rendering performance.

## What

- `svg-bench/svg-bench.el` — bare `emacs -Q` harness (built-in `svg` + `cl-lib` only, no packages, no I/O) measuring the per-frame cost of rendering a status bar as an SVG image vs the native text engine, plus a thin inline line animation.
- `svg-bench/README.md` — usage, command reference, and methodology.

## Commands

| kind | commands |
|---|---|
| recordable demos | `svg-perf-text`, `svg-perf-icons`, `builtin-perf-text`, `svg-perf-animation` |
| headless data | `svg-perf-benchmark`, `svg-perf-animation-benchmark` |

## Methodology safeguards

- GUI-only timing (raster is skipped under `--batch`)
- per-frame unique-image colour marker to defeat the Emacs image cache
- fixed glyph colour so librsvg's glyph cache behaves as in a real re-render
- pinned `gc-cons-threshold`, warm-up frame discarded, cache cleared per trial

The old `svg-perf/` directory is intentionally **not** included; this supersedes it.