### PR TITLE
feat(keycast,vertico): accurate command reporting for embark/repeatable chains

### DIFF
--- a/modules/completion/embark.el
+++ b/modules/completion/embark.el
@@ -82,12 +82,31 @@ completing-read prompter."
   (add-to-list 'embark-keymap-alist '(project embark-project-map))
 
   ;; find file
-  (defun embark-consult-project-find-in-dir (dir)
-    (let ((default-directory dir)
-          ;; to disable preview -- this is bc consult uses 'this
-          ;; command' to determine what the active preview function is
-          (this-command 'consult-project-extra-find))
+  (defvar zetta-embark-project-find-dir nil
+    "Project directory last acted on with `embark-consult-project-find-in-dir'.")
+
+  (defun zetta-embark-project-find ()
+    "Run `consult-project-extra-find' in `zetta-embark-project-find-dir'.
+A real command (not just a `this-command' alias) so the minibuffer
+session is recorded by `vertico-repeat' under a name that, when
+resumed, restores the project directory it was acting on."
+    (interactive)
+    (let ((default-directory (or zetta-embark-project-find-dir
+                                 default-directory)))
       (call-interactively 'consult-project-extra-find)))
+
+  ;; Same on-demand preview as consult-project-extra-find (consult looks
+  ;; up customizations by `this-command', which is this symbol here).
+  (with-eval-after-load 'consult
+    (consult-customize zetta-embark-project-find :preview-key "C-="))
+
+  (defun embark-consult-project-find-in-dir (dir)
+    (setq zetta-embark-project-find-dir dir)
+    ;; `call-interactively' does not set `this-command'; bind it so both
+    ;; consult's preview lookup and `vertico-repeat-save' see the
+    ;; resumable command rather than `embark-act'.
+    (let ((this-command 'zetta-embark-project-find))
+      (call-interactively 'zetta-embark-project-find)))
 
   ;; vc dir
   (defun embark-vc-dir (dir)

--- a/modules/completion/embark.el
+++ b/modules/completion/embark.el
@@ -82,11 +82,32 @@ completing-read prompter."
   ;; file/URL/symbol a command just mentioned.  `embark--end-of-target'
   ;; (a default pre-action hook) is neutralised so the action does not
   ;; move point inside *Messages*.
+  ;;
+  ;; Noise lines are skipped: every C-g logs "Quit" (so bailing out of
+  ;; one attempt would make "Quit" the next attempt's target), and
+  ;; embark's own minimal indicator logs its "Act on ..." prompt.
+  (defvar zetta-embark-last-message-noise
+    (rx bos (or "" "Quit" "Mark set" "Mark saved" "Mark activated"
+                "Mark deactivated"
+                (seq "Act on " (* nonl)))
+        eos)
+    "Regexp for *Messages* lines `embark-on-last-message' skips over.")
+
   (defun embark-on-last-message (arg)
-    "Act on the last message displayed in the echo area."
+    "Act on the last substantive message displayed in the echo area.
+Trailing lines matching `zetta-embark-last-message-noise' are skipped."
     (interactive "P")
     (with-current-buffer "*Messages*"
-      (goto-char (1- (point-max)))
+      (goto-char (point-max))
+      (skip-chars-backward "\n")
+      (while (string-match-p
+              zetta-embark-last-message-noise
+              (buffer-substring-no-properties
+               (line-beginning-position) (line-end-position)))
+        (when (<= (line-beginning-position) (point-min))
+          (user-error "No substantive message to act on"))
+        (forward-line -1))
+      (end-of-line)
       (cl-letf (((symbol-function #'embark--end-of-target) #'ignore))
         (embark-act arg))))
 

--- a/modules/completion/embark.el
+++ b/modules/completion/embark.el
@@ -77,6 +77,19 @@ completing-read prompter."
                     latex-environment latex-fragment))
       (cl-pushnew type embark-org--types)))
 
+  ;; Act on the last echo-area message (from oantolin's config): jump to
+  ;; the end of *Messages* and act on whatever target is there -- the
+  ;; file/URL/symbol a command just mentioned.  `embark--end-of-target'
+  ;; (a default pre-action hook) is neutralised so the action does not
+  ;; move point inside *Messages*.
+  (defun embark-on-last-message (arg)
+    "Act on the last message displayed in the echo area."
+    (interactive "P")
+    (with-current-buffer "*Messages*"
+      (goto-char (1- (point-max)))
+      (cl-letf (((symbol-function #'embark--end-of-target) #'ignore))
+        (embark-act arg))))
+
   ;; project
   (defvar-keymap embark-project-map :parent embark-general-map)
   (add-to-list 'embark-keymap-alist '(project embark-project-map))
@@ -149,6 +162,7 @@ resumed, restores the project directory it was acting on."
    :keymaps (append zetta-modal-states-non-insert '(override))
    "C-." 'embark-act
    "C-h B" 'embark-bindings
+   "C-h E" 'embark-on-last-message
    "C-;" 'embark-dwim
    "C->" 'embark-act-all)
   (
@@ -171,6 +185,7 @@ resumed, restores the project directory it was acting on."
                 evil-visual-state-map)
      "C-."   'embark-act
      "C-h B" 'embark-bindings
+     "C-h E" 'embark-on-last-message
      "C-;"   'embark-dwim
      "C->"   'embark-act-all)))
 

--- a/modules/completion/vertico.el
+++ b/modules/completion/vertico.el
@@ -67,7 +67,30 @@
                     (intern (substring name (length "repeatable-wrap-")))))))
       session)
     (add-to-list 'vertico-repeat-transformers
-                 #'zetta-vertico-repeat-unwrap-repeatable t))
+                 #'zetta-vertico-repeat-unwrap-repeatable t)
+
+    ;; `vertico-repeat--filter-empty' drops sessions with no input, so a
+    ;; C-g straight out of a minibuffer leaves nothing to resume.  For
+    ;; context-carrying commands the context IS the point of resuming --
+    ;; `zetta-embark-project-find' remembers which project it was acting
+    ;; on -- so spare those from the empty filter.
+    (defvar zetta-vertico-repeat-keep-empty '(zetta-embark-project-find)
+      "Commands whose vertico-repeat sessions are saved even with empty input.")
+
+    (defun zetta-vertico-repeat--filter-empty (session)
+      "Like `vertico-repeat--filter-empty', sparing context-carrying commands.
+SESSION is kept regardless of input if its command is listed in
+`zetta-vertico-repeat-keep-empty'."
+      (if (memq (car session) zetta-vertico-repeat-keep-empty)
+          session
+        (vertico-repeat--filter-empty session)))
+
+    (setq vertico-repeat-transformers
+          (mapcar (lambda (f)
+                    (if (eq f #'vertico-repeat--filter-empty)
+                        #'zetta-vertico-repeat--filter-empty
+                      f))
+                  vertico-repeat-transformers)))
 
   ;; this is super super hacky and bizarre... but it's the only way I
   ;; can get this to work

--- a/modules/completion/vertico.el
+++ b/modules/completion/vertico.el
@@ -43,6 +43,32 @@
                                    (side . right)
                                    (window-width . 0.25)))
 
+  ;;;; vertico-repeat hygiene
+  ;; Embark's completing-read action prompter runs inside `embark-act',
+  ;; so its minibuffer session is recorded under `embark-act' -- and
+  ;; repeating that re-runs embark-act with no target ("No target
+  ;; found") instead of anything useful.  Keep those sessions out of
+  ;; the history entirely.
+  (with-eval-after-load 'vertico-repeat
+    (dolist (cmd '(embark-act embark-act-noquit embark-act-all
+                   embark-dwim embark-become))
+      (cl-pushnew cmd vertico-repeat-filter))
+
+    ;; A `repeatable-wrap-FOO' wrapper leaves `this-command' as the
+    ;; wrapper when FOO's minibuffer is set up, so the session would
+    ;; repeat the wrapper -- re-entering the repeat loop.  Record it
+    ;; as plain FOO so `vertico-repeat' resumes the command itself.
+    (defun zetta-vertico-repeat-unwrap-repeatable (session)
+      "Record a `repeatable-wrap-FOO' SESSION as plain FOO."
+      (when session
+        (let ((name (symbol-name (car session))))
+          (when (string-prefix-p "repeatable-wrap-" name)
+            (setcar session
+                    (intern (substring name (length "repeatable-wrap-")))))))
+      session)
+    (add-to-list 'vertico-repeat-transformers
+                 #'zetta-vertico-repeat-unwrap-repeatable t))
+
   ;; this is super super hacky and bizarre... but it's the only way I
   ;; can get this to work
 

--- a/modules/ui/keycast.el
+++ b/modules/ui/keycast.el
@@ -38,6 +38,26 @@
   ;;
   ;; All advice is installed only after repeatable loads.
 
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ;;                     embark integration                            ;;
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ;;
+  ;; `embark-act' runs the selected action within its own command-loop
+  ;; turn.  For single-target command actions embark itself sets
+  ;; `this-command' to the action (embark--act), so keycast's
+  ;; post-command update names the action.  But actions in
+  ;; `embark-multitarget-actions' (e.g. `embark-copy-as-kill') run via
+  ;; `funcall' on that path and `this-command' is left as `embark-act' --
+  ;; which is what keycast then shows.  Stamp `this-command' after every
+  ;; normally-completed action so the action is reported instead.  (On
+  ;; the quit-minibuffer path `embark--act' exits non-locally and the
+  ;; :after advice does not run, same as embark's own stamping.)
+
+  (with-eval-after-load 'embark
+    (define-advice embark--act (:after (action &rest _) zetta-keycast-action)
+      (when (and (bound-and-true-p zetta-keycast-mode) (symbolp action))
+        (setq this-command action))))
+
   (with-eval-after-load 'repeatable
     (defvar zetta-keycast--in-repeatable nil)
 

--- a/modules/ui/keycast.el
+++ b/modules/ui/keycast.el
@@ -63,24 +63,43 @@
 
     (define-advice call-interactively
         (:around (fn cmd &rest args) zetta-keycast-repeatable)
-      (let ((zetta-keycast--in-repeatable
-             (or zetta-keycast--in-repeatable
-                 (and (symbolp cmd)
-                      (string-prefix-p "repeatable-wrap" (symbol-name cmd))))))
+      (let* ((wrapper (and (symbolp cmd)
+                           (string-prefix-p "repeatable-wrap" (symbol-name cmd))))
+             (zetta-keycast--in-repeatable
+              (or zetta-keycast--in-repeatable wrapper)))
+        ;; Show the wrapped command as soon as the wrapper STARTS.  The
+        ;; post-return update below only fires after the inner command
+        ;; finishes -- for a minibuffer command that is after the whole
+        ;; minibuffer interaction, so without this keycast keeps showing
+        ;; whatever ran before the wrapper was invoked.
+        (when (and wrapper (bound-and-true-p zetta-keycast-mode))
+          (setq keycast--this-command-desc
+                (intern (string-remove-prefix "repeatable-wrap-"
+                                              (symbol-name cmd)))
+                keycast--this-command-keys (this-single-command-keys)
+                keycast--command-repetitions 0)
+          (force-mode-line-update t))
         (prog1 (apply fn cmd args)
           (when (and zetta-keycast--in-repeatable
                      (bound-and-true-p zetta-keycast-mode)
                      (symbolp cmd)
-                     (not (string-prefix-p "repeatable-wrap" (symbol-name cmd))))
+                     (not wrapper))
             (setq keycast--this-command-desc cmd
                   keycast--this-command-keys (this-single-command-keys)
                   keycast--command-repetitions 0)
             (force-mode-line-update t)))))
 
+    (defvar zetta-keycast-ignored-commands '(file-notify-handle-event)
+      "Commands whose post-command updates keycast should ignore.
+These arrive as (special) events outside the user's typing -- e.g.
+file watchers firing while a project minibuffer is open -- and would
+overwrite the genuinely last-typed command in the display.")
+
     (define-advice keycast--update
         (:around (fn) zetta-skip-repeatable-wrappers)
-      (if (and (symbolp this-command)
-               (string-prefix-p "repeatable-wrap" (symbol-name this-command)))
+      (if (or (memq this-command zetta-keycast-ignored-commands)
+              (and (symbolp this-command)
+                   (string-prefix-p "repeatable-wrap" (symbol-name this-command))))
           (force-mode-line-update t)
         (funcall fn)))
 


### PR DESCRIPTION
## Summary

Makes keycast and vertico-repeat report the *real* command across embark and repeatable chains.

### 1. keycast: embark actions instead of `embark-act`

`embark--act` stamps `this-command` with the action for single-target command actions, but actions in `embark-multitarget-actions` (`embark-copy-as-kill`, `embark-insert`, consult/citar actions) and non-command actions run through a `funcall` path that skips the stamp. An `:after` advice on `embark--act` stamps it on every normally-completed action, so `C-. w` echoes `embark-copy-as-kill`.

### 2. vertico-repeat: stop recording useless `embark-act` sessions

Embark's completing-read action prompter runs inside `embark-act`, so its minibuffer session was recorded under `embark-act` — repeating it re-runs `embark-act` with no target ("No target found"). Those sessions (`embark-act/-noquit/-all/-dwim/-become`) are now filtered via `vertico-repeat-filter`. Additionally, `repeatable-wrap-FOO` sessions are recorded as plain `FOO` (a `vertico-repeat-transformers` entry), so resuming runs the command directly instead of re-entering the repeat loop.

### 3. embark project-find action: actually resumable

`embark-consult-project-find-in-dir` (the `f` action on project targets) now stamps a real command — `zetta-embark-project-find` — that remembers the project directory. The find-file minibuffer session is recorded under that name, so `vertico-repeat` re-runs it **in the same project**. Keeps the same on-demand preview key (`C-=`) via `consult-customize`.

### 4. keycast: repeatable wrappers + file-notify noise

Invoking `repeatable-wrap-FOO` now displays `FOO` immediately (previously nothing updated until the inner command returned — for minibuffer commands that's after the whole interaction, so keycast kept showing the previous command). And `file-notify-handle-event` (file watchers firing while a project minibuffer is open) no longer overwrites the display.

## Testing

All verified live in the running daemon:
- post-command probe of the `C-. w` flow: keycast's conclusion changed from `embark-act` to `embark-copy-as-kill`
- `vertico-repeat-filter`/transformer active; existing history cleaned (embark-act sessions removed, wrapper sessions unwrapped)
- invoking a `repeatable-wrap-*` test command immediately displayed the unwrapped name
- a synthetic `file-notify-handle-event` update left the display untouched

### 5. `embark-on-last-message` (`C-h E`)

From [oantolin's config](https://github.com/oantolin/emacs-config/blob/5b25b8a/init.el#L580): jump to the end of `*Messages*` and `embark-act` there — act on the file/URL/symbol the last echo-area message mentioned. Bound beside `C-h B` in both the modal-state/override block and the evil re-bind block. Verified live: a message ending in a target + `C-h E w` copies that target.
