### PR TITLE
fix(elfeed): manual preview for zetta-consult-elfeed to stop the freeze

### DIFF
--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -386,9 +386,16 @@ for every candidate the cursor crosses."
         (funcall preview action nil)))))
 
 (defun zetta-consult-elfeed ()
-  "Search recent elfeed entries with live preview (a la consult-mu).
+  "Search recent elfeed entries with preview (a la consult-mu).
 Filters over title, feed and tags of the `zetta-consult-elfeed-limit'
-most recent entries; RET opens the selection in the show buffer."
+most recent entries; RET opens the selection in the show buffer.
+
+Preview is MANUAL (press \\`C-=' to preview the current candidate),
+matching the other heavy consult commands: each preview renders a full
+elfeed entry (shr/HTML, ~0.2s+), so auto-previewing on every keystroke
+froze the picker -- especially the first render, which sets up
+`elfeed-show-mode'.  For preview-while-browsing instead, set
+`:preview-key' to e.g. \\='(:debounce 0.3 any)."
   (interactive)
   (require 'elfeed)
   (zetta-elfeed--ensure-db)
@@ -398,6 +405,7 @@ most recent entries; RET opens the selection in the show buffer."
                 :category 'elfeed-entry
                 :require-match t
                 :sort nil
+                :preview-key "C-="
                 :lookup #'consult--lookup-member
                 :state (zetta-consult-elfeed--state)
                 :history 'zetta-consult-elfeed--history))


### PR DESCRIPTION
## Problem

Two issues running `zetta-consult-elfeed`:

1. **Freeze on first run.** The command inherited `consult-preview-key 'any`, so the picker auto-previewed the first candidate the instant it opened — and previewing renders a *full elfeed entry* (shr/HTML, measured ~0.24s, more on the first render which also sets up `elfeed-show-mode`). That first render blocks the picker = freeze, with per-keystroke jank after.
2. **`Symbol's value as variable is void: state-fn`** — this was *not* a code bug. The committed `zetta--consult-preview-hide-tabline` wrapper (PR #56) is correct and lexical; the error came from an earlier `emacsclient --eval` live-load of it that ran with *dynamic* binding, so the closure's `state-fn` was a void free variable. Reloading from the file (lexical) fixes it — already done in the session, and a restart loads it correctly. No code change needed for this.

## Fix

Set `:preview-key "C-="` on the command's `consult--read`, so preview is **manual** — consistent with the other heavy consult commands (consult-buffer, consult-ripgrep, …). The picker opens instantly and never blocks on entry rendering; press `C-=` to preview the current candidate. Docstring notes `(:debounce 0.3 any)` as the alternative for preview-while-browsing.

## Testing

Verified live: `consult--read` accepts `:preview-key`; command reloaded with manual preview; candidate build ~0.1s, single entry render ~0.24s (now only on demand). Parens balance.