### PR TITLE
feat(ui): tab-bar sun/moon/clock cluster + circled tab-line numbers

### DIFF
--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -22,6 +22,14 @@
   :config
   (hyperbole-mode 1)
 
+  ;; --- HyWiki: highlight/buttonize WikiWords (pages live in ~/hywiki/) ---
+  ;; `hyperbole-mode' alone does NOT highlight WikiWords; the global
+  ;; `hywiki-mode' does.  `hywiki-directory' defaults to ~/hywiki/, which is
+  ;; where the generated chiply.dev WikiWord pages live.  Follow a WikiWord
+  ;; with the Action Key {s-H} (relocated from {M-RET} below).
+  (require 'hywiki)
+  (hywiki-mode 1)
+
   ;; --- Relocate the minibuffer menu: {C-h h} -> {C-h H} ---
   ;; Hyperbole binds `hyperbole' to {C-h h} globally; undo that and rebind.
   (when (eq (lookup-key (current-global-map) (kbd "C-h h")) 'hyperbole)

--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -306,19 +306,48 @@ up far to the left of the actual key/command.  Returns nil when idle."
 
 ;;; mode-line text segments
 (defun zetta-modeline-svg--modal ()
-  ;; show the modal STATE (normal/insert/...), not the modal system
-  (let ((st (zetta-line-modal-state)))
-    (zetta-svg-seg
-     st 'ml-modal
-     :help (format "modal state: %s" (string-trim (format "%s" st)))
-     :action-help "show key bindings"
-     :action #'describe-bindings
-     :menu (list (cons "Describe bindings" #'describe-bindings)
-                 (cons "Describe mode" #'describe-mode)
-                 (cons "Command (M-x)" #'execute-extended-command)))))
+  ;; show the modal STATE (normal/insert/...), styled per state:
+  ;; normal -> regular; insert -> dark bg + light fg; visual -> distinct colour.
+  (let* ((st (zetta-line-modal-state))
+         (style (cond
+                 ((string= st "insert") (list :bg "#33503f" :color "#dcecdf" :weight 'bold))
+                 ((string= st "visual") (list :bg "#5c3733" :color "#f0dcd8" :weight 'bold))
+                 ((string= st "emacs")  (list :color "#6aa0c8"))
+                 (t nil))))   ; normal & friends: plain foreground
+    (apply #'zetta-svg-seg st 'ml-modal
+           (append
+            (list :help (format "modal state: %s" (string-trim (format "%s" st)))
+                  :action-help "show key bindings"
+                  :action #'describe-bindings
+                  :menu (list (cons "Describe bindings" #'describe-bindings)
+                              (cons "Describe mode" #'describe-mode)
+                              (cons "Command (M-x)" #'execute-extended-command)))
+            style))))
 
 (defun zetta-modeline-svg--ace ()
-  (or (window-parameter (selected-window) 'ace-window-path) ""))
+  "Ace-window key for this window as a bold standout badge (dark bg, light fg)."
+  (let ((path (window-parameter (selected-window) 'ace-window-path)))
+    (and path (> (length path) 0)
+         (zetta-svg-seg (format " %s " path) 'ml-ace
+                        :bg "#aab4c4" :color "#262c38" :weight 'bold
+                        :help (format "ace-window key: %s" path)))))
+
+(defvar zetta-modeline--buffer-bg-cache nil
+  "Cons (BG . LIGHTER) caching the lightened buffer-name pill background.")
+(defun zetta-modeline--lighter-bg ()
+  "The modeline active background blended ~halfway to white, as #rrggbb.
+Gives the buffer name a subtle, slightly-lighter pill so it stands out."
+  (let ((bg (bound-and-true-p zetta-modeline-svg-bg-active)))
+    (cond ((not (stringp bg)) nil)
+          ((equal (car zetta-modeline--buffer-bg-cache) bg)
+           (cdr zetta-modeline--buffer-bg-cache))
+          (t (cdr (setq zetta-modeline--buffer-bg-cache
+                        (cons bg (ignore-errors
+                                   (require 'color)
+                                   (apply #'color-rgb-to-hex
+                                          (append (mapcar (lambda (c) (+ c (* (- 1.0 c) 0.5)))
+                                                          (color-name-to-rgb bg))
+                                                  (list 2)))))))))))
 
 (defun zetta-modeline-svg--buffer ()
   (let* ((buf (current-buffer))
@@ -328,6 +357,7 @@ up far to the left of the actual key/command.  Returns nil when idle."
      label
      ;; id includes the buffer so only THIS window's name boxes on hover
      :id (list 'ml-buffer buf)
+     :bg (zetta-modeline--lighter-bg)
      :help (format "buffer: %s" n)
      :action-help "switch buffer"
      :action #'switch-to-buffer
@@ -478,14 +508,17 @@ Shown whenever `flycheck-mode' is active."
    (t "")))
 
 (defun zetta-modeline-svg--point ()
-  (zetta-svg-seg
-   (format-mode-line "%l:%c") 'ml-point
-   :help "line:column"
-   :action-help "go to line"
-   :action #'goto-line
-   :menu (list (cons "Go to line…" #'goto-line)
-               (cons "What cursor position" #'what-cursor-position)
-               (cons "Go to char…" #'goto-char))))
+  (let* ((cur (line-number-at-pos))
+         (tot (max 1 (line-number-at-pos (point-max))))
+         (pct (round (* 100.0 (/ (float cur) tot)))))
+    (zetta-svg-seg
+     (format "%s  %d%%" (format-mode-line "%l:%c") pct) 'ml-point
+     :help (format "line %d/%d (%d%%) : column" cur tot pct)
+     :action-help "go to line"
+     :action #'goto-line
+     :menu (list (cons "Go to line…" #'goto-line)
+                 (cons "What cursor position" #'what-cursor-position)
+                 (cons "Go to char…" #'goto-char)))))
 
 ;;; header-line breadcrumb content
 (defvar zetta-header-line-svg-line1-format
@@ -500,6 +533,9 @@ Shown whenever `flycheck-mode' is active."
     " "
     (:eval (when (fboundp 'spinner-print) (spinner-print spinner-current)))
     " "
+    (:eval (ignore-errors (let ((i (nerd-icons-icon-for-buffer)))
+                            (and (stringp i) (> (length i) 0) (concat i " ")))))
+    (:eval (ignore-errors (concat (nerd-icons-mdicon "nf-md-folder") " ")))
     (:eval
      (let* ((dir default-directory)
             (path (abbreviate-file-name dir))
@@ -512,22 +548,22 @@ Shown whenever `flycheck-mode' is active."
                              (define-key m [header-line mouse-1]
                                (lambda () (interactive) (dired dir)))
                              m)
-                   'help-echo (format "mouse-1: dired %s" dir))))
-    " "
-    "%c|%l(%p)")
-  "Mode-line construct for header-line row 1 (path / position).")
+                   'help-echo (format "mouse-1: dired %s" dir)))))
+  "Mode-line construct for header-line row 1 (mode icon / folder / path).")
 
 (defvar zetta-header-line-svg-line2-format
   '((:eval
      (cond
       ((and (boundp 'lsp-mode) lsp-mode)
-       (window-parameter nil 'lsp-headerline--string))
+       (concat (ignore-errors (concat (nerd-icons-mdicon "nf-md-sitemap") " "))
+               (window-parameter nil 'lsp-headerline--string)))
       ((derived-mode-p 'org-mode)
        ;; Prefer breadcrumb's imenu crumbs (each carries a clickable keymap our
        ;; header-line harvests) over `org-display-outline-path' (no per-crumb
        ;; keymap, so it would render as plain, non-clickable text).
        (if (fboundp 'breadcrumb-imenu-crumbs)
-           (breadcrumb-imenu-crumbs)
+           (concat (ignore-errors (concat (nerd-icons-mdicon "nf-md-format_list_bulleted") " "))
+                   (breadcrumb-imenu-crumbs))
          (propertize
           (or (ignore-errors (org-display-outline-path nil t "/" t)) "/")
           'face '(:height 0.8))))
@@ -536,7 +572,9 @@ Shown whenever `flycheck-mode' is active."
       ((or (equal major-mode 'docker-compose-mode)
            (equal major-mode 'yaml-mode))
        (concat (jpt-yaml-path-to-point)))
-      (t (when (fboundp 'breadcrumb-imenu-crumbs) (breadcrumb-imenu-crumbs))))))
+      (t (when (fboundp 'breadcrumb-imenu-crumbs)
+           (concat (ignore-errors (concat (nerd-icons-mdicon "nf-md-format_list_bulleted") " "))
+                   (breadcrumb-imenu-crumbs)))))))
   "Mode-line construct for header-line row 2 (lsp / org / imenu crumbs).")
 
 (defun zetta-header-line-svg--line1 ()
@@ -649,10 +687,10 @@ keep their own font (`zetta-font').")
   "At or below this battery percentage the indicator is drawn orange (red wins
 below `zetta-tab-bar-battery-low'); above it the indicator is green."
   :type 'integer :group 'zetta)
-(defcustom zetta-tab-bar-battery-colors '((low . "#f85149")
-                                          (medium . "#d29922")
-                                          (full . "#3fb950"))
-  "Colours for low / medium / full battery levels."
+(defcustom zetta-tab-bar-battery-colors '((low . "#a85949")
+                                          (medium . "#a8843f")
+                                          (full . "#6f8a55"))
+  "Colours for low / medium / full battery levels (muted earth tones)."
   :type '(alist :key-type symbol :value-type color) :group 'zetta)
 
 (defun zetta-tab-bar--battery-data ()

--- a/modules/ui/modeline-svg.el
+++ b/modules/ui/modeline-svg.el
@@ -5,12 +5,6 @@
 ;; file supplies only CONTENT + styling + activation policy; rendering
 ;; lives in `svg-line'.
 ;;
-;; It RECREATES the data from `telephone-line.el' as TEXT.  telephone-line
-;; is mostly icons/animations, which single-font SVG text cannot draw, so
-;; those become short text labels or are dropped; the textual segments
-;; (modal tag, ace path, repo:branch, flycheck, R/T/D/N/H indicators, doc
-;; position, point position) recreate faithfully.
-;;
 ;; Switch at runtime:
 ;;   M-x zetta-modeline-use-svg            ; activate this renderer
 ;;   M-x zetta-modeline-use-telephone-line ; restore telephone-line
@@ -66,11 +60,12 @@ A barely-there light tint."
   "Return the mode line as rows (cons LEFT . RIGHT, or :left/:center/:right)."
   (list
    ;; line 1:  [file] modal | ace | buffer   <progress pie>   mode | line:col
-   (list :left '(zetta-modeline-svg--file-icon " "
-                 zetta-modeline-svg--modal " " zetta-modeline-svg--ace " "
-                 zetta-modeline-svg--buffer)
-         :center '(zetta-modeline-svg--file-progress)
-         :right '(zetta-modeline-svg--mode "  " zetta-modeline-svg--point))
+   (list :left '(zetta-modeline-svg--buffer " "
+                 zetta-modeline-svg--ace " "
+                 zetta-modeline-svg--modal)
+         :center nil
+         :right '(zetta-modeline-svg--file-icon " "
+                  zetta-modeline-svg--mode "  " zetta-modeline-svg--point))
    ;; line 2:  git:branch (clickable -> magit) | [copilot] lsp | flycheck | flags
    ;;          ......   doc-position
    ;; (the git + branch glyphs are folded into the clickable vc segment)
@@ -79,11 +74,18 @@ A barely-there light tint."
            zetta-modeline-svg--flycheck " " zetta-modeline-svg--indicators)
          '(zetta-modeline-svg--docpos))))
 
+(defun zetta-modeline-svg-spans ()
+  "Centred overlay for the SVG mode line: a progress pie spanning both rows."
+  (let* ((total (max 1 (- (point-max) (point-min))))
+         (frac (/ (float (- (point) (point-min))) total)))
+    (list (list :pie '(0 . 1) frac "#2a4d77" "#d4dcea"))))
+
 (svg-line-define 'zetta-mode-line
   :target 'mode-line
   :layout 'lines
   :width 'window
   :content #'zetta-modeline-svg-lines
+  :spans #'zetta-modeline-svg-spans
   :active #'mode-line-window-selected-p
   :font (lambda () zetta-svg-line-font)
   :font-size (lambda () zetta-modeline-svg-font-size)

--- a/modules/ui/tab-bar-svg.el
+++ b/modules/ui/tab-bar-svg.el
@@ -16,6 +16,7 @@
 ;; so the icon-rich built-in (text) format defined below is the fallback.
 
 (require 'svg-line)
+(require 'svg-lib nil t)   ; for the svg-lib-date calendar page (optional)
 
 (defcustom zetta-tab-bar-svg-font-size 15
   "Font size (px) for SVG tab-bar text."
@@ -89,37 +90,179 @@ Icons are nerd-font glyphs (plain text in `zetta-svg-line-font'), so every
 side is one font-accurate text run -- no char-advance estimation, nothing
 jitters as keycast changes width."
   (list
-   ;; line 1 -- file-type glyph + buffer name (buffer name is clickable)
+   ;; line 1 -- file glyph + buffer (left); keycast + recursion + thing-at-point (right)
    (cons '(zetta-tab-bar-file-icon " "
                                    zetta-tab-bar-svg--buffer
                                    zmc-modeline-indicator
                                    zetta-pyvenv-activate-poetry-modeline)
-         ;; keycast (caps-kbd glyph, padding trimmed) + recursion depth (hierarchy glyph)
-         '(zetta-tab-bar-svg--keycast
-           " "
-           zetta-tab-bar-recursion-icon " " zetta-tab-bar-recursion-level
-           " "
-           recursion-indicator--string
-           ))
-   ;; line 2 -- Spotify left; workspace (space-tree) centered; mail right
-   (list :left '(zetta-tab-bar-svg--spotify)
-         :center '(zetta-tab-bar-svg--workspace)
-         :right '(zetta-tab-bar-svg--mu4e))
-   ;; line 3 -- modal (clickable) left; current-thing centered;
-   ;;           clock/battery (clickable) right
-   (list :left '(zetta-tab-bar-svg--modal
+         '(zetta-tab-bar-svg--keycast " "
+           zetta-tab-bar-recursion-icon " " zetta-tab-bar-recursion-level " "
+           recursion-indicator--string))
+   ;; line 2 -- modal etc left; <analog clock spans the centre>; mail right
+   (list :left '(zetta-tab-bar-svg--modal " "
+                 zetta-tab-bar-current-thing
                  zetta-gptel-processes
                  blinker-tab-bar)
-         :center '(zetta-tab-bar-current-thing)
-         :right '(zetta-tab-bar-svg--clock " "
-                  zetta-tab-bar-svg--battery " "
-                  zetta-current-prefix))))
+         :center nil
+         :right '(zetta-tab-bar-svg--mu4e))
+   ;; line 3 -- Spotify left; calendar centre; space-tree (+battery/prefix) right
+   (list :left '(zetta-tab-bar-svg--spotify)
+         :center nil
+         :right '(zetta-tab-bar-svg--battery " "
+                  zetta-current-prefix "  "
+                  zetta-tab-bar-svg--workspace))))
+
+(defun zetta-tab-bar-calendar ()
+  "Calendar glyph + weekday/day/month/year, for the SVG tab bar's last row."
+  (concat (and (featurep 'nerd-icons)
+               (ignore-errors (concat (nerd-icons-mdicon "nf-md-calendar_month") " ")))
+          (format-time-string "%a  %d %b %Y")))
+
+(defcustom zetta-tab-bar-calendar-color "#9aa0aa"
+  "Gray colour for the tab-bar clock and the minimalist date widget (kept uniform)."
+  :type 'color :group 'zetta)
+
+(defconst zetta-tab-bar--moon-glyph-names
+  ["nf-md-moon_new" "nf-md-moon_waxing_crescent" "nf-md-moon_first_quarter"
+   "nf-md-moon_waxing_gibbous" "nf-md-moon_full" "nf-md-moon_waning_gibbous"
+   "nf-md-moon_last_quarter" "nf-md-moon_waning_crescent"]
+  "Nerd Font moon glyphs indexed by lunar octant (0=new, 4=full).")
+
+(defun zetta-tab-bar--moon-octant ()
+  "Return the current lunar octant 0-7 (0=new, 2=first quarter, 4=full, 6=last).
+Phase age is days since the 2000-01-06 18:14 UTC new moon, modulo the mean
+synodic month (29.530588853 d), rounded to the nearest eighth."
+  (let* ((synodic 29.530588853)
+         (ref 947182440.0)                       ; 2000-01-06 18:14 UTC, epoch seconds
+         (days (/ (- (float-time) ref) 86400.0))
+         (cycles (/ days synodic))
+         (frac (- cycles (floor cycles))))
+    (mod (round (* frac 8)) 8)))
+
+(defun zetta-tab-bar--moon-glyph ()
+  "Raw (unpropertized) Nerd Font glyph for the current moon phase, or nil."
+  (when (require 'nerd-icons nil t)
+    (let ((g (ignore-errors
+               (nerd-icons-mdicon
+                (aref zetta-tab-bar--moon-glyph-names (zetta-tab-bar--moon-octant))))))
+      (and g (substring-no-properties g)))))
+
+(defun zetta-tab-bar-calendar--build ()
+  "Build the minimalist date widget as an svg.el DOM (spliced as vectors, sharp):
+an outlined weekday badge + an outlined date box (small month over big day) +
+the current moon-phase glyph, monochrome in `zetta-tab-bar-calendar-color'."
+  (let* ((col zetta-tab-bar-calendar-color)
+         (h 30) (gap (round (* h 0.24))) (wd-w (round (* h 1.05))) (pw (round (* h 0.98)))
+         (rx (max 2 (round (* h 0.16))))
+         ;; vertical inset so the outline stroke isn't clipped at the bar edge
+         (vm 2) (bh (- h (* 2 vm)))
+         (svg (svg-create 600 h)) (x 0))
+    ;; weekday -- outlined
+    (svg-rectangle svg x vm wd-w bh :rx rx :fill "none" :stroke col :stroke-width 1.5)
+    (svg-text svg (upcase (format-time-string "%a")) :x (+ x (/ wd-w 2)) :y (round (* h 0.69))
+              :text-anchor "middle" :font-family "Helvetica" :font-size (round (* h 0.46)) :font-weight "bold" :fill col)
+    (setq x (+ x wd-w gap))
+    ;; date -- outlined box, small month over big day
+    (svg-rectangle svg x vm pw bh :rx rx :fill "none" :stroke col :stroke-width 1.5)
+    (svg-text svg (upcase (format-time-string "%b")) :x (+ x (/ pw 2)) :y (round (* h 0.36))
+              :text-anchor "middle" :font-family "Helvetica" :font-size (round (* h 0.27)) :font-weight "bold" :fill col)
+    (svg-text svg (format-time-string "%-d") :x (+ x (/ pw 2)) :y (round (* h 0.88))
+              :text-anchor "middle" :font-family "Helvetica" :font-size (round (* h 0.5)) :font-weight "bold" :fill col)
+    (setq x (+ x pw))
+    ;; moon phase -- nerd-font glyph to the right of the date box
+    (let ((moon (zetta-tab-bar--moon-glyph)))
+      (when moon
+        (setq x (+ x gap))
+        (svg-text svg moon :x (+ x (round (* h 0.34))) :y (round (* h 0.74))
+                  :text-anchor "middle" :font-family "Terminess Nerd Font Mono"
+                  :font-size (round (* h 0.78)) :fill col)
+        (setq x (+ x (round (* h 0.68))))))
+    (dom-set-attribute svg 'width (number-to-string x))
+    svg))
+
+(defvar zetta-tab-bar-calendar--cache nil
+  "Cons of (DAY-KEY . SVG-DOM) so the date widget is rebuilt at most once a day.")
+(defun zetta-tab-bar-calendar-image ()
+  "The date-widget SVG DOM, rebuilt only when the day changes."
+  (let ((key (format-time-string "%Y%m%d")))
+    (if (equal (car zetta-tab-bar-calendar--cache) key)
+        (cdr zetta-tab-bar-calendar--cache)
+      (cdr (setq zetta-tab-bar-calendar--cache (cons key (zetta-tab-bar-calendar--build)))))))
+
+;;; ------------------------------------------------------------------
+;;; Sunrise / sunset (flanking the clock on the first row).  Needs a
+;;; location for `solar-sunrise-sunset'; set it here (only when unset, so
+;;; an explicit setting elsewhere wins) so the feature works at startup.
+;;; ------------------------------------------------------------------
+(with-eval-after-load 'solar
+  (unless (numberp (bound-and-true-p calendar-latitude))
+    (setq calendar-latitude 39.95
+          calendar-longitude -75.17
+          calendar-location-name "Philadelphia, PA"
+          calendar-time-zone -300
+          calendar-standard-time-zone-name "EST"
+          calendar-daylight-time-zone-name "EDT")))
+
+(defun zetta-tab-bar--fmt-suntime (decimal)
+  "Format DECIMAL hours (0-24) as a 24-hour \"HH:MM\" string."
+  (let* ((h24 (floor decimal))
+         (m (round (* 60 (- decimal h24)))))
+    (when (= m 60) (setq m 0 h24 (1+ h24)))
+    (format "%02d:%02d" (mod h24 24) m)))
+
+(defun zetta-tab-bar--compute-sun ()
+  "Compute ((SUNRISE . GLYPH) . (SUNSET . GLYPH)) for the clock flank.
+Returns nil if `solar'/`nerd-icons' or a location is unavailable."
+  (when (and (require 'solar nil t) (require 'nerd-icons nil t)
+             (numberp (bound-and-true-p calendar-latitude))
+             (numberp (bound-and-true-p calendar-longitude)))
+    (let* ((ss (ignore-errors (solar-sunrise-sunset (calendar-current-date))))
+           (rise (car ss)) (set (cadr ss))
+           (rise-s (and (numberp (car rise)) (zetta-tab-bar--fmt-suntime (car rise))))
+           (set-s  (and (numberp (car set))  (zetta-tab-bar--fmt-suntime (car set))))
+           (gr (ignore-errors (substring-no-properties (nerd-icons-wicon "nf-weather-sunrise"))))
+           (gs (ignore-errors (substring-no-properties (nerd-icons-wicon "nf-weather-sunset")))))
+      ;; Each side is (TIME . GLYPH); the `:flank' span draws the glyph nearest
+      ;; the clock at a larger size and the time on its outer side.
+      (cons (and rise-s gr (cons rise-s gr))
+            (and set-s gs (cons set-s gs))))))
+
+(defvar zetta-tab-bar--sun-cache nil
+  "Cons of (DAY-KEY . (LEFT . RIGHT)) so sunrise/sunset compute once a day.")
+(defun zetta-tab-bar--sun-strings ()
+  "The (LEFT . RIGHT) sunrise/sunset flank strings, recomputed once a day."
+  (let ((key (format-time-string "%Y%m%d")))
+    (if (equal (car zetta-tab-bar--sun-cache) key)
+        (cdr zetta-tab-bar--sun-cache)
+      (cdr (setq zetta-tab-bar--sun-cache (cons key (zetta-tab-bar--compute-sun)))))))
+
+(defun zetta-tab-bar-svg-spans ()
+  "Analog clock spanning lines 1-2 (centre), sunrise/sunset flanking it on the
+first row; the date widget (with moon phase) below, on the last row."
+  (let* ((gray zetta-tab-bar-calendar-color)
+         (cal (zetta-tab-bar-calendar-image))
+         (sun (zetta-tab-bar--sun-strings)))
+    (append
+     (list (list :clock '(0 . 1) gray gray))
+     (and sun (or (car sun) (cdr sun))
+          (list (list :flank '(0 . 1) (car sun) (cdr sun) gray)))
+     (and cal (list (list :image '(2 . 2) cal 'center))))))
+
+(defvar zetta-tab-bar-svg--clock-timer nil
+  "Periodic timer that re-renders the SVG tab bar so the analog clock ticks.")
+(unless zetta-tab-bar-svg--clock-timer
+  (setq zetta-tab-bar-svg--clock-timer
+        (run-at-time t 30 (lambda ()
+                            (when (and (fboundp 'zetta-tab-bar-using-svg-p)
+                                       (zetta-tab-bar-using-svg-p))
+                              (force-mode-line-update t))))))
 
 (svg-line-define 'zetta-tab-bar
                  :target 'tab-bar
                  :layout 'lines
                  :width 'frame
                  :content #'zetta-tab-bar-svg-lines
+                 :spans #'zetta-tab-bar-svg-spans
                  :font (lambda () zetta-svg-line-font)
                  :font-size (lambda () zetta-tab-bar-svg-font-size)
                  :line-pad (lambda () zetta-tab-bar-svg-line-pad)

--- a/modules/ui/tab-line-svg.el
+++ b/modules/ui/tab-line-svg.el
@@ -71,40 +71,22 @@ Lastly, if no tabs are left in the window, it is deleted with the `delete-window
                    (ignore-errors (delete-window window)))))))
       (force-mode-line-update)))
 
-  (defvar ct/circle-numbers-alist
-    '(
-      ;;(0 . "⓪")
-      ;;(1 . "①")
-      ;;(2 . "②")
-      ;;(3 . "③")
-      ;;(4 . "④")
-      ;;(5 . "⑤")
-      ;;(6 . "⑥")
-      ;;(7 . "⑦")
-      ;;(8 . "⑧")
-      ;;(9 . "⑨")
-      (0 . "0")
-      (1 . "1")
-      (2 . "2")
-      (3 . "3")
-      (4 . "4")
-      (5 . "5")
-      (6 . "6")
-      (7 . "7")
-      (8 . "8")
-      (9 . "9")
-      (10 . "10")
-      (11 . "11")
-      (12 . "12")
-      (13 . "13")
-      (14 . "14")
-      (15 . "15")
-      (16 . "16")
-      (17 . "17")
-      (18 . "18")
-      (19 . "19")
-      )
-    "Alist of integers to strings of circled unicode numbers.")
+  (defun ct/circle-number (n)
+    "Return a Nerd Font circled-number glyph for tab index N (1-based).
+1-9 use `nf-md-numeric_N_circle'; 10 uses `nf-md-numeric_10_circle';
+anything higher falls back to `nf-md-numeric_9_plus_circle'.  The glyph is
+re-faced to \"Terminess Nerd Font Mono\" (installed) rather than nerd-icons'
+default \"Symbols Nerd Font Mono\" (NOT installed here) so it renders in the
+plain-text tab line instead of tofu.  Trailing space keeps it off the icon."
+    (when (require 'nerd-icons nil t)
+      (let ((glyph (cond ((<= 1 n 9)
+                          (nerd-icons-mdicon (format "nf-md-numeric_%d_circle" n)))
+                         ((= n 10) (nerd-icons-mdicon "nf-md-numeric_10_circle"))
+                         (t (nerd-icons-mdicon "nf-md-numeric_9_plus_circle")))))
+        (when glyph
+          (concat (propertize (substring-no-properties glyph)
+                              'face '(:family "Terminess Nerd Font Mono"))
+                  " ")))))
 
   (defun zetta-tab-line-tab-name-buffer (buffer &optional _buffers)
     (let* ((buffer-name (buffer-name buffer))
@@ -121,7 +103,7 @@ Lastly, if no tabs are left in the window, it is deleted with the `delete-window
            (icon (cond (fname (all-the-icons-icon-for-file fname))
                        (t (all-the-icons-icon-for-mode (with-current-buffer buffer major-mode))))))
       (concat
-       (alist-get (+ 1 (cl-position buffer (funcall tab-line-tabs-function))) ct/circle-numbers-alist)
+       (ct/circle-number (+ 1 (cl-position buffer (funcall tab-line-tabs-function))))
        icon
        (propertize (if fname
                        ;; the file name including the suffix
@@ -134,18 +116,6 @@ Lastly, if no tabs are left in the window, it is deleted with the `delete-window
 
   (setq tab-line-tabs-function 'tab-line-tabs-window-buffers)
 
-  ;;:brushup
-  ;; NOTE This achieves the desired effect of having all tabs be
-  ;; rendered simply in white, and then to have the active tab only
-  ;; rendered with highlighting and also an underline and bold weight
-  ;; for ease of reading, basically. This fits into the higher level
-  ;; styling scheme of having minimum viable visual components on the
-  ;; screen, but the tabline still provides some indication of
-  ;; separation between inactive windows that are stacked vertically
-  ;; or horizontally. active tabs in other windows are underlined to
-  ;; preserve that visual of which is the actual buffer being
-  ;; displayed and this also enhances separation between vertically
-  ;; stacked windows
   (add-to-list
    'brushup-styles
    '(progn


### PR DESCRIPTION
## Summary
SVG status-bar work driven by the dev `svg-line` engine (spans), plus a HyWiki toggle.

**Tab bar**
- Sunrise/sunset times flanking the analog clock (`solar`, location = Philadelphia, guarded so an explicit setting wins), 24h, with `nf-weather` glyphs drawn larger than the time.
- Moon-phase glyph in the date widget (8 `nf-md-moon_*` phases from days-since-new-moon mod the synodic month).
- Modal/thing-at-point moved up beside the clock; Spotify moved down beside the date.

**Tab line**
- Tab indices as `nf-md-numeric_*_circle` glyphs, re-faced to the installed **Terminess Nerd Font Mono** (nerd-icons' default *Symbols Nerd Font Mono* isn't installed and would tofu in the plain-text tab line).

**Mode line**
- ace/modal/battery/buffer-name/point styling + a progress-pie span.

**Hyperbole**
- Enable `hywiki-mode` so WikiWords highlight.

## Notes
- The clock/sun/moon/pie rely on dev-only `svg-line` span features (`:clock`, `:flank`, `:image`, `:pie`); the published engine ignores those tokens with no error, so the config loads cleanly either way.