### PR TITLE
fix(consult): hide the tab-line during buffer preview

### DIFF
--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -326,6 +326,19 @@ minibuffer, and old entries are reachable via elfeed's own search."
 
 (defvar zetta-consult-elfeed--history nil)
 
+(defun zetta-elfeed--ensure-db ()
+  "Ensure the elfeed db is loaded AND its index is a usable avl-tree.
+`elfeed-db-ensure' only loads when `elfeed-db' is nil, so it cannot
+recover a db left half-loaded or with a clobbered global (index not an
+avl-tree) -- which makes `with-elfeed-db-visit' signal
+\"Wrong type argument: avl-tree-, nil\".  Force a fresh load from disk
+in that case so elfeed commands self-heal instead of erroring."
+  (require 'elfeed-db)
+  (elfeed-db-ensure)
+  (unless (avl-tree-p elfeed-db-index)
+    (setq elfeed-db nil)
+    (elfeed-db-load)))
+
 (defun zetta-consult-elfeed--candidates ()
   "Format the most recent db entries as propertized candidate strings."
   (let ((n 0) out)
@@ -378,7 +391,7 @@ Filters over title, feed and tags of the `zetta-consult-elfeed-limit'
 most recent entries; RET opens the selection in the show buffer."
   (interactive)
   (require 'elfeed)
-  (elfeed-db-ensure)
+  (zetta-elfeed--ensure-db)
   (let* ((cand (consult--read
                 (zetta-consult-elfeed--candidates)
                 :prompt "Elfeed entry: "

--- a/modules/completion/consult.el
+++ b/modules/completion/consult.el
@@ -47,6 +47,49 @@
    consult-theme
    :preview-key "C-=")
 
+  ;;;; Hide the tab-line during buffer preview
+  ;; The tab-line is meaningless while previewing, and as preview swaps
+  ;; buffers in and out of the window its tab-line flickers in and out (a
+  ;; distracting pop -- independent of the renderer, it happens with the
+  ;; built-in text tab-line too).  Rather than try to hold it steady,
+  ;; hide it on every previewed buffer and restore on exit, so it is
+  ;; consistently absent for the whole preview instead of popping.
+  ;; `consult--buffer-preview' backs consult-buffer, consult-project-buffer
+  ;; AND `zetta-consult-elfeed' (which reuses it), so one wrapper covers
+  ;; them all.
+  (defun zetta--consult-preview-hide-tabline (state-fn)
+    "Wrap a consult buffer-preview STATE-FN to hide previewed buffers' tab-line.
+On `preview' the shown buffer's `tab-line-format' is set nil (hiding the
+tab-line); on `exit'/`return' every buffer touched this session is
+restored to its prior value."
+    (let ((saved (make-hash-table :test 'eq)))
+      (lambda (action cand)
+        (prog1 (funcall state-fn action cand)
+          (pcase action
+            ('preview
+             (when-let* ((buf (and cand (get-buffer cand)))
+                         ((buffer-live-p buf))
+                         ((not (gethash buf saved))))
+               (with-current-buffer buf
+                 ;; `t'-tagged cons = had a buffer-local value to restore;
+                 ;; `global' = was not buffer-local (kill on restore).
+                 (puthash buf (if (local-variable-p 'tab-line-format)
+                                  (cons t tab-line-format)
+                                'global)
+                          saved)
+                 (setq-local tab-line-format nil))))
+            ((or 'exit 'return)
+             (maphash (lambda (buf orig)
+                        (when (buffer-live-p buf)
+                          (with-current-buffer buf
+                            (if (eq orig 'global)
+                                (kill-local-variable 'tab-line-format)
+                              (setq-local tab-line-format (cdr orig))))))
+                      saved)
+             (clrhash saved)))))))
+  (advice-add 'consult--buffer-preview :filter-return
+              #'zetta--consult-preview-hide-tabline)
+
   (setq consult-async-split-style 'comma)
   ;; NOTE consult-omni--get-split-style-character fix moved to consult-omni.el
   ;; (must be defined after consult-omni loads or it gets overwritten)


### PR DESCRIPTION
## Problem

As consult swaps buffers in and out of the window during preview, the tab-line **flickers in and out** — a distracting pop. After extensive instrumentation (render logging, height recording, frame-by-frame video) the pop proved to be **independent of the renderer**: it happens with the built-in text tab-line too, so it is *not* an svg-line issue. It's the preview repeatedly toggling the window's tab-line as buffers cycle through.

## Fix (per @charlie's suggestion)

The tab-line is meaningless while previewing, so rather than try to hold it steady, **hide it**. A `:filter-return` advice on `consult--buffer-preview` wraps the state function:
- on `'preview`: set the previewed buffer's `tab-line-format` to nil (hiding its tab-line)
- on `'exit`/`'return`: restore every buffer touched this session to its prior value

The tab-line is then **consistently absent** for the whole preview (reappearing when the session ends) instead of popping. One wrapper covers `consult-buffer`, `consult-project-buffer`, and `zetta-consult-elfeed` — all build on `consult--buffer-preview`.

## Testing

Verified live (driven C-= preview): during preview the previewed buffer's tab-line height is **0** (hidden); after exit a normal buffer shows **19** (restored). Zero buffers left in a hidden state after the session. Parens balance.