### PR TITLE
fix(svg-margin): don't abort compilation when the package isn't built yet

### DIFF
--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -18,11 +18,30 @@
 (use-package svg-margin
   :ensure (:host github :repo "chiply/svg-margin" :wait t))
 
-(require 'svg-margin)
+;; `nil t' (no-error): `use-package' above installs+loads svg-margin at LOAD
+;; time (`:wait t'), but `compile-angel' byte/native-compiles this file as it
+;; loads, and at COMPILE time the `use-package' has not run yet -- so a plain
+;; `(require 'svg-margin)' aborts compilation with "Cannot open load file"
+;; until elpaca has built the package.  No-error keeps compilation going; the
+;; svg-margin symbols below are declared so it compiles cleanly regardless.
+(require 'svg-margin nil t)
 (require 'svg)
 (require 'cl-lib)
 
 ;; External symbols (declared so this byte-compiles without those packages).
+;; svg-margin itself is declared here too: it may be absent at compile time
+;; (see the no-error require above), but `use-package' loads it before any of
+;; these run at load time.
+(declare-function svg-margin-define-shape "svg-margin")
+(declare-function svg-margin-register-provider "svg-margin")
+(declare-function svg-margin-refresh "svg-margin")
+(declare-function svg-margin-refresh-all "svg-margin")
+(declare-function svg-margin--note-help "svg-margin")
+(declare-function global-svg-margin-mode "svg-margin")
+(defvar svg-margin-disable-fringe)
+(defvar svg-margin-min-left-columns)
+(defvar svg-margin-min-right-columns)
+(defvar svg-margin-hover-highlight)
 (defvar evil-markers-alist)
 (defvar git-gutter:diffinfos)
 (defvar bookmark-alist)


### PR DESCRIPTION
## Problem

On a fresh start — and whenever `modules/ui/svg-margin.el` is recompiled after an edit — `compile-angel` byte/native-compiles the file as it loads. At **compile** time the `use-package :ensure :wait t` has not run yet, so the top-level `(require 'svg-margin)` aborted compilation with:

```
Entering directory '…/modules/ui/'
svg-margin.el:21:11: Error: Cannot open load file: No such file or directory, svg-margin
```

…until elpaca finished building the package — a scary error on startup (recurs whenever the file changes, hence "often").

`svg-line.el` doesn't hit this because it has no top-level require — its consumers require it later, after it's installed.

## Fix

- `(require 'svg-margin nil t)` — no-error, so compilation proceeds when the package isn't on the load-path yet.
- Declare the svg-margin functions/variables the config uses, so it still compiles cleanly (no undefined-symbol warnings) — the file's existing pattern (it already declares evil, git-gutter, … the same way).

At **load** time `use-package :wait t` installs+loads svg-margin before any of these run, so runtime is unchanged and the file stays byte/native-compiled (preserves provider-scan perf).

## Testing

`emacs -Q --batch` byte-compiling the file with svg-margin **absent** (simulating first startup):
- before: aborts with `Cannot open load file: svg-margin`
- after: completes (`result: t`), with **no** svg-margin symbol warnings