### PR TITLE
fix(elfeed): self-heal a half-loaded db in zetta-consult-elfeed

### DIFF
--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -326,6 +326,19 @@ minibuffer, and old entries are reachable via elfeed's own search."
 
 (defvar zetta-consult-elfeed--history nil)
 
+(defun zetta-elfeed--ensure-db ()
+  "Ensure the elfeed db is loaded AND its index is a usable avl-tree.
+`elfeed-db-ensure' only loads when `elfeed-db' is nil, so it cannot
+recover a db left half-loaded or with a clobbered global (index not an
+avl-tree) -- which makes `with-elfeed-db-visit' signal
+\"Wrong type argument: avl-tree-, nil\".  Force a fresh load from disk
+in that case so elfeed commands self-heal instead of erroring."
+  (require 'elfeed-db)
+  (elfeed-db-ensure)
+  (unless (avl-tree-p elfeed-db-index)
+    (setq elfeed-db nil)
+    (elfeed-db-load)))
+
 (defun zetta-consult-elfeed--candidates ()
   "Format the most recent db entries as propertized candidate strings."
   (let ((n 0) out)
@@ -378,7 +391,7 @@ Filters over title, feed and tags of the `zetta-consult-elfeed-limit'
 most recent entries; RET opens the selection in the show buffer."
   (interactive)
   (require 'elfeed)
-  (elfeed-db-ensure)
+  (zetta-elfeed--ensure-db)
   (let* ((cand (consult--read
                 (zetta-consult-elfeed--candidates)
                 :prompt "Elfeed entry: "


### PR DESCRIPTION
## Problem

`zetta-consult-elfeed` signalled `Wrong type argument: avl-tree-, nil` (from `with-elfeed-db-visit`) when the elfeed db global was in a half-loaded state — `elfeed-db` non-nil but `elfeed-db-index` not an avl-tree.

`elfeed-db-ensure` only loads `(when (null elfeed-db))`, so once `elfeed-db` is non-nil-but-bad, ensure is a no-op and every `with-elfeed-db-visit` fails. (In the live session, `elfeed-db` had been clobbered to a stray symbol out-of-band; reloading from disk restored 56,414 entries.)

## Fix

Add `zetta-elfeed--ensure-db`: run `elfeed-db-ensure`, then if `elfeed-db-index` is not a valid `avl-tree-p`, reset `elfeed-db` to nil and force `elfeed-db-load` from disk. `zetta-consult-elfeed` calls it instead of bare `elfeed-db-ensure`, so the command self-heals rather than erroring.

Cheap (one `avl-tree-p` check on the healthy path) and defensive against any future half-initialized-db state.

## Testing

Verified live: with the db restored, the guard is a clean no-op and `zetta-consult-elfeed--candidates` builds 2000 candidates; parens balance; the command path runs error-free.