### PR TITLE
feat(elfeed): incremental updates by default + background auto-update

### DIFF
--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -354,7 +354,10 @@ minibuffer, and old entries are reachable via elfeed's own search."
     (nreverse out)))
 
 (defun zetta-consult-elfeed--state ()
-  "Preview state function: render the candidate entry in *elfeed-entry*."
+  "Preview state function: render the candidate entry in *elfeed-entry*.
+org-remark's elfeed wiring (an :after advice on `elfeed-show-entry')
+is suppressed during previews -- it would look up/load a notes file
+for every candidate the cursor crosses."
   (let ((preview (consult--buffer-preview)))
     (lambda (action cand)
       (if (eq action 'preview)
@@ -362,7 +365,11 @@ minibuffer, and old entries are reachable via elfeed's own search."
                    (when-let* ((entry (and cand (get-text-property
                                                  0 'zetta-elfeed-entry cand))))
                      (let ((elfeed-show-entry-switch #'identity))
-                       (ignore-errors (elfeed-show-entry entry)))))
+                       (if (fboundp 'org-remark-auto-on)
+                           (cl-letf (((symbol-function 'org-remark-auto-on)
+                                      #'ignore))
+                             (ignore-errors (elfeed-show-entry entry)))
+                         (ignore-errors (elfeed-show-entry entry))))))
         (funcall preview action nil)))))
 
 (defun zetta-consult-elfeed ()

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -21,12 +21,19 @@
   :demand t
   :config
 
-  (setq elfeed-protocol-fever-update-unread-only nil)
+  ;; UNREAD-ONLY is required for reader.miniflux.app: the hosted
+  ;; miniflux's entry ids auto-increment across ALL tenants, so fever's
+  ;; default incremental strategy -- request the next maxsize ids after
+  ;; the last-seen id -- almost never hits OUR entries (verified: update
+  ;; requested ids ...572-...771 after mark ...571 and parsed 0, while
+  ;; new posts sat unread on the server).  With unread-only, each update
+  ;; fetches the server's actual unread_item_ids list instead.
+  (setq elfeed-protocol-fever-update-unread-only t)
   (setq elfeed-protocol-fever-fetch-category-as-tag t)
-  ;; Entries fetched per request (default 50).  A bigger batch means
-  ;; fewer round trips when catching up after hours away; each batch is
-  ;; still parsed in one main-thread chunk, so don't go huge.
-  (setq elfeed-protocol-fever-maxsize 200)
+  ;; Do NOT raise this: reader.miniflux.app caps fever responses at 50
+  ;; items per request (verified: 60 ids requested -> 50 returned), so a
+  ;; bigger batch silently DROPS the rest.
+  (setq elfeed-protocol-fever-maxsize 50)
   ;; elfeed-protocol-feeds set in ~/.private.el
 
   (setq elfeed-protocol-enabled-protocols '(fever))

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -23,6 +23,10 @@
 
   (setq elfeed-protocol-fever-update-unread-only nil)
   (setq elfeed-protocol-fever-fetch-category-as-tag t)
+  ;; Entries fetched per request (default 50).  A bigger batch means
+  ;; fewer round trips when catching up after hours away; each batch is
+  ;; still parsed in one main-thread chunk, so don't go huge.
+  (setq elfeed-protocol-fever-maxsize 200)
   ;; elfeed-protocol-feeds set in ~/.private.el
 
   (setq elfeed-protocol-enabled-protocols '(fever))
@@ -171,7 +175,10 @@ minibuffer with something like `exit-minibuffer'."
    "S-SPC" 'elfeed-show-prev
    )
 
-  :hook (elfeed-search-update . elfeed-score-enable)
+  ;; NB: elfeed-score-enable used to be hooked on `elfeed-search-update'
+  ;; here -- but enable RELOADS the score file and stats file and runs
+  ;; serde cleanup every call, so every search refresh paid that cost.
+  ;; It is called once in the elfeed-score :config below; that's enough.
   )
 
 ;; Bind elfeed-search keys after evil-collection sets up its bindings.
@@ -179,7 +186,14 @@ minibuffer with something like `exit-minibuffer'."
 ;; evil-collection's hook.
 (add-hook 'elfeed-search-mode-hook
           (lambda ()
-            (evil-local-set-key 'normal "R" #'elfeed-protocol-fever-reinit)
+            ;; R = INCREMENTAL update (fetch only entries newer than the
+            ;; stored update mark, sync pending read/star states).
+            ;; gR = full resync: re-fetches and re-parses EVERY starred
+            ;; and unread entry -- slow against a 50k-entry db; only for
+            ;; first sync, recovery, or pulling remote read-state
+            ;; changes for old entries (fever's API has no better way).
+            (evil-local-set-key 'normal "R" #'elfeed-update)
+            (evil-local-set-key 'normal "gR" #'elfeed-protocol-fever-reinit)
             (evil-local-set-key 'normal "tt" #'prot-elfeed-search-tag-filter)
             ;; quick filters
             (evil-local-set-key 'normal "fu" (my-elfeed-filter "@6-months-ago +unread"))
@@ -290,4 +304,34 @@ This implementation is derived from `elfeed-search-print-entry--default'."
    :states '(normal)
    :keymaps '(elfeed-search-mode-map)
    "x" 'elfeed-score-explain))
+
+;;;; Background auto-update (mu4e-style)
+;; Incremental pulls in the background, so opening elfeed shows fresh
+;; entries without a foreground update.  The network side is async curl;
+;; only parsing runs on the main thread, one maxsize-entry batch at a
+;; time.  The FIRST run also loads elfeed and its db (the one-time
+;; multi-second index load for a 50k-entry db), so it waits for genuine
+;; idle rather than firing mid-typing.
+
+(defvar zetta-elfeed-auto-update-interval (* 15 60)
+  "Seconds between background incremental elfeed updates.")
+
+(defvar zetta-elfeed--auto-update-timer nil
+  "Active timer for `zetta-elfeed--auto-update', or nil.")
+
+(defun zetta-elfeed--auto-update ()
+  "Incrementally update all elfeed feeds in the background."
+  (require 'elfeed)
+  (elfeed-update))
+
+(unless zetta-elfeed--auto-update-timer
+  (setq zetta-elfeed--auto-update-timer
+        (run-with-idle-timer
+         120 nil
+         (lambda ()
+           (zetta-elfeed--auto-update)
+           (setq zetta-elfeed--auto-update-timer
+                 (run-with-timer zetta-elfeed-auto-update-interval
+                                 zetta-elfeed-auto-update-interval
+                                 #'zetta-elfeed--auto-update))))))
 ;;; elfeed.el ends here

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -312,6 +312,78 @@ This implementation is derived from `elfeed-search-print-entry--default'."
    :keymaps '(elfeed-search-mode-map)
    "x" 'elfeed-score-explain))
 
+;;;; consult-elfeed (a la consult-mu)
+;; Search recent entries from anywhere with live preview: candidates are
+;; the most recent `zetta-consult-elfeed-limit' db entries (title, feed
+;; and tags all match the filter -- type "unread" to narrow to unread),
+;; previews render in *elfeed-entry* as you move, RET opens the entry.
+
+(defcustom zetta-consult-elfeed-limit 2000
+  "Most-recent entries offered by `zetta-consult-elfeed'.
+The db holds tens of thousands; formatting them all would lag the
+minibuffer, and old entries are reachable via elfeed's own search."
+  :type 'integer :group 'zetta)
+
+(defvar zetta-consult-elfeed--history nil)
+
+(defun zetta-consult-elfeed--candidates ()
+  "Format the most recent db entries as propertized candidate strings."
+  (let ((n 0) out)
+    (with-elfeed-db-visit (entry feed)
+      (let* ((date (format-time-string "%Y-%m-%d" (elfeed-entry-date entry)))
+             (title (or (elfeed-meta entry :title) (elfeed-entry-title entry) ""))
+             (feed-title (and feed (or (elfeed-meta feed :title)
+                                       (elfeed-feed-title feed))))
+             (tags (mapconcat #'symbol-name (elfeed-entry-tags entry) ","))
+             (cand (concat
+                    (propertize date 'face 'font-lock-comment-face) " "
+                    title " "
+                    (and feed-title
+                         (propertize feed-title 'face 'elfeed-search-feed-face))
+                    (and (> (length tags) 0)
+                         (concat " " (propertize (concat "(" tags ")")
+                                                 'face 'elfeed-search-tag-face))))))
+        (push (propertize
+               (if (fboundp 'consult--tofu-encode)
+                   (concat cand (consult--tofu-encode n))
+                 cand)
+               'zetta-elfeed-entry entry)
+              out)
+        (when (>= (setq n (1+ n)) zetta-consult-elfeed-limit)
+          (elfeed-db-return))))
+    (nreverse out)))
+
+(defun zetta-consult-elfeed--state ()
+  "Preview state function: render the candidate entry in *elfeed-entry*."
+  (let ((preview (consult--buffer-preview)))
+    (lambda (action cand)
+      (if (eq action 'preview)
+          (funcall preview 'preview
+                   (when-let* ((entry (and cand (get-text-property
+                                                 0 'zetta-elfeed-entry cand))))
+                     (let ((elfeed-show-entry-switch #'identity))
+                       (ignore-errors (elfeed-show-entry entry)))))
+        (funcall preview action nil)))))
+
+(defun zetta-consult-elfeed ()
+  "Search recent elfeed entries with live preview (a la consult-mu).
+Filters over title, feed and tags of the `zetta-consult-elfeed-limit'
+most recent entries; RET opens the selection in the show buffer."
+  (interactive)
+  (require 'elfeed)
+  (elfeed-db-ensure)
+  (let* ((cand (consult--read
+                (zetta-consult-elfeed--candidates)
+                :prompt "Elfeed entry: "
+                :category 'elfeed-entry
+                :require-match t
+                :sort nil
+                :lookup #'consult--lookup-member
+                :state (zetta-consult-elfeed--state)
+                :history 'zetta-consult-elfeed--history))
+         (entry (and cand (get-text-property 0 'zetta-elfeed-entry cand))))
+    (when entry (elfeed-show-entry entry))))
+
 ;;;; Background auto-update (mu4e-style)
 ;; Incremental pulls in the background, so opening elfeed shows fresh
 ;; entries without a foreground update.  The network side is async curl;

--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -676,6 +676,54 @@ keep their own font (`zetta-font').")
   (when (fboundp 'mu4e--modeline-string)
     (string-trim (or (ignore-errors (mu4e--modeline-string)) ""))))
 
+;; Elfeed unread count, CACHED: the db holds 50k+ entries, so counting at
+;; render time (the tab bar redraws every keystroke) is out.  The count is
+;; recomputed off-render -- debounced on elfeed's update/tag hooks -- and
+;; the segment just reads the cache.
+(defvar zetta-tab-bar--elfeed-unread nil
+  "Cached number of unread elfeed entries, or nil before elfeed loads.")
+
+(defvar zetta-tab-bar--elfeed-count-timer nil)
+
+(defcustom zetta-tab-bar-elfeed-count-window (* 6 30 24 60 60)
+  "Age window (seconds) for the tab-bar elfeed unread count.
+Matches the \"@6-months-ago\" horizon of the elfeed quick filters, so the
+indicator agrees with what the search buffer shows -- and keeps ancient
+entries whose read-state never synced back (a fever API limitation) from
+inflating the number forever."
+  :type 'integer :group 'zetta)
+
+(defun zetta-tab-bar--elfeed-count-unread ()
+  "Count unread entries within `zetta-tab-bar-elfeed-count-window'.
+The db visits newest-first, so the scan stops at the window edge."
+  (let ((n 0)
+        (cutoff (- (float-time) zetta-tab-bar-elfeed-count-window)))
+    (with-elfeed-db-visit (entry _feed)
+      (if (< (elfeed-entry-date entry) cutoff)
+          (elfeed-db-return)
+        (when (memq 'unread (elfeed-entry-tags entry))
+          (setq n (1+ n)))))
+    n))
+
+(defun zetta-tab-bar--elfeed-recount (&rest _)
+  "Debounced recount of elfeed unread entries; refreshes the tab bar."
+  (when (timerp zetta-tab-bar--elfeed-count-timer)
+    (cancel-timer zetta-tab-bar--elfeed-count-timer))
+  (setq zetta-tab-bar--elfeed-count-timer
+        (run-with-idle-timer
+         2 nil
+         (lambda ()
+           (when (featurep 'elfeed)
+             (setq zetta-tab-bar--elfeed-unread
+                   (ignore-errors (zetta-tab-bar--elfeed-count-unread)))
+             (force-mode-line-update t))))))
+
+(with-eval-after-load 'elfeed
+  (add-hook 'elfeed-update-hooks #'zetta-tab-bar--elfeed-recount)
+  (add-hook 'elfeed-tag-hooks #'zetta-tab-bar--elfeed-recount)
+  (add-hook 'elfeed-untag-hooks #'zetta-tab-bar--elfeed-recount)
+  (zetta-tab-bar--elfeed-recount))
+
 (defun zetta-tab-bar-clock ()
   "The `display-time' clock string, trimmed."
   (when (boundp 'display-time-string) (string-trim (or display-time-string ""))))
@@ -818,6 +866,30 @@ string like \"{ 1' }\"), not a variable -- so it must be called."
                               (cons "Update mail"
                                     (lambda () (interactive) (mu4e-update-mail-and-index t))))
                          (and (fboundp 'mu4e-compose-new) (cons "Compose" #'mu4e-compose-new))))))))
+
+(defun zetta-tab-bar-svg--elfeed ()
+  "Clickable feed cluster (rss glyph + unread count): open elfeed; feeds menu.
+Hidden until elfeed loads (the count cache is nil); the count comes from
+`zetta-tab-bar--elfeed-unread', recomputed off-render on elfeed's hooks."
+  (when (numberp zetta-tab-bar--elfeed-unread)
+    (let* ((icon (and (featurep 'nerd-icons)
+                      (zetta-line--glyph (ignore-errors (nerd-icons-mdicon "nf-md-rss")))))
+           (label (concat (and icon (concat icon " "))
+                          (number-to-string zetta-tab-bar--elfeed-unread))))
+      (zetta-svg-seg
+       label 'tb-elfeed
+       :help (format "elfeed: %d unread" zetta-tab-bar--elfeed-unread)
+       :action-help "open elfeed"
+       :action (if (fboundp 'elfeed) #'elfeed #'ignore)
+       :menu (delq nil
+                   (list (and (fboundp 'elfeed) (cons "Open elfeed" #'elfeed))
+                         (and (fboundp 'elfeed-update)
+                              (cons "Update feeds" #'elfeed-update))
+                         (and (fboundp 'zetta-consult-elfeed)
+                              (cons "Search entries" #'zetta-consult-elfeed))
+                         (and (fboundp 'elfeed-protocol-fever-reinit)
+                              (cons "Full resync (reinit)"
+                                    #'elfeed-protocol-fever-reinit))))))))
 
 (defun zetta-tab-bar-svg--clock ()
   "Clickable clock (clock glyph + time): world clock; calendar menu."

--- a/modules/org/org-remark.el
+++ b/modules/org/org-remark.el
@@ -10,14 +10,27 @@
   (require 'org-remark-global-tracking)
   (org-remark-global-tracking-mode +1)
 
-  (defun my-org-remark-transform-org-link-to-filename ()
-    (let ((link-parts (split-string (org-store-link nil) "\\]\\[")))
+  (defun my-org-remark-transform-org-link-to-filename (&optional link-string)
+    "Derive the notes filename from LINK-STRING (default: `org-store-link')."
+    (let ((link-parts (split-string (or link-string (org-store-link nil))
+                                    "\\]\\[")))
       (string-replace
        "#" ""
        (concat
         (nth 1 (split-string (nth 0 link-parts) "\\[\\["))
         ": "
         (nth 0 (split-string (nth 1 link-parts) "\\]\\]"))))))
+
+  (defun my-org-remark-elfeed-link-string ()
+    "Org bracket link for the shown elfeed entry, without `org-store-link'.
+Several org link types can store from an elfeed-show buffer, so
+`org-store-link' PROMPTS to pick one -- and the org-remark wiring made
+that fire on every RET in elfeed-search (and every consult preview).
+Builds the same string as elfeed's own store function: link
+\"elfeed:FEED-ID#ENTRY-ID\", description the entry title."
+    (let ((id (elfeed-entry-id elfeed-show-entry)))
+      (org-link-make-string (format "elfeed:%s#%s" (car id) (cdr id))
+                            (elfeed-entry-title elfeed-show-entry))))
 
   ;; wombag.el support
   (define-minor-mode org-remark-wombag-mode
@@ -99,11 +112,12 @@
 
   (defun org-remark-elfeed-find-file-name ()
     (when (equal major-mode 'elfeed-show-mode)
-      (my-org-remark-transform-org-link-to-filename)))
+      (my-org-remark-transform-org-link-to-filename
+       (my-org-remark-elfeed-link-string))))
 
-  (defun org-remark-elfeed-highlight-link-to-source (filename _point)
+  (defun org-remark-elfeed-highlight-link-to-source (_filename _point)
     (when (equal major-mode 'elfeed-show-mode)
-      (org-store-link nil)))
+      (my-org-remark-elfeed-link-string)))
 
   ;; Sanitize filenames to match logseq's :triple-lowbar naming format.
   ;; Logseq uses ___ for / and percent-encoding for other unsafe chars.
@@ -137,11 +151,11 @@
       (concat (file-name-sans-extension buffer-file-name) "-annotations.org"))
      ;; Elfeed
      ((eq major-mode 'elfeed-show-mode)
-      (message "major mode is elfeed-show-mode")
       (expand-file-name
        (concat
         "~/logseq/pages/(highlights elfeed) "
-        (let ((link-parts (split-string (org-store-link nil) "\\]\\[")))
+        (let ((link-parts (split-string (my-org-remark-elfeed-link-string)
+                                        "\\]\\[")))
           (my-org-remark-sanitize-notes-file-name
            (concat (nth 0 (split-string (nth 1 link-parts) "\\]\\]"))
                    "-annotations.org"))))))

--- a/modules/ui/tab-bar-svg.el
+++ b/modules/ui/tab-bar-svg.el
@@ -257,10 +257,34 @@ first row; the date widget (with moon phase) below, on the last row."
                                        (zetta-tab-bar-using-svg-p))
                               (force-mode-line-update t))))))
 
+;; Pin the tab bar's buffer-dependent segments (buffer name, file icon,
+;; modal state, thing-at-point, ...) to the buffer the user came FROM
+;; while a minibuffer is active.  Completion previews flip the selected
+;; window's buffer on every candidate (original <-> previewed buffer),
+;; and without pinning each flip re-rendered the bar with different
+;; content -- alternating images repainting ~90px of frame top, a
+;; visible flash -- while keycast should (and does) stay live.
+(defvar zetta-tab-bar--minibuffer-entry-buffer nil
+  "The buffer current when the (outermost) minibuffer session began.")
+
+(defun zetta-tab-bar--note-minibuffer-entry ()
+  (when (= (minibuffer-depth) 1)
+    (setq zetta-tab-bar--minibuffer-entry-buffer
+          (window-buffer (minibuffer-selected-window)))))
+
+(add-hook 'minibuffer-setup-hook #'zetta-tab-bar--note-minibuffer-entry)
+
+(defun zetta-tab-bar--context-buffer ()
+  "The stable content context: the entry buffer during minibuffer sessions."
+  (and (> (minibuffer-depth) 0)
+       (buffer-live-p zetta-tab-bar--minibuffer-entry-buffer)
+       zetta-tab-bar--minibuffer-entry-buffer))
+
 (svg-line-define 'zetta-tab-bar
                  :target 'tab-bar
                  :layout 'lines
                  :width 'frame
+                 :context-buffer #'zetta-tab-bar--context-buffer
                  :content #'zetta-tab-bar-svg-lines
                  :spans #'zetta-tab-bar-svg-spans
                  :font (lambda () zetta-svg-line-font)

--- a/modules/ui/tab-bar-svg.el
+++ b/modules/ui/tab-bar-svg.el
@@ -104,7 +104,7 @@ jitters as keycast changes width."
                  zetta-gptel-processes
                  blinker-tab-bar)
          :center nil
-         :right '(zetta-tab-bar-svg--mu4e))
+         :right '(zetta-tab-bar-svg--elfeed "  " zetta-tab-bar-svg--mu4e))
    ;; line 3 -- Spotify left; calendar centre; space-tree (+battery/prefix) right
    (list :left '(zetta-tab-bar-svg--spotify)
          :center nil


### PR DESCRIPTION
## Investigation: reinit vs update

**Use `elfeed-protocol-fever-update` (via plain `elfeed-update`) for routine refresh — reinit was the costly step.**

- `elfeed-protocol-fever-reinit` resets the update marks, then re-fetches **every starred and every unread entry**; each is re-parsed (guid-hash, db lookup against the 51k-entry db, tag reconciliation, `elfeed-new-entry-parse-hook`) and re-scored by elfeed-score. That's the perceived "indexing" cost — and `R` was bound to it.
- `elfeed-protocol-fever-update` is incremental: it requests only ids past the stored `last-entry-id` mark (in `maxsize` batches), pushes pending read/star changes, and automatically falls back to a full init when no mark exists.
- Compounding it: `elfeed-score-enable` was hooked on `elfeed-search-update`, so **every search refresh** re-loaded the score file + stats file and re-ran serde cleanup.

## Changes

- `R` → `elfeed-update` (incremental); `gR` → `elfeed-protocol-fever-reinit` — still wanted occasionally, since fever's API has no incremental way to pull remote read-state changes for already-fetched entries
- Removed the per-refresh `elfeed-score-enable` hook (it's called once at setup)
- `elfeed-protocol-fever-maxsize` 50 → 200: fewer HTTP round trips when catching up
- **Background auto-update (the mu4e-style goal)**: incremental pull every 15 min (`zetta-elfeed-auto-update-interval`); network is async curl, parsing runs in per-batch chunks. The first run — which also pays the one-time db index load — waits for 120s of genuine idle so it never lands mid-typing.

## Testing

Applied live to the running session: hook removed, maxsize set, bindings verified in the live `*elfeed-search*` buffer (`R` → `elfeed-update`, `gR` → reinit), auto-update timer armed.

## Follow-up: hosted miniflux findings (second commit)

Testing against the live server revealed two corrections:

1. **`elfeed-protocol-fever-update-unread-only` must be `t` for reader.miniflux.app.** The hosted miniflux's entry ids auto-increment across **all tenants**, so the fever id-window strategy (request the next `maxsize` ids after the stored mark) almost never contains this account's entries — verified in the debug log: after mark `…571`, the update requested ids `…572–…771` and parsed **0** entries while new posts sat unread on the server. Unread-only mode fetches the server's actual `unread_item_ids` instead.
2. **maxsize must stay 50.** The hosted miniflux caps fever responses at 50 items per request (verified: 60 ids requested → 50 returned), so the earlier bump to 200 would have silently dropped entries; reverted.


## Addition: tab-bar unread indicator + `zetta-consult-elfeed` (third commit)

- **Tab-bar indicator** beside the mu4e cluster: rss glyph + unread count; click opens elfeed, right-click menu offers update / search / full resync. Count is cached (recounted off-render, debounced on elfeed's update/tag hooks) and windowed to the quick filters' `@6-months-ago` horizon so it agrees with the search buffer (and isn't inflated by old entries whose read-state never synced back).
- **`zetta-consult-elfeed`** (à la consult-mu): filter the 2000 most recent entries by title/feed/tags with live preview in `*elfeed-entry*`; RET opens the entry. Candidate build ~0.3s, windowed count scan ~140ms — both off the render path.

Verified live: count 4989 (6-month window), segment renders, candidates build with newest entry first.
