### PR TITLE
fix(consult): make preview tab-line advice binding-robust

### DIFF
--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -570,7 +570,7 @@ To restore: copy index.bak over index in `elfeed-db-directory' and restart."
 ;; persist on the next idle after each pull (the ~0.6s save then never lands
 ;; on active work; a clean exit also saves via elfeed's `kill-emacs-hook').
 
-(defcustom zetta-elfeed-auto-update-interval (* 5 60)
+(defcustom zetta-elfeed-auto-update-interval (* 15 60)
   "Seconds between background incremental elfeed updates."
   :type 'integer :group 'zetta)
 

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -324,16 +324,6 @@ The db holds tens of thousands; formatting them all would lag the
 minibuffer, and old entries are reachable via elfeed's own search."
   :type 'integer :group 'zetta)
 
-(defcustom zetta-consult-elfeed-keep-tab-line t
-  "When non-nil, keep the tab-line during `zetta-consult-elfeed' preview.
-Every entry previews into the single *elfeed-entry* buffer, so its
-tab-line is stable (same buffer, fixed height) and can show the previewed
-entry as the selected tab.  When nil, fall back to the default behaviour
-of hiding the tab-line for the whole preview (as with consult-buffer).
-Read by the `consult--buffer-preview' tab-line advice in
-`modules/completion/consult.el'."
-  :type 'boolean :group 'zetta)
-
 (defvar zetta-consult-elfeed--history nil)
 
 (defun zetta-elfeed--ensure-db ()
@@ -387,9 +377,9 @@ re-running the mode strips the tab-line on the live buffer; the heavy
 `elfeed-show-refresh' that follows gives redisplay a chance to paint the
 stripped state, and `global-tab-line-mode' restores it a moment later --
 i.e. the tab-line flashes once per candidate (visible when the tab-line is
-kept, `zetta-consult-elfeed-keep-tab-line').  Reuse the live elfeed-show
-buffer in place, running the major mode only when it is not already active,
-so the tab-line is never stripped between previews.
+kept during preview, `zetta-consult-preview-keep-tab-line').  Reuse the live
+elfeed-show buffer in place, running the major mode only when it is not
+already active, so the tab-line is never stripped between previews.
 
 Also bypasses `elfeed-show-entry' (and so its `:after' advice -- org-remark
 auto-notes), which we do not want firing for every candidate the cursor

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -46,6 +46,12 @@
   :commands elfeed
   :ensure t
   :config
+  ;; Cap the search buffer at 500 entries (elfeed's `#N' filter limit).
+  ;; The default "@6-months-ago +unread" yields ~6000 entries, and elfeed
+  ;; renders ALL matching entries -- ~380ms/refresh, most of it drawing rows.
+  ;; Capping cuts every refresh/filter/live-filter to a fraction; raise the
+  ;; number or drop "#500" in a live filter to see more.
+  (setq-default elfeed-search-filter "@6-months-ago +unread #500")
   (setq elfeed-use-curl t)
   (elfeed-set-timeout 36000)
   (setq elfeed-curl-extra-arguments '("--insecure"))

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -430,6 +430,73 @@ froze the picker -- especially the first render, which sets up
          (entry (and cand (get-text-property 0 'zetta-elfeed-entry cand))))
     (when entry (elfeed-show-entry entry))))
 
+;;;; Prune old entries to keep the db (and its saves) small
+;; `elfeed-db-save' serializes the WHOLE index with one synchronous `prin1';
+;; its cost scales with entry count, so a 50k-entry db freezes Emacs for
+;; seconds on every save.  Dropping old, already-read entries shrinks the
+;; index and shortens that freeze proportionally.  Fever resync won't bring
+;; old read entries back (the server only sends recent/unread), so this is
+;; safe for an elfeed-protocol setup.
+
+(defcustom zetta-elfeed-prune-keep-months 6
+  "`zetta-elfeed-prune' removes read entries older than this many months.
+Unread and protected entries (`zetta-elfeed-prune-protect-tags') are kept."
+  :type 'integer :group 'zetta)
+
+(defvar zetta-elfeed-prune-protect-tags '(unread starred important)
+  "Entries carrying any of these tags are never removed by `zetta-elfeed-prune'.")
+
+(defun zetta-elfeed-prune--victims (cutoff)
+  "Collect read, unprotected entries older than CUTOFF (a `float-time').
+Gathers into a list first -- never mutates the index mid-traversal."
+  (let (out)
+    (with-elfeed-db-visit (entry _feed)
+      (when (< (elfeed-entry-date entry) cutoff)
+        (unless (seq-some (lambda (tag) (memq tag (elfeed-entry-tags entry)))
+                          zetta-elfeed-prune-protect-tags)
+          (push entry out))))
+    out))
+
+(defun zetta-elfeed-prune (&optional months)
+  "Remove old, already-read entries to shrink the elfeed db and speed saves.
+Removes entries older than MONTHS (prefix arg; default
+`zetta-elfeed-prune-keep-months') that are read and not tagged in
+`zetta-elfeed-prune-protect-tags'.  Backs up the index to index.bak first,
+then removes from the in-memory db, runs `elfeed-db-gc' to reclaim content,
+and saves.  Fever resync will not re-add old read entries.
+
+To restore: copy index.bak over index in `elfeed-db-directory' and restart."
+  (interactive (list (and current-prefix-arg
+                          (prefix-numeric-value current-prefix-arg))))
+  (require 'elfeed)
+  (zetta-elfeed--ensure-db)
+  (let* ((months (or months zetta-elfeed-prune-keep-months))
+         (cutoff (- (float-time) (* months 30 24 60 60)))
+         (total (hash-table-count elfeed-db-entries))
+         (victims (zetta-elfeed-prune--victims cutoff))
+         (n (length victims)))
+    (cond
+     ((zerop n)
+      (message "elfeed-prune: nothing to remove (0 read entries older than %d months)"
+               months))
+     ((yes-or-no-p
+       (format "elfeed-prune: remove %d of %d entries (read, older than %d months)? "
+               n total months))
+      (let ((backup (expand-file-name "index.bak" elfeed-db-directory)))
+        (copy-file (expand-file-name "index" elfeed-db-directory) backup t)
+        (message "elfeed-prune: backed up index -> %s" backup))
+      (dolist (entry victims)
+        (let ((id (elfeed-entry-id entry)))
+          (avl-tree-delete elfeed-db-index id)
+          (remhash id elfeed-db-entries)))
+      (message "elfeed-prune: removed %d entries; running gc + save..." n)
+      (elfeed-db-gc)
+      (let ((t0 (float-time)))
+        (elfeed-db-save)
+        (message "elfeed-prune: done -- %d -> %d entries; db-save now %.2fs"
+                 total (hash-table-count elfeed-db-entries)
+                 (- (float-time) t0)))))))
+
 ;;;; Background auto-update (mu4e-style)
 ;; Incremental pulls in the background, so opening elfeed shows fresh
 ;; entries without a foreground update.  The network side is async curl;

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -547,29 +547,52 @@ To restore: copy index.bak over index in `elfeed-db-directory' and restart."
 (with-eval-after-load 'elfeed-search
   (setq elfeed-search-update-delay 0.5))
 
-;;;; Background auto-update (mu4e-style)
-;; Incremental pulls in the background, so opening elfeed shows fresh
-;; entries without a foreground update.  The network side is async curl;
-;; only parsing runs on the main thread, one maxsize-entry batch at a
-;; time.  The FIRST run also loads elfeed and its db (the one-time
-;; multi-second index load for a 50k-entry db), so it waits for genuine
-;; idle rather than firing mid-typing.
+;;;; Background auto-update (mu4e-style, non-blocking)
+;; Pull incrementally in the background so the tab-bar unread count + the
+;; new-items (+N) counter stay fresh without opening elfeed.  Use elfeed
+;; 4.0's `elfeed-update-background': unlike `elfeed-update' it skips the
+;; INITIAL forced search refresh and the synchronous end-of-update
+;; `elfeed-db-save', so it neither jumps nor hangs a visible *elfeed-search*.
+;; (elfeed-protocol's fetcher still fires `elfeed-update-hooks' per sub-feed,
+;; but those are all debounced now -- 4.0 native search refresh + our
+;; stats-write / +N-promote / unread-recount -- so they coalesce into one
+;; cheap refresh.)  New entries are counted live via `elfeed-new-entry-hook'.
+;;
+;; The FIRST run loads the ~48M db index (a one-time multi-second BLOCKING
+;; read), so it waits for a short idle after startup rather than firing
+;; mid-typing.  Because `elfeed-update-background' does not save the db, we
+;; persist on the next idle after each pull (the ~0.6s save then never lands
+;; on active work; a clean exit also saves via elfeed's `kill-emacs-hook').
 
-(defvar zetta-elfeed-auto-update-interval (* 15 60)
-  "Seconds between background incremental elfeed updates.")
+(defcustom zetta-elfeed-auto-update-interval (* 15 60)
+  "Seconds between background incremental elfeed updates."
+  :type 'integer :group 'zetta)
+
+(defcustom zetta-elfeed-auto-update-initial-idle 20
+  "Idle seconds after startup before the FIRST background elfeed update.
+Deferred so the one-time db load doesn't run during active startup."
+  :type 'integer :group 'zetta)
 
 (defvar zetta-elfeed--auto-update-timer nil
-  "Active timer for `zetta-elfeed--auto-update', or nil.")
+  "Active repeating timer for `zetta-elfeed--auto-update', or nil.")
 
 (defun zetta-elfeed--auto-update ()
-  "Incrementally update all elfeed feeds in the background."
+  "Pull all feeds in the background without disturbing visible elfeed windows.
+Indicators refresh via the (debounced) update hooks; the db is persisted on
+the next idle, since `elfeed-update-background' does not save it itself."
   (require 'elfeed)
-  (elfeed-update))
+  (cond
+   ((fboundp 'elfeed-update-background)
+    (elfeed-update-background)
+    (run-with-idle-timer
+     90 nil
+     (lambda () (when (fboundp 'elfeed-db-save) (ignore-errors (elfeed-db-save))))))
+   (t (elfeed-update))))                 ; pre-4.0 fallback
 
 (unless zetta-elfeed--auto-update-timer
   (setq zetta-elfeed--auto-update-timer
         (run-with-idle-timer
-         120 nil
+         zetta-elfeed-auto-update-initial-idle nil
          (lambda ()
            (zetta-elfeed--auto-update)
            (setq zetta-elfeed--auto-update-timer

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -536,37 +536,16 @@ To restore: copy index.bak over index in `elfeed-db-directory' and restart."
                  total (hash-table-count elfeed-db-entries)
                  (- (float-time) t0)))))))
 
-;;;; Debounce the search-buffer refresh during updates (THE freeze fix)
-;; `elfeed-search-mode' adds `elfeed-search-update' to `elfeed-update-hooks',
-;; which elfeed-protocol/Fever fires ONCE PER SUB-FEED.  Each call re-filters
-;; AND re-sorts the whole *elfeed-search* buffer; with ~6000 entries and a
-;; score-recomputing sort comparator (`elfeed-score-sort'), 150+ refreshes per
-;; sync = a multi-minute, 98%-CPU freeze (profiled: 155x elfeed-search-update =
-;; ~260s; the actual new-entry work was ~5s).  Replace the per-feed refresh
-;; with a single debounced one that fires after update activity settles.
-
-(defvar zetta-elfeed--search-update-timer nil)
-
-(defun zetta-elfeed--search-update-debounced (&rest _)
-  "Refresh *elfeed-search* once, shortly after update activity settles."
-  (when (timerp zetta-elfeed--search-update-timer)
-    (cancel-timer zetta-elfeed--search-update-timer))
-  (setq zetta-elfeed--search-update-timer
-        (run-with-idle-timer
-         0.5 nil
-         (lambda ()
-           (when (fboundp 'elfeed-search-update)
-             (ignore-errors (elfeed-search-update :force)))))))
-
-(defun zetta-elfeed--install-search-debounce ()
-  "Swap the per-feed `elfeed-search-update' hook for the debounced one.
-Runs from `elfeed-search-mode-hook' so it re-asserts after the mode body
-re-adds the stock hook each time elfeed-search is entered."
-  (remove-hook 'elfeed-update-hooks #'elfeed-search-update)
-  (add-hook 'elfeed-update-hooks #'zetta-elfeed--search-update-debounced))
-
+;;;; Search-buffer refresh during updates
+;; elfeed 4.0 debounces the per-update search refresh NATIVELY via
+;; `elfeed-search-update-delay' (it puts a debounced `elfeed-search--update-debounce'
+;; on `elfeed-update-hooks'), which supersedes the manual debounce we needed on
+;; 3.4.2.  Background: elfeed-protocol/Fever fires `elfeed-update-hooks' once per
+;; sub-feed, and without debouncing each fired a full re-filter+re-sort of the
+;; whole search buffer -- 150+ per sync, a multi-minute 98%-CPU freeze.  Just
+;; tune the native delay a touch tighter than the 1.0s default.
 (with-eval-after-load 'elfeed-search
-  (add-hook 'elfeed-search-mode-hook #'zetta-elfeed--install-search-debounce))
+  (setq elfeed-search-update-delay 0.5))
 
 ;;;; Background auto-update (mu4e-style)
 ;; Incremental pulls in the background, so opening elfeed shows fresh

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -523,6 +523,38 @@ To restore: copy index.bak over index in `elfeed-db-directory' and restart."
                  total (hash-table-count elfeed-db-entries)
                  (- (float-time) t0)))))))
 
+;;;; Debounce the search-buffer refresh during updates (THE freeze fix)
+;; `elfeed-search-mode' adds `elfeed-search-update' to `elfeed-update-hooks',
+;; which elfeed-protocol/Fever fires ONCE PER SUB-FEED.  Each call re-filters
+;; AND re-sorts the whole *elfeed-search* buffer; with ~6000 entries and a
+;; score-recomputing sort comparator (`elfeed-score-sort'), 150+ refreshes per
+;; sync = a multi-minute, 98%-CPU freeze (profiled: 155x elfeed-search-update =
+;; ~260s; the actual new-entry work was ~5s).  Replace the per-feed refresh
+;; with a single debounced one that fires after update activity settles.
+
+(defvar zetta-elfeed--search-update-timer nil)
+
+(defun zetta-elfeed--search-update-debounced (&rest _)
+  "Refresh *elfeed-search* once, shortly after update activity settles."
+  (when (timerp zetta-elfeed--search-update-timer)
+    (cancel-timer zetta-elfeed--search-update-timer))
+  (setq zetta-elfeed--search-update-timer
+        (run-with-idle-timer
+         0.5 nil
+         (lambda ()
+           (when (fboundp 'elfeed-search-update)
+             (ignore-errors (elfeed-search-update :force)))))))
+
+(defun zetta-elfeed--install-search-debounce ()
+  "Swap the per-feed `elfeed-search-update' hook for the debounced one.
+Runs from `elfeed-search-mode-hook' so it re-asserts after the mode body
+re-adds the stock hook each time elfeed-search is entered."
+  (remove-hook 'elfeed-update-hooks #'elfeed-search-update)
+  (add-hook 'elfeed-update-hooks #'zetta-elfeed--search-update-debounced))
+
+(with-eval-after-load 'elfeed-search
+  (add-hook 'elfeed-search-mode-hook #'zetta-elfeed--install-search-debounce))
+
 ;;;; Background auto-update (mu4e-style)
 ;; Incremental pulls in the background, so opening elfeed shows fresh
 ;; entries without a foreground update.  The network side is async curl;

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -376,23 +376,41 @@ in that case so elfeed commands self-heal instead of erroring."
           (elfeed-db-return))))
     (nreverse out)))
 
+(defun zetta-consult-elfeed--show (entry)
+  "Render ENTRY in *elfeed-entry* for PREVIEW, without re-running the mode.
+Return the buffer (so the consult preview can display it).
+
+`elfeed-show-entry' calls `elfeed-show-mode' on EVERY invocation, and that
+runs `kill-all-local-variables', which strips `tab-line-format'.  After the
+first preview *elfeed-entry* is already on screen WITH its tab-line, so
+re-running the mode strips the tab-line on the live buffer; the heavy
+`elfeed-show-refresh' that follows gives redisplay a chance to paint the
+stripped state, and `global-tab-line-mode' restores it a moment later --
+i.e. the tab-line flashes once per candidate (visible when the tab-line is
+kept, `zetta-consult-elfeed-keep-tab-line').  Reuse the live elfeed-show
+buffer in place, running the major mode only when it is not already active,
+so the tab-line is never stripped between previews.
+
+Also bypasses `elfeed-show-entry' (and so its `:after' advice -- org-remark
+auto-notes), which we do not want firing for every candidate the cursor
+crosses anyway."
+  (let ((buff (get-buffer-create "*elfeed-entry*")))
+    (with-current-buffer buff
+      (unless (derived-mode-p 'elfeed-show-mode)
+        (elfeed-show-mode))
+      (setq elfeed-show-entry entry)
+      (elfeed-show-refresh))
+    buff))
+
 (defun zetta-consult-elfeed--state ()
-  "Preview state function: render the candidate entry in *elfeed-entry*.
-org-remark's elfeed wiring (an :after advice on `elfeed-show-entry')
-is suppressed during previews -- it would look up/load a notes file
-for every candidate the cursor crosses."
+  "Preview state function: render the candidate entry in *elfeed-entry*."
   (let ((preview (consult--buffer-preview)))
     (lambda (action cand)
       (if (eq action 'preview)
           (funcall preview 'preview
                    (when-let* ((entry (and cand (get-text-property
                                                  0 'zetta-elfeed-entry cand))))
-                     (let ((elfeed-show-entry-switch #'identity))
-                       (if (fboundp 'org-remark-auto-on)
-                           (cl-letf (((symbol-function 'org-remark-auto-on)
-                                      #'ignore))
-                             (ignore-errors (elfeed-show-entry entry)))
-                         (ignore-errors (elfeed-show-entry entry))))))
+                     (ignore-errors (zetta-consult-elfeed--show entry))))
         (funcall preview action nil)))))
 
 (defun zetta-consult-elfeed ()

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -324,6 +324,16 @@ The db holds tens of thousands; formatting them all would lag the
 minibuffer, and old entries are reachable via elfeed's own search."
   :type 'integer :group 'zetta)
 
+(defcustom zetta-consult-elfeed-keep-tab-line t
+  "When non-nil, keep the tab-line during `zetta-consult-elfeed' preview.
+Every entry previews into the single *elfeed-entry* buffer, so its
+tab-line is stable (same buffer, fixed height) and can show the previewed
+entry as the selected tab.  When nil, fall back to the default behaviour
+of hiding the tab-line for the whole preview (as with consult-buffer).
+Read by the `consult--buffer-preview' tab-line advice in
+`modules/completion/consult.el'."
+  :type 'boolean :group 'zetta)
+
 (defvar zetta-consult-elfeed--history nil)
 
 (defun zetta-elfeed--ensure-db ()

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -564,7 +564,7 @@ To restore: copy index.bak over index in `elfeed-db-directory' and restart."
 ;; persist on the next idle after each pull (the ~0.6s save then never lands
 ;; on active work; a clean exit also saves via elfeed's `kill-emacs-hook').
 
-(defcustom zetta-elfeed-auto-update-interval (* 15 60)
+(defcustom zetta-elfeed-auto-update-interval (* 5 60)
   "Seconds between background incremental elfeed updates."
   :type 'integer :group 'zetta)
 
@@ -584,6 +584,9 @@ the next idle, since `elfeed-update-background' does not save it itself."
   (cond
    ((fboundp 'elfeed-update-background)
     (elfeed-update-background)
+    ;; Light the tab-bar "refreshing" (sync) glyph now -- it self-clears when
+    ;; the queue drains; force a redraw so it shows even while idle.
+    (force-mode-line-update t)
     (run-with-idle-timer
      90 nil
      (lambda () (when (fboundp 'elfeed-db-save) (ignore-errors (elfeed-db-save))))))

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -242,7 +242,13 @@ minibuffer with something like `exit-minibuffer'."
 (use-package elfeed-org
   :demand t
   :ensure t
-  :after elfeed org
+  ;; MUST load after elfeed-protocol: protocol 1.0 keeps the Fever feed in
+  ;; `elfeed-feeds' alongside elfeed-org's, via an advice on
+  ;; `rmh-elfeed-org-process' installed by `elfeed-protocol-enable'.  If
+  ;; `(elfeed-org)' runs first it clears `elfeed-feeds' (dropping the Fever
+  ;; feed) before that advice exists, so enable registers 0 protocol feeds and
+  ;; elfeed tries to curl `fever+https://…' directly ("Unsupported protocol").
+  :after elfeed org elfeed-protocol
   :config
   (setq rmh-elfeed-org-files
         (list

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -246,6 +246,32 @@ minibuffer with something like `exit-minibuffer'."
   :config
   (progn
     (elfeed-score-enable)
+    ;; FREEZE FIX: elfeed-protocol/Fever fires `elfeed-update-hooks' once per
+    ;; protocol sub-feed, each with the curl queue already drained, so
+    ;; elfeed-score's `elfeed-score-rule-stats-update-hook' (guarded only by
+    ;; (= (elfeed-queue-count-total) 0)) passes every time and writes the WHOLE
+    ;; rule-stats file once per feed -- ~300 full-file writes (each a visible
+    ;; "Wrote .../tmpXXXX") per sync, a multi-second freeze.  Replace that
+    ;; per-feed write with ONE debounced idle write per sync, disable the
+    ;; mid-scoring periodic flush (every 64 matches -- same whole-file write on
+    ;; a different trigger), and persist once more on exit.
+    (remove-hook 'elfeed-update-hooks #'elfeed-score-rule-stats-update-hook)
+    (setq elfeed-score-rule-stats-dirty-threshold nil)
+    (defun zetta-elfeed-score-stats-write ()
+      "Persist elfeed-score rule stats now, if enabled."
+      (when (and (bound-and-true-p elfeed-score-rule-stats-file)
+                 (fboundp 'elfeed-score-rule-stats-write))
+        (ignore-errors
+          (elfeed-score-rule-stats-write elfeed-score-rule-stats-file))))
+    (defvar zetta-elfeed-score-stats--timer nil)
+    (defun zetta-elfeed-score-stats-write-debounced (&rest _)
+      "Persist rule stats once, after update activity settles."
+      (when (timerp zetta-elfeed-score-stats--timer)
+        (cancel-timer zetta-elfeed-score-stats--timer))
+      (setq zetta-elfeed-score-stats--timer
+            (run-with-idle-timer 3 nil #'zetta-elfeed-score-stats-write)))
+    (add-hook 'elfeed-update-hooks #'zetta-elfeed-score-stats-write-debounced)
+    (add-hook 'kill-emacs-hook #'zetta-elfeed-score-stats-write)
     (define-key elfeed-search-mode-map "=" elfeed-score-map))
   (setq elfeed-search-print-entry-function #'elfeed-score-print-entry)
   ;; TODO add as a hook?

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -16,7 +16,11 @@
     (elfeed-search-toggle-all mytag)))
 
 (use-package elfeed-protocol
-  :ensure (elfeed-protocol :host github :repo "fasheng/elfeed-protocol")
+  ;; Pinned to 1.0.0: first release supporting elfeed 4.0; feeds move from
+  ;; `elfeed-protocol-feeds' to `elfeed-feeds' (see ~/.private.el), and it
+  ;; integrates with elfeed-org automatically (saves/re-appends protocol
+  ;; feeds, tags org feeds `:no-update').
+  :ensure (elfeed-protocol :host github :repo "fasheng/elfeed-protocol" :ref "1.0.0")
   :after elfeed
   :demand t
   :config
@@ -44,7 +48,10 @@
 (use-package elfeed
   :after embark
   :commands elfeed
-  :ensure t
+  ;; Pinned to 4.0.x (elpaca otherwise tracks the old `master'; 4.0 lives on
+  ;; tag 4.0.1 / branch `main').  4.0 brings native search-redraw debouncing
+  ;; (`elfeed-search-update-delay'), which supersedes our manual debounce.
+  :ensure (elfeed :ref "4.0.1")
   :config
   ;; Cap the search buffer at 500 entries (elfeed's `#N' filter limit).
   ;; The default "@6-months-ago +unread" yields ~6000 entries, and elfeed

--- a/modules/app/eww.el
+++ b/modules/app/eww.el
@@ -25,7 +25,7 @@
     "Set shr-inhibit-images based on URL before calling eww."
     (setq shr-inhibit-images
           (not (string-match-p
-                "reddit\\.com\\|twitter\\.com\\|xkcd\\.com\\|github\\.com\\|wikipedia\\.org"
+                "reddit\\.com\\|twitter\\.com\\|xkcd\\.com\\|github\\.com\\|wikipedia\\.org\\|wikipedia\\.org"
                 url)))
     (apply orig-fun url args))
   (advice-add 'eww :around #'my-eww-inhibit-images-advice)
@@ -33,7 +33,7 @@
   ;; Per-URL readable mode
   (defun zetta-eww-after-render-functions ()
     (unless (string-match-p
-             "reddit\\|xkcd\\|orgmode\\.org"
+             "reddit\\|xkcd\\|orgmode\\.org\\|sachachua\\.com"
              (eww-current-url))
       (eww-readable))
     (setq-local truncate-lines nil)

--- a/modules/completion/consult.el
+++ b/modules/completion/consult.el
@@ -54,8 +54,10 @@
   ;; out -- a distracting vertical pop -- because some candidates (special
   ;; buffers) carry no tab-line, so it disappears for those and reappears for
   ;; the next normal buffer.  The other preview family (`consult--jump-preview':
-  ;; ripgrep, grep, line, imenu, ...) doesn't need this -- it switches to the
-  ;; target's NATURAL tab-line and never hides it.
+  ;; consult-ripgrep, consult-grep, consult-line, consult-imenu, ...) has the
+  ;; same problem for cross-file hits -- preview opens files with hooks that can
+  ;; skip `global-tab-line-mode', so their tab-line is missing -- so we cover it
+  ;; too; there the previewed buffer is whatever the jump leaves current.
   ;;
   ;; We want the tab-line PRESENT and steady for the whole preview rather than
   ;; popping, so force uniform presence: on every previewed buffer that lacks a
@@ -80,53 +82,72 @@
   ;; subr.el, so the partial it returns captures STATE-FN/SAVED correctly
   ;; no matter how THIS file was loaded.
   (defcustom zetta-consult-preview-keep-tab-line t
-    "How `consult--buffer-preview' treats the tab-line while previewing.
+    "How consult preview treats the tab-line while previewing.
 When non-nil, keep the tab-line PRESENT and steady on every previewed
 buffer (giving a standard tab-line to candidates that lack one) so it
 never pops in and out as preview swaps buffers.  When nil, hide it for
 the whole preview instead (steady but blank).  Restored on exit either
-way."
+way.  Covers both `consult--buffer-preview' and `consult--jump-preview'."
     :type 'boolean :group 'zetta)
+  (defun zetta--consult-preview-set-tabline (buf saved)
+    "Force BUF's `tab-line-format' present (keep) or absent (hide).
+Per `zetta-consult-preview-keep-tab-line'.  Record BUF's prior value in
+SAVED once (so restore is exact); only write when it must actually change."
+    (when (buffer-live-p buf)
+      (with-current-buffer buf
+        (let ((target (if zetta-consult-preview-keep-tab-line
+                          (or tab-line-format '(:eval (tab-line-format)))
+                        nil)))
+          (unless (equal tab-line-format target)
+            ;; `t'-tagged cons = had a buffer-local value to restore;
+            ;; `global' = was not buffer-local (kill on restore).
+            (unless (gethash buf saved)
+              (puthash buf (if (local-variable-p 'tab-line-format)
+                               (cons t tab-line-format)
+                             'global)
+                       saved))
+            (setq-local tab-line-format target))))))
+  (defun zetta--consult-preview-restore-tabline (saved)
+    "Restore `tab-line-format' for every buffer recorded in SAVED, then clear it."
+    (maphash (lambda (buf orig)
+               (when (buffer-live-p buf)
+                 (with-current-buffer buf
+                   (if (eq orig 'global)
+                       (kill-local-variable 'tab-line-format)
+                     (setq-local tab-line-format (cdr orig))))))
+             saved)
+    (clrhash saved))
   (defun zetta--consult-preview-tabline-1 (state-fn saved action cand)
-    "Run consult STATE-FN, keeping/hiding previewed buffers' tab-line steady.
-Per `zetta-consult-preview-keep-tab-line'.  SAVED is a hash table tracking
-touched buffers' prior `tab-line-format' so it can be restored on exit."
+    "tab-line wrapper body for `consult--buffer-preview' (CAND is the buffer)."
     (prog1 (funcall state-fn action cand)
       (pcase action
         ('preview
-         (when-let* ((buf (and cand (get-buffer cand)))
-                     ((buffer-live-p buf)))
-           (with-current-buffer buf
-             ;; keep => ensure a tab-line is present (give one if missing);
-             ;; hide => force it absent.
-             (let ((target (if zetta-consult-preview-keep-tab-line
-                               (or tab-line-format '(:eval (tab-line-format)))
-                             nil)))
-               (unless (equal tab-line-format target)
-                 ;; Record the original ONCE before first changing it:
-                 ;; `t'-tagged cons = had a buffer-local value to restore;
-                 ;; `global' = was not buffer-local (kill on restore).
-                 (unless (gethash buf saved)
-                   (puthash buf (if (local-variable-p 'tab-line-format)
-                                    (cons t tab-line-format)
-                                  'global)
-                            saved))
-                 (setq-local tab-line-format target))))))
+         (when-let* ((buf (and cand (get-buffer cand))))
+           (zetta--consult-preview-set-tabline buf saved)))
         ((or 'exit 'return)
-         (maphash (lambda (buf orig)
-                    (when (buffer-live-p buf)
-                      (with-current-buffer buf
-                        (if (eq orig 'global)
-                            (kill-local-variable 'tab-line-format)
-                          (setq-local tab-line-format (cdr orig))))))
-                  saved)
-         (clrhash saved)))))
+         (zetta--consult-preview-restore-tabline saved)))))
+  (defun zetta--consult-preview-jump-tabline-1 (state-fn saved action cand)
+    "tab-line wrapper body for `consult--jump-preview' (ripgrep/grep/line/...).
+CAND is a location; the previewed buffer is the one the jump left current."
+    (prog1 (funcall state-fn action cand)
+      (pcase action
+        ('preview
+         (when cand
+           (zetta--consult-preview-set-tabline (current-buffer) saved)))
+        ((or 'exit 'return)
+         (zetta--consult-preview-restore-tabline saved)))))
   (defun zetta--consult-preview-tabline (state-fn)
-    "Wrap consult buffer-preview STATE-FN to keep previewed buffers' tab-line steady."
+    "Wrap `consult--buffer-preview' STATE-FN to keep the tab-line steady."
     (apply-partially #'zetta--consult-preview-tabline-1
+                     state-fn (make-hash-table :test 'eq)))
+  (defun zetta--consult-preview-jump-tabline (state-fn)
+    "Wrap `consult--jump-preview' STATE-FN to keep the tab-line steady."
+    (apply-partially #'zetta--consult-preview-jump-tabline-1
                      state-fn (make-hash-table :test 'eq)))
   (advice-add 'consult--buffer-preview :filter-return
               #'zetta--consult-preview-tabline)
+  (advice-add 'consult--jump-preview :filter-return
+              #'zetta--consult-preview-jump-tabline)
 
   (setq consult-async-split-style 'comma)
   ;; NOTE consult-omni--get-split-style-character fix moved to consult-omni.el

--- a/modules/completion/consult.el
+++ b/modules/completion/consult.el
@@ -74,6 +74,17 @@
   ;; state-fn") and hangs.  `apply-partially' is defined lexically in
   ;; subr.el, so the partial it returns captures STATE-FN/SAVED correctly
   ;; no matter how THIS file was loaded.
+  (defun zetta--consult-preview-keep-tabline-p (buf)
+    "Non-nil when BUF's tab-line should STAY (and show the preview), not hide.
+`zetta-consult-elfeed' reuses the single *elfeed-entry* buffer, so its
+tab-line is stable -- same buffer, fixed height, no accumulation (consult
+previews with `norecord') -- and can show the previewed entry as the
+selected tab instead of being hidden.  Gated on the user toggle
+`zetta-consult-elfeed-keep-tab-line' so it can be A/B'd against the hide;
+scoped to elfeed-show buffers so consult-buffer's churnier preview (a
+different buffer per candidate) still hides cleanly."
+    (and (bound-and-true-p zetta-consult-elfeed-keep-tab-line)
+         (eq (buffer-local-value 'major-mode buf) 'elfeed-show-mode)))
   (defun zetta--consult-preview-hide-tabline-1 (state-fn saved action cand)
     "Run consult STATE-FN, hiding/restoring previewed buffers' tab-line.
 SAVED is a hash table tracking touched buffers' prior `tab-line-format'."
@@ -81,7 +92,8 @@ SAVED is a hash table tracking touched buffers' prior `tab-line-format'."
       (pcase action
         ('preview
          (when-let* ((buf (and cand (get-buffer cand)))
-                     ((buffer-live-p buf)))
+                     ((buffer-live-p buf))
+                     ((not (zetta--consult-preview-keep-tabline-p buf))))
            (with-current-buffer buf
              ;; Record the original ONCE (don't clobber it on re-preview):
              ;; `t'-tagged cons = had a buffer-local value to restore;

--- a/modules/completion/consult.el
+++ b/modules/completion/consult.el
@@ -47,25 +47,30 @@
    consult-theme
    :preview-key "C-=")
 
-  ;;;; Hide the tab-line during buffer preview
-  ;; The tab-line is meaningless while previewing, and as preview swaps
-  ;; buffers in and out of the window its tab-line flickers in and out (a
-  ;; distracting pop -- independent of the renderer, it happens with the
-  ;; built-in text tab-line too).  Rather than try to hold it steady,
-  ;; hide it on every previewed buffer and restore on exit, so it is
-  ;; consistently absent for the whole preview instead of popping.
-  ;; `consult--buffer-preview' backs consult-buffer, consult-project-buffer
-  ;; AND `zetta-consult-elfeed' (which reuses it), so one wrapper covers
-  ;; them all.
-  ;; NB2: re-apply `tab-line-format nil' on EVERY preview, not just the
-  ;; first time a buffer is seen.  consult-buffer previews a fresh buffer
-  ;; per candidate, but `zetta-consult-elfeed' renders every entry into the
-  ;; same *elfeed-entry* buffer via `elfeed-show-entry', which re-runs
-  ;; `elfeed-show-mode' (=> `kill-all-local-variables') each time and so
-  ;; wipes the local nil we set -- making the tab-line pop back in on the
-  ;; 2nd+ preview.  Record the ORIGINAL value once (guarded), but force the
-  ;; hide unconditionally.
-  ;; NB: split into a wrapper-maker + a plain helper, joined with
+  ;;;; Keep the tab-line steady during buffer preview
+  ;; `consult--buffer-preview' (consult-buffer, consult-project-buffer AND
+  ;; `zetta-consult-elfeed', which reuses it) swaps buffers in and out of the
+  ;; window as you move candidates.  Left alone the tab-line flickers in and
+  ;; out -- a distracting vertical pop -- because some candidates (special
+  ;; buffers) carry no tab-line, so it disappears for those and reappears for
+  ;; the next normal buffer.  The other preview family (`consult--jump-preview':
+  ;; ripgrep, grep, line, imenu, ...) doesn't need this -- it switches to the
+  ;; target's NATURAL tab-line and never hides it.
+  ;;
+  ;; We want the tab-line PRESENT and steady for the whole preview rather than
+  ;; popping, so force uniform presence: on every previewed buffer that lacks a
+  ;; tab-line, give it the standard one for the duration; restore on exit.  The
+  ;; height never changes, so no vertical pop -- only the (meaningful) tab
+  ;; content reflects the buffer under preview.  Set
+  ;; `zetta-consult-preview-keep-tab-line' to nil to hide it instead (force it
+  ;; absent), which is also steady but blank.
+  ;;
+  ;; NB: re-evaluate the target on EVERY preview, not just the first time a
+  ;; buffer is seen -- `zetta-consult-elfeed' rendered into a buffer whose
+  ;; `tab-line-format' could be clobbered between previews (see
+  ;; `zetta-consult-elfeed--show'); only act when the value actually needs to
+  ;; change, and record the ORIGINAL once so restore is exact.
+  ;; NB2: split into a wrapper-maker + a plain helper, joined with
   ;; `apply-partially', rather than returning a lambda that closes over
   ;; STATE-FN.  A closure would need this file to be loaded lexically; if
   ;; anything ever (re)defines this in a dynamic-binding context, that
@@ -74,38 +79,39 @@
   ;; state-fn") and hangs.  `apply-partially' is defined lexically in
   ;; subr.el, so the partial it returns captures STATE-FN/SAVED correctly
   ;; no matter how THIS file was loaded.
-  (defun zetta--consult-preview-keep-tabline-p (buf)
-    "Non-nil when BUF's tab-line should STAY (and show the preview), not hide.
-`zetta-consult-elfeed' reuses the single *elfeed-entry* buffer, so its
-tab-line is stable -- same buffer, fixed height, no accumulation (consult
-previews with `norecord') -- and can show the previewed entry as the
-selected tab instead of being hidden.  Gated on the user toggle
-`zetta-consult-elfeed-keep-tab-line' so it can be A/B'd against the hide;
-scoped to elfeed-show buffers so consult-buffer's churnier preview (a
-different buffer per candidate) still hides cleanly."
-    (and (bound-and-true-p zetta-consult-elfeed-keep-tab-line)
-         (eq (buffer-local-value 'major-mode buf) 'elfeed-show-mode)))
-  (defun zetta--consult-preview-hide-tabline-1 (state-fn saved action cand)
-    "Run consult STATE-FN, hiding/restoring previewed buffers' tab-line.
-SAVED is a hash table tracking touched buffers' prior `tab-line-format'."
+  (defcustom zetta-consult-preview-keep-tab-line t
+    "How `consult--buffer-preview' treats the tab-line while previewing.
+When non-nil, keep the tab-line PRESENT and steady on every previewed
+buffer (giving a standard tab-line to candidates that lack one) so it
+never pops in and out as preview swaps buffers.  When nil, hide it for
+the whole preview instead (steady but blank).  Restored on exit either
+way."
+    :type 'boolean :group 'zetta)
+  (defun zetta--consult-preview-tabline-1 (state-fn saved action cand)
+    "Run consult STATE-FN, keeping/hiding previewed buffers' tab-line steady.
+Per `zetta-consult-preview-keep-tab-line'.  SAVED is a hash table tracking
+touched buffers' prior `tab-line-format' so it can be restored on exit."
     (prog1 (funcall state-fn action cand)
       (pcase action
         ('preview
          (when-let* ((buf (and cand (get-buffer cand)))
-                     ((buffer-live-p buf))
-                     ((not (zetta--consult-preview-keep-tabline-p buf))))
+                     ((buffer-live-p buf)))
            (with-current-buffer buf
-             ;; Record the original ONCE (don't clobber it on re-preview):
-             ;; `t'-tagged cons = had a buffer-local value to restore;
-             ;; `global' = was not buffer-local (kill on restore).
-             (unless (gethash buf saved)
-               (puthash buf (if (local-variable-p 'tab-line-format)
-                                (cons t tab-line-format)
-                              'global)
-                        saved))
-             ;; ...but force the hide every time -- elfeed-show-mode resets
-             ;; the local var between previews of the *elfeed-entry* buffer.
-             (setq-local tab-line-format nil))))
+             ;; keep => ensure a tab-line is present (give one if missing);
+             ;; hide => force it absent.
+             (let ((target (if zetta-consult-preview-keep-tab-line
+                               (or tab-line-format '(:eval (tab-line-format)))
+                             nil)))
+               (unless (equal tab-line-format target)
+                 ;; Record the original ONCE before first changing it:
+                 ;; `t'-tagged cons = had a buffer-local value to restore;
+                 ;; `global' = was not buffer-local (kill on restore).
+                 (unless (gethash buf saved)
+                   (puthash buf (if (local-variable-p 'tab-line-format)
+                                    (cons t tab-line-format)
+                                  'global)
+                            saved))
+                 (setq-local tab-line-format target))))))
         ((or 'exit 'return)
          (maphash (lambda (buf orig)
                     (when (buffer-live-p buf)
@@ -115,12 +121,12 @@ SAVED is a hash table tracking touched buffers' prior `tab-line-format'."
                           (setq-local tab-line-format (cdr orig))))))
                   saved)
          (clrhash saved)))))
-  (defun zetta--consult-preview-hide-tabline (state-fn)
-    "Wrap consult buffer-preview STATE-FN to hide previewed buffers' tab-line."
-    (apply-partially #'zetta--consult-preview-hide-tabline-1
+  (defun zetta--consult-preview-tabline (state-fn)
+    "Wrap consult buffer-preview STATE-FN to keep previewed buffers' tab-line steady."
+    (apply-partially #'zetta--consult-preview-tabline-1
                      state-fn (make-hash-table :test 'eq)))
   (advice-add 'consult--buffer-preview :filter-return
-              #'zetta--consult-preview-hide-tabline)
+              #'zetta--consult-preview-tabline)
 
   (setq consult-async-split-style 'comma)
   ;; NOTE consult-omni--get-split-style-character fix moved to consult-omni.el

--- a/modules/completion/consult.el
+++ b/modules/completion/consult.el
@@ -57,36 +57,45 @@
   ;; `consult--buffer-preview' backs consult-buffer, consult-project-buffer
   ;; AND `zetta-consult-elfeed' (which reuses it), so one wrapper covers
   ;; them all.
-  (defun zetta--consult-preview-hide-tabline (state-fn)
-    "Wrap a consult buffer-preview STATE-FN to hide previewed buffers' tab-line.
-On `preview' the shown buffer's `tab-line-format' is set nil (hiding the
-tab-line); on `exit'/`return' every buffer touched this session is
-restored to its prior value."
-    (let ((saved (make-hash-table :test 'eq)))
-      (lambda (action cand)
-        (prog1 (funcall state-fn action cand)
-          (pcase action
-            ('preview
-             (when-let* ((buf (and cand (get-buffer cand)))
-                         ((buffer-live-p buf))
-                         ((not (gethash buf saved))))
-               (with-current-buffer buf
-                 ;; `t'-tagged cons = had a buffer-local value to restore;
-                 ;; `global' = was not buffer-local (kill on restore).
-                 (puthash buf (if (local-variable-p 'tab-line-format)
-                                  (cons t tab-line-format)
-                                'global)
-                          saved)
-                 (setq-local tab-line-format nil))))
-            ((or 'exit 'return)
-             (maphash (lambda (buf orig)
-                        (when (buffer-live-p buf)
-                          (with-current-buffer buf
-                            (if (eq orig 'global)
-                                (kill-local-variable 'tab-line-format)
-                              (setq-local tab-line-format (cdr orig))))))
+  ;; NB: split into a wrapper-maker + a plain helper, joined with
+  ;; `apply-partially', rather than returning a lambda that closes over
+  ;; STATE-FN.  A closure would need this file to be loaded lexically; if
+  ;; anything ever (re)defines this in a dynamic-binding context, that
+  ;; closure's STATE-FN is void and consult's state call -- which fires on
+  ;; `setup' the instant the picker opens -- errors ("void-variable
+  ;; state-fn") and hangs.  `apply-partially' is defined lexically in
+  ;; subr.el, so the partial it returns captures STATE-FN/SAVED correctly
+  ;; no matter how THIS file was loaded.
+  (defun zetta--consult-preview-hide-tabline-1 (state-fn saved action cand)
+    "Run consult STATE-FN, hiding/restoring previewed buffers' tab-line.
+SAVED is a hash table tracking touched buffers' prior `tab-line-format'."
+    (prog1 (funcall state-fn action cand)
+      (pcase action
+        ('preview
+         (when-let* ((buf (and cand (get-buffer cand)))
+                     ((buffer-live-p buf))
+                     ((not (gethash buf saved))))
+           (with-current-buffer buf
+             ;; `t'-tagged cons = had a buffer-local value to restore;
+             ;; `global' = was not buffer-local (kill on restore).
+             (puthash buf (if (local-variable-p 'tab-line-format)
+                              (cons t tab-line-format)
+                            'global)
                       saved)
-             (clrhash saved)))))))
+             (setq-local tab-line-format nil))))
+        ((or 'exit 'return)
+         (maphash (lambda (buf orig)
+                    (when (buffer-live-p buf)
+                      (with-current-buffer buf
+                        (if (eq orig 'global)
+                            (kill-local-variable 'tab-line-format)
+                          (setq-local tab-line-format (cdr orig))))))
+                  saved)
+         (clrhash saved)))))
+  (defun zetta--consult-preview-hide-tabline (state-fn)
+    "Wrap consult buffer-preview STATE-FN to hide previewed buffers' tab-line."
+    (apply-partially #'zetta--consult-preview-hide-tabline-1
+                     state-fn (make-hash-table :test 'eq)))
   (advice-add 'consult--buffer-preview :filter-return
               #'zetta--consult-preview-hide-tabline)
 

--- a/modules/completion/consult.el
+++ b/modules/completion/consult.el
@@ -57,6 +57,14 @@
   ;; `consult--buffer-preview' backs consult-buffer, consult-project-buffer
   ;; AND `zetta-consult-elfeed' (which reuses it), so one wrapper covers
   ;; them all.
+  ;; NB2: re-apply `tab-line-format nil' on EVERY preview, not just the
+  ;; first time a buffer is seen.  consult-buffer previews a fresh buffer
+  ;; per candidate, but `zetta-consult-elfeed' renders every entry into the
+  ;; same *elfeed-entry* buffer via `elfeed-show-entry', which re-runs
+  ;; `elfeed-show-mode' (=> `kill-all-local-variables') each time and so
+  ;; wipes the local nil we set -- making the tab-line pop back in on the
+  ;; 2nd+ preview.  Record the ORIGINAL value once (guarded), but force the
+  ;; hide unconditionally.
   ;; NB: split into a wrapper-maker + a plain helper, joined with
   ;; `apply-partially', rather than returning a lambda that closes over
   ;; STATE-FN.  A closure would need this file to be loaded lexically; if
@@ -73,15 +81,18 @@ SAVED is a hash table tracking touched buffers' prior `tab-line-format'."
       (pcase action
         ('preview
          (when-let* ((buf (and cand (get-buffer cand)))
-                     ((buffer-live-p buf))
-                     ((not (gethash buf saved))))
+                     ((buffer-live-p buf)))
            (with-current-buffer buf
+             ;; Record the original ONCE (don't clobber it on re-preview):
              ;; `t'-tagged cons = had a buffer-local value to restore;
              ;; `global' = was not buffer-local (kill on restore).
-             (puthash buf (if (local-variable-p 'tab-line-format)
-                              (cons t tab-line-format)
-                            'global)
-                      saved)
+             (unless (gethash buf saved)
+               (puthash buf (if (local-variable-p 'tab-line-format)
+                                (cons t tab-line-format)
+                              'global)
+                        saved))
+             ;; ...but force the hide every time -- elfeed-show-mode resets
+             ;; the local var between previews of the *elfeed-entry* buffer.
              (setq-local tab-line-format nil))))
         ((or 'exit 'return)
          (maphash (lambda (buf orig)

--- a/modules/completion/embark-scope.el
+++ b/modules/completion/embark-scope.el
@@ -23,6 +23,18 @@
   (add-to-list 'embark-target-finders
                #'embark-scope-target-word-at-point)
 
+  ;; expand-region nesting levels as `expansion' targets: the
+  ;; bounds-sorted cycle (`C-.' expand / `C-,' contract) then steps
+  ;; through fine syntactic nesting, not just the coarse
+  ;; thing-at-point rungs.  Dedup (folded into the sort) drops levels
+  ;; coinciding with a named target; the by-type/avy pickers exclude
+  ;; `expansion' (see `embark-scope-pick-exclude-types').  Map it to
+  ;; `sexp' so the nav/instance family treats an expanded level
+  ;; sensibly.
+  (add-to-list 'embark-target-finders
+               #'embark-scope-target-expansions)
+  (setf (alist-get 'expansion embark-scope-nav-type-map) 'sexp)
+
   ;; Register zetta-flavored TAP-thing finders.  brick comes from
   ;; `treesit-tap.el' wrapper; line/sentence/paragraph are stock
   ;; thing-at-point things that embark's built-ins skip in most

--- a/modules/completion/embark.el
+++ b/modules/completion/embark.el
@@ -55,6 +55,20 @@ targets."
           embark-highlight-indicator
           embark-isearch-highlight-indicator))
 
+  ;; Show the target TYPE (and any shadowed target types) in the minibuffer,
+  ;; the same as in a regular buffer.  `embark--format-targets' deliberately
+  ;; collapses to a bare "Act" when acting from a non-prompter minibuffer
+  ;; (hiding the type and the other cyclable types); neutralise just the one
+  ;; `minibufferp' check inside it so the minibuffer gets the full
+  ;; "Act on TYPE ‘TARGET’(other-types…)" indicator -- and so the extra types
+  ;; `embark-cycle' can reach become visible there too.
+  (defun zetta-embark--full-minibuffer-target (orig &rest args)
+    "Run ORIG `embark--format-targets' as if not in a minibuffer (full indicator)."
+    (cl-letf (((symbol-function 'minibufferp) #'ignore))
+      (apply orig args)))
+  (advice-add 'embark--format-targets :around
+              #'zetta-embark--full-minibuffer-target)
+
   (defun embark-hide-which-key-indicator (fn &rest args)
     "Hide the which-key indicator immediately when using the
 completing-read prompter."

--- a/modules/completion/embark.el
+++ b/modules/completion/embark.el
@@ -69,6 +69,43 @@ targets."
   (advice-add 'embark--format-targets :around
               #'zetta-embark--full-minibuffer-target)
 
+  ;; In a file-completion minibuffer, also offer the candidate FILENAME's
+  ;; subwords as cyclable `identifier' targets, so `embark-act' can step
+  ;; file -> "config" -> "utils" -> ... like the at-point types you get in a
+  ;; regular buffer (dired etc.).  `embark-act' uses only the FIRST finder that
+  ;; returns in a minibuffer, so a new finder can't add targets; instead append
+  ;; to the one that wins (the vertico candidate finder) via `:filter-return',
+  ;; reusing embark's already-correct (directory-aware) file target as the
+  ;; first/default entry.
+  (defcustom zetta-embark-file-subword-targets t
+    "When non-nil, `embark-act' in a file minibuffer also offers the candidate's
+filename subwords as cyclable `identifier' targets."
+    :type 'boolean :group 'zetta)
+
+  (defun zetta-embark--append-file-subwords (target)
+    "Append filename-subword `identifier' targets to a file candidate TARGET.
+In a file-completion minibuffer return a LIST -- TARGET first (so the file
+stays the default), then one `identifier' target per >=2-char filename subword
+-- else TARGET unchanged."
+    (if (and zetta-embark-file-subword-targets
+             (consp target)
+             (minibufferp) minibuffer-completing-file-name)
+        (let* ((tb (cdr target))
+               (path (if (consp tb) (car tb) tb))
+               (base (and (stringp path)
+                          (file-name-nondirectory (directory-file-name path))))
+               (subs (and base
+                          (seq-uniq (seq-filter (lambda (s) (>= (length s) 2))
+                                                (split-string base "[^[:alnum:]]+" t))))))
+          (if subs
+              (cons target (mapcar (lambda (s) (cons 'identifier s)) subs))
+            target))
+      target))
+
+  (with-eval-after-load 'vertico
+    (advice-add 'embark--vertico-selected :filter-return
+                #'zetta-embark--append-file-subwords))
+
   (defun embark-hide-which-key-indicator (fn &rest args)
     "Hide the which-key indicator immediately when using the
 completing-read prompter."

--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -912,18 +912,27 @@ string like \"{ 1' }\"), not a variable -- so it must be called."
 Hidden until elfeed loads (the count cache is nil); the count comes from
 `zetta-tab-bar--elfeed-unread', recomputed off-render on elfeed's hooks."
   (when (numberp zetta-tab-bar--elfeed-unread)
-    (let* ((icon (and (featurep 'nerd-icons)
-                      (zetta-line--glyph (ignore-errors (nerd-icons-mdicon "nf-md-rss")))))
+    (let* ((refreshing (and (fboundp 'elfeed-queue-count-total)
+                            (ignore-errors (> (elfeed-queue-count-total) 0))))
+           ;; While a pull is in flight show a sync glyph instead of the rss
+           ;; glyph; `elfeed-queue-count-total' > 0 means curl fetches are
+           ;; active, so this self-clears when the pull drains.
+           (icon (and (featurep 'nerd-icons)
+                      (zetta-line--glyph
+                       (ignore-errors
+                         (nerd-icons-mdicon (if refreshing "nf-md-sync" "nf-md-rss"))))))
            (new zetta-tab-bar--elfeed-new-count)
            (label (concat (and icon (concat icon " "))
                           (number-to-string zetta-tab-bar--elfeed-unread)
                           (when (> new 0) (format " +%d" new)))))
       (zetta-svg-seg
        label 'tb-elfeed
-       :help (if (> new 0)
-                 (format "elfeed: %d unread (+%d new this pull)"
-                         zetta-tab-bar--elfeed-unread new)
-               (format "elfeed: %d unread" zetta-tab-bar--elfeed-unread))
+       :help (cond
+              (refreshing (format "elfeed: refreshing… (%d unread)"
+                                  zetta-tab-bar--elfeed-unread))
+              ((> new 0) (format "elfeed: %d unread (+%d new this pull)"
+                                 zetta-tab-bar--elfeed-unread new))
+              (t (format "elfeed: %d unread" zetta-tab-bar--elfeed-unread)))
        :action-help "open elfeed"
        :action (if (fboundp 'elfeed) #'elfeed #'ignore)
        :menu (delq nil

--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -884,11 +884,41 @@ recolours it via `zetta-tab-bar-svg-icon-color', so the raw glyph is returned."
      :menu (list (cons "Describe bindings" #'describe-bindings)
                  (cons "Command (M-x)" #'execute-extended-command)))))
 
+(defun zetta-tab-bar--left-of-clock-chars ()
+  "How many characters a line-3 LEFT segment may use before the centred clock.
+Derived from the LIVE frame width and the tab bar's own geometry, so it
+adapts to any screen width: the clock spans all three rows, centred at
+WIDTH/2 with radius ~0.86*(3*LH)/2; the left content starts past the square
+masthead (width = bar height); inline-segment rows lay out at
+`zetta-tab-bar-svg-char-advance' px/char.  These mirror `svg-line''s internal
+geometry -- keep in sync if its clock-radius/masthead formulas change."
+  (let* ((width (frame-inner-width))
+         (fz   (or (bound-and-true-p zetta-tab-bar-svg-font-size) 15))
+         (lp   (or (bound-and-true-p zetta-tab-bar-svg-line-pad) 4))
+         (lh   (+ fz lp))
+         (rows 3)
+         (height (* lh rows))                              ; full bar height
+         (r    (round (* 0.86 (/ (float height) 2))))      ; clock radius
+         (masthead (if (bound-and-true-p zetta-tab-bar-svg-icon) height 0))
+         (gap  (* 2 fz))                                    ; breathing room
+         (ca   (max 1 (or (bound-and-true-p zetta-tab-bar-svg-char-advance) 8)))
+         (avail (- (/ width 2) r masthead gap)))
+    (max 0 (floor avail ca))))
+
 (defun zetta-tab-bar-svg--spotify ()
-  "Clickable Spotify cluster (glyph + spot string): play/pause; transport menu."
+  "Clickable Spotify cluster (glyph + spot string): play/pause; transport menu.
+The track string is truncated so the cluster never reaches the centred clock,
+at any frame width (see `zetta-tab-bar--left-of-clock-chars')."
   (let* ((icon (ignore-errors (zetta-tab-bar-spotify-icon)))
          (txt  (zetta-tab-bar-spot-mode-line-string))
-         (label (concat (and icon (concat icon " ")) txt)))
+         (prefix (if icon (concat icon " ") ""))
+         (maxc (zetta-tab-bar--left-of-clock-chars))
+         (budget (- maxc (length prefix)))
+         (txt (cond
+               ((or (null txt) (<= (length txt) budget)) txt)
+               ((> budget 1) (concat (substring txt 0 (1- budget)) "…"))
+               (t "")))                                     ; no room -> icon only
+         (label (concat prefix txt)))
     (zetta-svg-seg
      label 'tb-spotify
      :help "Spotify"

--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -834,6 +834,22 @@ string like \"{ 1' }\"), not a variable -- so it must be called."
   (and (featurep 'nerd-icons)
        (zetta-line--glyph (ignore-errors (nerd-icons-sucicon "nf-custom-emacs")))))
 
+(defun zetta-tab-bar-mode-icon ()
+  "Nerd-Font glyph for the (context) buffer's major mode, for the masthead.
+Reflects the buffer the tab bar reports on -- the minibuffer entry buffer
+during completion/preview (`zetta-tab-bar--context-buffer'), else the current
+buffer -- so it does not flicker as previews swap buffers.  The masthead
+recolours it via `zetta-tab-bar-svg-icon-color', so the raw glyph is returned."
+  (when (featurep 'nerd-icons)
+    (let ((buf (or (and (fboundp 'zetta-tab-bar--context-buffer)
+                        (zetta-tab-bar--context-buffer))
+                   (current-buffer))))
+      (with-current-buffer buf
+        (let ((g (ignore-errors (nerd-icons-icon-for-buffer))))
+          (and (stringp g)
+               (let ((s (substring-no-properties (string-trim g))))
+                 (and (> (length s) 0) s))))))))
+
 ;;; tab-bar interactive (svg-only) wrappers
 ;; ----------------------------------------------------------------
 ;; The base tab-bar segments above are shared with the *text* `tab-bar-format'

--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -724,6 +724,46 @@ The db visits newest-first, so the scan stops at the window edge."
   (add-hook 'elfeed-untag-hooks #'zetta-tab-bar--elfeed-recount)
   (zetta-tab-bar--elfeed-recount))
 
+;; "+N new this pull": how many entries the most recent update added, shown
+;; mu4e-style beside the unread count and cleared when you open elfeed.  New
+;; entries arrive asynchronously (curl/fever callbacks), so accumulate per
+;; entry and promote the batch to the indicator once update activity settles.
+(defvar zetta-tab-bar--elfeed-new-count 0
+  "New elfeed entries from the last completed pull (the +N indicator).")
+(defvar zetta-tab-bar--elfeed-new-accum 0
+  "New entries seen so far in the in-progress pull, before promotion.")
+(defvar zetta-tab-bar--elfeed-new-timer nil)
+
+(defun zetta-tab-bar--elfeed-note-new (&rest _)
+  "Count one new entry for the current pull (on `elfeed-new-entry-hook')."
+  (setq zetta-tab-bar--elfeed-new-accum (1+ zetta-tab-bar--elfeed-new-accum)))
+
+(defun zetta-tab-bar--elfeed-promote-new (&rest _)
+  "Debounced: promote the pull's accumulated new count to the indicator.
+Runs after update activity settles, so a burst of feeds reads as one pull.
+A pull that added nothing leaves the previous +N (entries you've not seen)."
+  (when (timerp zetta-tab-bar--elfeed-new-timer)
+    (cancel-timer zetta-tab-bar--elfeed-new-timer))
+  (setq zetta-tab-bar--elfeed-new-timer
+        (run-with-idle-timer
+         2 nil
+         (lambda ()
+           (when (> zetta-tab-bar--elfeed-new-accum 0)
+             (setq zetta-tab-bar--elfeed-new-count zetta-tab-bar--elfeed-new-accum
+                   zetta-tab-bar--elfeed-new-accum 0)
+             (force-mode-line-update t))))))
+
+(defun zetta-tab-bar--elfeed-clear-new (&rest _)
+  "Clear the +N indicator -- you've opened elfeed, so the new ones are seen."
+  (setq zetta-tab-bar--elfeed-new-count 0
+        zetta-tab-bar--elfeed-new-accum 0)
+  (force-mode-line-update t))
+
+(with-eval-after-load 'elfeed
+  (add-hook 'elfeed-new-entry-hook #'zetta-tab-bar--elfeed-note-new)
+  (add-hook 'elfeed-update-hooks #'zetta-tab-bar--elfeed-promote-new)
+  (advice-add 'elfeed :after #'zetta-tab-bar--elfeed-clear-new))
+
 (defun zetta-tab-bar-clock ()
   "The `display-time' clock string, trimmed."
   (when (boundp 'display-time-string) (string-trim (or display-time-string ""))))
@@ -874,11 +914,16 @@ Hidden until elfeed loads (the count cache is nil); the count comes from
   (when (numberp zetta-tab-bar--elfeed-unread)
     (let* ((icon (and (featurep 'nerd-icons)
                       (zetta-line--glyph (ignore-errors (nerd-icons-mdicon "nf-md-rss")))))
+           (new zetta-tab-bar--elfeed-new-count)
            (label (concat (and icon (concat icon " "))
-                          (number-to-string zetta-tab-bar--elfeed-unread))))
+                          (number-to-string zetta-tab-bar--elfeed-unread)
+                          (when (> new 0) (format " +%d" new)))))
       (zetta-svg-seg
        label 'tb-elfeed
-       :help (format "elfeed: %d unread" zetta-tab-bar--elfeed-unread)
+       :help (if (> new 0)
+                 (format "elfeed: %d unread (+%d new this pull)"
+                         zetta-tab-bar--elfeed-unread new)
+               (format "elfeed: %d unread" zetta-tab-bar--elfeed-unread))
        :action-help "open elfeed"
        :action (if (fboundp 'elfeed) #'elfeed #'ignore)
        :menu (delq nil

--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -401,65 +401,203 @@ edit/execute from the menu."
                           out)))))))
         out))))
 
-(defcustom zetta-svg-margin-scroll-hide-delay 0.8
-  "Seconds the margin scrollbar thumb stays visible after scrolling."
+;;;; Scroll thumb -- window-anchored, pixel-smooth, synchronous
+;; A yascroll-style thumb in the right margin, done right.  The old version
+;; was a buffer-anchored `:background' provider rendered on svg-margin's 0.1s
+;; IDLE debounce, so during a continuous scroll it never re-rendered: the
+;; thumb (pinned to text) scrolled away and only snapped back on pause
+;; (hence the flash + no ultra-scroll response), and line-number math made it
+;; jitter and vary in height.  This is anchored to the WINDOW, recomputed from
+;; the live viewport and drawn SYNCHRONOUSLY on every scroll (no idle debounce
+;; -- tracks ultra-scroll, never flashes).  Position/size come from the
+;; viewport's CHAR-fraction (O(1), smooth); the top/bottom rows get a PARTIAL
+;; SVG fill for sub-line precision.  It re-composites visible lines from
+;; svg-margin's render cache, so providers never re-run while scrolling.
+
+(defcustom zetta-svg-margin-scroll-color "#7c828c"
+  "Colour of the margin scroll thumb." :type 'color :group 'zetta)
+(defcustom zetta-svg-margin-scroll-opacity 0.6
+  "Opacity (0..1) of the margin scroll thumb." :type 'number :group 'zetta)
+(defcustom zetta-svg-margin-scroll-width 0.55
+  "Thumb width: a fraction of the right margin when < 1, else pixels."
+  :type 'number :group 'zetta)
+(defcustom zetta-svg-margin-scroll-min-pixels 18
+  "Minimum thumb height in pixels." :type 'integer :group 'zetta)
+(defcustom zetta-svg-margin-scroll-hide-delay 1.0
+  "Seconds the thumb stays visible after scrolling stops."
   :type 'number :group 'zetta)
 
+(defvar-local zetta-svg-margin-scroll--ovs nil
+  "Thumb-only overlays created on the current tick.")
+(defvar-local zetta-svg-margin-scroll--saved nil
+  "Alist (CONTENT-OVERLAY . ORIG-BEFORE-STRING) composited onto this tick.")
 (defvar-local zetta-svg-margin-scroll--until nil
-  "Time until which the scrollbar thumb is shown, or nil.")
+  "Time until which the thumb is shown, or nil.")
+(defvar-local zetta-svg-margin-scroll--hide-timer nil)
 
-(defvar-local zetta-svg-margin-scroll--hide-timer nil
-  "Timer that refreshes the margin to hide the thumb after the delay.")
+(defun zetta-svg-margin-scroll--clear ()
+  "Undo this tick's thumb layer: restore composited overlays, delete ours."
+  (dolist (pair zetta-svg-margin-scroll--saved)
+    (when (overlayp (car pair))
+      (overlay-put (car pair) 'before-string (cdr pair))))
+  (setq zetta-svg-margin-scroll--saved nil)
+  (dolist (ov zetta-svg-margin-scroll--ovs)
+    (when (overlayp ov) (delete-overlay ov)))
+  (setq zetta-svg-margin-scroll--ovs nil))
 
-(defun zetta-svg-margin-scrollbar (buffer)
-  "Background highlight on the visible lines covered by the scrollbar thumb.
-The yascroll idea delivered through svg-margin's `:background' indicators:
-within the window's visible rows, the thumb's offset and size are
-proportional to the viewport's position in and coverage of the whole buffer.
-Emitted only while `zetta-svg-margin-scroll--until' is in the future (stamped
-by `zetta-svg-margin-scroll--on-scroll'), so it disappears on the refresh
-after `zetta-svg-margin-scroll-hide-delay'.  Backgrounds claim no indicator
-column, so the thumb tints the margin behind the icons without widening it."
-  (with-current-buffer buffer
-    (when (and zetta-svg-margin-scroll--until
-               (time-less-p nil zetta-svg-margin-scroll--until))
-      (when-let* ((win (get-buffer-window buffer)))
-        (let* ((total (save-restriction (widen)
-                                        (max 1 (line-number-at-pos (point-max)))))
-               (first (line-number-at-pos (window-start win) t))
-               (last (line-number-at-pos (window-end win t) t))
-               (visible (max 1 (1+ (- last first)))))
-          (when (> total visible)       ; buffer scrolls at all
-            (let* ((size (max 1 (round (* visible (/ (float visible) total)))))
-                   (frac (/ (float (1- first)) (max 1 (- total visible))))
-                   (start (+ first (round (* (min 1.0 frac) (- visible size)))))
-                   (face (if (facep 'yascroll:thumb-fringe)
-                             'yascroll:thumb-fringe 'shadow))
-                   out)
-              (dotimes (i size)
-                (push (list :line (+ start i) :background t
-                            :face face :opacity 0.45)
-                      out))
-              out)))))))
+(defun zetta-svg-margin-scroll--line-y (pos win)
+  "Top pixel Y of POS within WIN's body, or nil if POS is not visible."
+  (let ((v (pos-visible-in-window-p pos win t)))
+    (and v (nth 1 v))))
 
-(defun zetta-svg-margin-scroll--on-scroll (win _new-start)
-  "Show the scrollbar thumb for WIN's buffer and schedule its hiding.
-On `window-scroll-functions', which runs during redisplay -- so this only
-stamps the visibility deadline and (re)schedules timers; the rendering
-itself happens through svg-margin's debounced refresh."
-  (let ((buf (window-buffer win)))
+(defun zetta-svg-margin-scroll--rows (win start lh)
+  "Return (BOL Y0 Y1) per LOGICAL line WIN's thumb covers, from START.
+Each entry becomes ONE LH-tall (single screen row) margin image at a line's
+bol.  Margin images MUST be one screen row tall -- a taller one (e.g. a whole
+wrapped line) does not fit and Emacs falls back to rendering the overlay
+string INLINE, inserting whitespace into the buffer.  So each line contributes
+only its FIRST screen row; on wrapped lines the continuation rows stay unpainted
+\(a margin limitation), but the buffer is never disturbed.  The viewport's
+char-fraction is intersected with each first row for sub-line partial fills."
+  (let ((total (- (point-max) (point-min)))
+        (track (window-body-height win t)))
+    (when (> total 0)
+      (let (lines (end start))
+        (save-excursion
+          (goto-char start)
+          (catch 'done
+            (while (not (eobp))
+              (let* ((bol (line-beginning-position))
+                     (y (zetta-svg-margin-scroll--line-y bol win)))
+                (when (or (null y) (>= y track)) (throw 'done nil))
+                (push (cons bol (float y)) lines)
+                (forward-line 1)
+                (setq end (point))
+                (when (eobp) (throw 'done nil))))))
+        (setq lines (nreverse lines))
+        (let* ((tp (* track (/ (float (- start (point-min))) total)))
+               (bp (* track (/ (float (- end (point-min))) total))))
+          (when (< (- bp tp) zetta-svg-margin-scroll-min-pixels)
+            (let ((g (/ (- zetta-svg-margin-scroll-min-pixels (- bp tp)) 2.0)))
+              (setq tp (- tp g) bp (+ bp g))))
+          (setq tp (max 0.0 (min tp (float track)))
+                bp (max 0.0 (min bp (float track))))
+          (when (> bp (+ tp 0.5))
+            (let (rows)
+              (dolist (ln lines)
+                (let* ((bol (car ln)) (ytop (cdr ln))
+                       (ybot (+ ytop lh))            ; first screen row only
+                       (o0 (max tp (max 0.0 ytop))) (o1 (min bp ybot)))
+                  (when (> o1 o0)
+                    (push (list bol (- o0 ytop) (- o1 ytop)) rows))))
+              (nreverse rows))))))))
+
+(defun zetta-svg-margin-scroll--image (rcols cw rh y0 y1 right-packed)
+  "SVG for one thumb row: a partial fill (Y0..Y1) plus cached RIGHT-PACKED icons."
+  (let* ((w (max 1 (* rcols cw)))
+         (h (max 1 (round rh)))
+         (svg (svg-create w h))
+         (tw (if (>= zetta-svg-margin-scroll-width 1)
+                 (round zetta-svg-margin-scroll-width)
+               (max 2 (round (* w zetta-svg-margin-scroll-width)))))
+         (tx (max 0 (- w tw)))
+         (fy (max 0 (round y0)))
+         (fh (max 1 (round (- y1 y0)))))
+    ;; Square corners: each line is a separate image, so rounding every row
+    ;; would pinch the bar into a stack of pills.  A flat bar reads as one
+    ;; continuous thumb.
+    (svg-rectangle svg tx fy tw fh
+                   :fill (if (fboundp 'svg-margin--color)
+                             (svg-margin--color zetta-svg-margin-scroll-color)
+                           zetta-svg-margin-scroll-color)
+                   :fill-opacity zetta-svg-margin-scroll-opacity)
+    (dolist (cell right-packed)
+      (let ((col (plist-get cell :column)) (ind (plist-get cell :indicator)))
+        (when (and col (fboundp 'svg-margin--draw))
+          (ignore-errors (svg-margin--draw ind svg (* col cw) 0 cw h)))))
+    (svg-image svg :ascent 'center :scale 1.0)))
+
+(defun zetta-svg-margin-scroll--right-overlay (pos)
+  "The svg-margin RIGHT-margin content overlay at POS, if any."
+  (cl-find-if
+   (lambda (o)
+     (and (overlay-get o 'svg-margin)
+          (let ((bs (overlay-get o 'before-string)))
+            (and (stringp bs) (> (length bs) 0)
+                 (let ((d (get-text-property 0 'display bs)))
+                   (and (consp d) (consp (car d))
+                        (eq (cadr (car d)) 'right-margin)))))))
+   (overlays-in pos pos)))
+
+(defun zetta-svg-margin-scroll--update (win start)
+  "Redraw WIN's scroll thumb now (window-anchored, synchronous)."
+  (when (window-live-p win)
+    (let ((buf (window-buffer win)))
+      (when (buffer-local-value 'svg-margin-mode buf)
+        (with-current-buffer buf
+          (zetta-svg-margin-scroll--clear)
+          (when (and zetta-svg-margin-scroll--until
+                     (time-less-p nil zetta-svg-margin-scroll--until)
+                     (bound-and-true-p svg-margin--render-cache))
+            (let* ((cache svg-margin--render-cache)
+                   (content (plist-get cache :content))
+                   (cw (or (plist-get cache :cw) (frame-char-width)))
+                   (lh (or (plist-get cache :lh) (default-line-height)))
+                   (rcols (max 1 (or (plist-get cache :right) 2)))
+                   (rows (zetta-svg-margin-scroll--rows
+                          win (or start (window-start win)) lh)))
+              (dolist (r rows)
+                (cl-destructuring-bind (pos y0 y1) r
+                  (let* ((cell (and content (gethash pos content)))
+                         (right (and (consp cell) (cdr cell)))
+                         (img (zetta-svg-margin-scroll--image rcols cw lh y0 y1 right))
+                         (str (propertize " " 'display
+                                          (list '(margin right-margin) img)
+                                          'face 'svg-margin-cell))
+                         (ex (and right (zetta-svg-margin-scroll--right-overlay pos))))
+                    (if ex
+                        (progn
+                          (push (cons ex (overlay-get ex 'before-string))
+                                zetta-svg-margin-scroll--saved)
+                          (overlay-put ex 'before-string str))
+                      (let ((ov (make-overlay pos pos)))
+                        (overlay-put ov 'svg-margin-scroll t)
+                        (overlay-put ov 'before-string str)
+                        (push ov zetta-svg-margin-scroll--ovs)))))))))))))
+
+(defun zetta-svg-margin-scroll--hide (buf)
+  "Drop the thumb in BUF after the hide delay."
+  (when (buffer-live-p buf)
+    (with-current-buffer buf
+      (setq zetta-svg-margin-scroll--until nil)
+      (zetta-svg-margin-scroll--clear))))
+
+(defvar zetta-svg-margin-scroll--last (make-hash-table :test 'eq :weakness 'key)
+  "Window -> (WINDOW-START . VSCROLL) at the last check, to detect scrolling.")
+
+(defun zetta-svg-margin-scroll--post-command ()
+  "Show + redraw the thumb whenever the selected window's viewport moved.
+Keyed off `window-start'/`window-vscroll', so it catches keyboard, mouse-wheel,
+pixel- and ultra-scroll alike -- the old `window-scroll-functions' trigger
+missed pure-pixel and some wheel scrolls (so the thumb only appeared after a
+big jump, and vanished at the bottom).  Runs post-redisplay, so
+`pos-visible-in-window-p'/overlay edits here are safe."
+  (let* ((win (selected-window))
+         (buf (window-buffer win)))
     (when (buffer-local-value 'svg-margin-mode buf)
-      (with-current-buffer buf
-        (setq zetta-svg-margin-scroll--until
-              (time-add nil zetta-svg-margin-scroll-hide-delay))
-        (when (timerp zetta-svg-margin-scroll--hide-timer)
-          (cancel-timer zetta-svg-margin-scroll--hide-timer))
-        (setq zetta-svg-margin-scroll--hide-timer
-              (run-at-time (+ zetta-svg-margin-scroll-hide-delay 0.05) nil
-                           (lambda (b)
-                             (when (buffer-live-p b) (svg-margin-refresh b)))
-                           buf))
-        (svg-margin-refresh buf)))))
+      (let ((cur (cons (window-start win) (window-vscroll win t)))
+            (prev (gethash win zetta-svg-margin-scroll--last)))
+        (unless (equal cur prev)
+          (puthash win cur zetta-svg-margin-scroll--last)
+          (with-current-buffer buf
+            (setq zetta-svg-margin-scroll--until
+                  (time-add nil zetta-svg-margin-scroll-hide-delay))
+            (when (timerp zetta-svg-margin-scroll--hide-timer)
+              (cancel-timer zetta-svg-margin-scroll--hide-timer))
+            (setq zetta-svg-margin-scroll--hide-timer
+                  (run-at-time (+ zetta-svg-margin-scroll-hide-delay 0.02) nil
+                               #'zetta-svg-margin-scroll--hide buf)))
+          (zetta-svg-margin-scroll--update win (window-start win)))))))
 
 (defvar zetta-svg-margin--last-symbol nil
   "Last symbol at point, to refresh only when it changes.")
@@ -554,7 +692,9 @@ the recompute yields the same hunks we skip, breaking the cycle."
 (svg-margin-register-provider 'long-lines   #'zetta-svg-margin-long-lines   :side 'right :priority 3)
 (svg-margin-register-provider 'symbol       #'zetta-svg-margin-symbol       :side 'left  :priority 2)
 (svg-margin-register-provider 'trailing-ws  #'zetta-svg-margin-trailing-ws  :side 'right :priority 1)
-(svg-margin-register-provider 'scrollbar    #'zetta-svg-margin-scrollbar    :side 'right)
+;; The scroll thumb is NOT a provider -- it is a window-anchored layer driven
+;; synchronously from `post-command-hook' (`zetta-svg-margin-scroll--post-command'
+;; below), not the debounced per-buffer render.
 
 ;; Refresh triggers, deferred until each source package loads.
 (with-eval-after-load 'evil
@@ -565,7 +705,7 @@ the recompute yields the same hunks we skip, breaking the cycle."
 (with-eval-after-load 'flycheck
   (add-hook 'flycheck-after-syntax-check-hook #'zetta-svg-margin--refresh))
 (add-hook 'post-command-hook #'zetta-svg-margin--symbol-watch)
-(add-hook 'window-scroll-functions #'zetta-svg-margin-scroll--on-scroll)
+(add-hook 'post-command-hook #'zetta-svg-margin-scroll--post-command)
 
 ;;;; Activation
 ;; ----------------------------------------------------------------

--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -313,6 +313,58 @@
           (forward-line 1)))
       out)))
 
+(defcustom zetta-svg-margin-wrap-color "#6b7280"
+  "Colour of the margin line-wrap / visual-line indicator."
+  :type 'color :group 'zetta)
+
+(defcustom zetta-svg-margin-wrap-glyph "nf-md-keyboard_return"
+  "Nerd-Font glyph for a char-wrapped line (`truncate-lines' nil)."
+  :type 'string :group 'zetta)
+
+(defcustom zetta-svg-margin-visual-line-glyph "nf-md-wrap"
+  "Nerd-Font glyph for a wrapped line under `visual-line-mode'."
+  :type 'string :group 'zetta)
+
+(defcustom zetta-svg-margin-wrap-max-lines 10000
+  "Skip the wrap provider in buffers with more than this many lines."
+  :type 'integer :group 'zetta)
+
+(defun zetta-svg-margin-wrap (buffer)
+  "Right-margin glyph on each logical line that wraps in BUFFER's window.
+Replaces the right-fringe continuation/visual-line arrows, which vanish once
+the right fringe is zeroed (see `svg-margin-disable-fringe').  One indicator
+per wrapped logical line, drawn at its first screen row; a distinct glyph is
+used under `visual-line-mode'.  No-op when lines are truncated (no wrap) or the
+buffer is huge (`zetta-svg-margin-wrap-max-lines').
+
+A line is judged to wrap when its display-column width exceeds the displaying
+window's body width -- a cheap, fixed-pitch approximation; exact pixel layout
+(variable-pitch, `wrap-prefix') is not consulted."
+  (with-current-buffer buffer
+    (when (and (not truncate-lines)
+               (<= (count-lines (point-min) (point-max))
+                   zetta-svg-margin-wrap-max-lines))
+      (let* ((win (get-buffer-window buffer))
+             (cols (and win (window-body-width win)))
+             (vlm (bound-and-true-p visual-line-mode))
+             (glyph (zetta-svg-margin--glyph
+                     (if vlm zetta-svg-margin-visual-line-glyph
+                       zetta-svg-margin-wrap-glyph)))
+             out)
+        (when (and cols glyph)
+          (save-excursion
+            (goto-char (point-min))
+            (while (not (eobp))
+              (when (> (progn (end-of-line) (current-column)) cols)
+                (let ((bol (line-beginning-position)))
+                  (push (list :pos bol :text glyph
+                              :color zetta-svg-margin-wrap-color
+                              :font zetta-svg-margin-icon-font :scale 1.0
+                              :help (if vlm "visual-line wrap" "line wraps"))
+                        out)))
+              (forward-line 1))))
+        out))))
+
 (defun zetta-svg-margin-org-headings (buffer)
   "A numbered-circle level marker per Org heading in the left margin.
 This is the org-margin idea delivered through an svg-margin provider: each
@@ -670,10 +722,12 @@ the recompute yields the same hunks we skip, breaking the cycle."
 ;;;; Configuration + registration
 ;; ----------------------------------------------------------------
 
-;; Reclaim only the left fringe (evil-fringe-mark's old home).  The right
-;; fringe no longer hosts yascroll (the scrollbar provider draws in the
-;; margin now) but keeps the line-continuation arrows, so leave it alone.
-(setq svg-margin-disable-fringe 'left)
+;; Reclaim BOTH fringes.  Left was evil-fringe-mark's old home; right hosted
+;; the line-continuation / visual-line arrows.  Those arrows now come from the
+;; `zetta-svg-margin-wrap' provider in the right margin, so the right fringe is
+;; redundant -- zero it too (`zetta-svg-margin-visual-line-glyph' /
+;; `-wrap-glyph' replace `top-right-angle' and the continuation arrow).
+(setq svg-margin-disable-fringe 'both)
 
 ;; Reserve a baseline margin width so buffer text doesn't shift as indicators
 ;; come and go (the margin still grows past this when a line needs more).
@@ -692,6 +746,7 @@ the recompute yields the same hunks we skip, breaking the cycle."
 (svg-margin-register-provider 'long-lines   #'zetta-svg-margin-long-lines   :side 'right :priority 3)
 (svg-margin-register-provider 'symbol       #'zetta-svg-margin-symbol       :side 'left  :priority 2)
 (svg-margin-register-provider 'trailing-ws  #'zetta-svg-margin-trailing-ws  :side 'right :priority 1)
+(svg-margin-register-provider 'wrap         #'zetta-svg-margin-wrap         :side 'right :priority 0)
 ;; The scroll thumb is NOT a provider -- it is a window-anchored layer driven
 ;; synchronously from `post-command-hook' (`zetta-svg-margin-scroll--post-command'
 ;; below), not the debounced per-buffer render.
@@ -706,6 +761,10 @@ the recompute yields the same hunks we skip, breaking the cycle."
   (add-hook 'flycheck-after-syntax-check-hook #'zetta-svg-margin--refresh))
 (add-hook 'post-command-hook #'zetta-svg-margin--symbol-watch)
 (add-hook 'post-command-hook #'zetta-svg-margin-scroll--post-command)
+;; Wrap state depends on `truncate-lines' / `visual-line-mode'; window resize is
+;; already covered by the package's `window-configuration-change-hook'.
+(add-hook 'visual-line-mode-hook #'zetta-svg-margin--refresh)
+(advice-add 'toggle-truncate-lines :after #'zetta-svg-margin--refresh)
 
 ;;;; Activation
 ;; ----------------------------------------------------------------

--- a/modules/ui/tab-bar-svg.el
+++ b/modules/ui/tab-bar-svg.el
@@ -34,11 +34,11 @@ its text.  Plain all-text rows use exact font anchoring and ignore this."
   :type 'number :group 'zetta)
 
 (defcustom zetta-tab-bar-svg-icon t
-  "When non-nil, draw a full-height Emacs-logo masthead at the left of the tab bar."
+  "When non-nil, draw a full-height major-mode-icon masthead at the left of the tab bar."
   :type 'boolean :group 'zetta)
 
 (defcustom zetta-tab-bar-svg-icon-color "#6c4dab"
-  "Fill colour for the tab-bar masthead icon (a purple that fits the theme)."
+  "Fill colour for the tab-bar masthead major-mode icon (a purple that fits the theme)."
   :type 'color :group 'zetta)
 
 (defcustom zetta-tab-bar-svg-icon-width 'square
@@ -105,148 +105,22 @@ jitters as keycast changes width."
                  blinker-tab-bar)
          :center nil
          :right '(zetta-tab-bar-svg--elfeed "  " zetta-tab-bar-svg--mu4e))
-   ;; line 3 -- Spotify left; calendar centre; space-tree (+battery/prefix) right
+   ;; line 3 -- Spotify left; clock centre (it spans all 3 rows); battery/prefix/space-tree right
    (list :left '(zetta-tab-bar-svg--spotify)
          :center nil
          :right '(zetta-tab-bar-svg--battery " "
                   zetta-current-prefix "  "
                   zetta-tab-bar-svg--workspace))))
 
-(defun zetta-tab-bar-calendar ()
-  "Calendar glyph + weekday/day/month/year, for the SVG tab bar's last row."
-  (concat (and (featurep 'nerd-icons)
-               (ignore-errors (concat (nerd-icons-mdicon "nf-md-calendar_month") " ")))
-          (format-time-string "%a  %d %b %Y")))
-
 (defcustom zetta-tab-bar-calendar-color "#9aa0aa"
   "Gray colour for the tab-bar clock and the minimalist date widget (kept uniform)."
   :type 'color :group 'zetta)
 
-(defconst zetta-tab-bar--moon-glyph-names
-  ["nf-md-moon_new" "nf-md-moon_waxing_crescent" "nf-md-moon_first_quarter"
-   "nf-md-moon_waxing_gibbous" "nf-md-moon_full" "nf-md-moon_waning_gibbous"
-   "nf-md-moon_last_quarter" "nf-md-moon_waning_crescent"]
-  "Nerd Font moon glyphs indexed by lunar octant (0=new, 4=full).")
-
-(defun zetta-tab-bar--moon-octant ()
-  "Return the current lunar octant 0-7 (0=new, 2=first quarter, 4=full, 6=last).
-Phase age is days since the 2000-01-06 18:14 UTC new moon, modulo the mean
-synodic month (29.530588853 d), rounded to the nearest eighth."
-  (let* ((synodic 29.530588853)
-         (ref 947182440.0)                       ; 2000-01-06 18:14 UTC, epoch seconds
-         (days (/ (- (float-time) ref) 86400.0))
-         (cycles (/ days synodic))
-         (frac (- cycles (floor cycles))))
-    (mod (round (* frac 8)) 8)))
-
-(defun zetta-tab-bar--moon-glyph ()
-  "Raw (unpropertized) Nerd Font glyph for the current moon phase, or nil."
-  (when (require 'nerd-icons nil t)
-    (let ((g (ignore-errors
-               (nerd-icons-mdicon
-                (aref zetta-tab-bar--moon-glyph-names (zetta-tab-bar--moon-octant))))))
-      (and g (substring-no-properties g)))))
-
-(defun zetta-tab-bar-calendar--build ()
-  "Build the minimalist date widget as an svg.el DOM (spliced as vectors, sharp):
-an outlined weekday badge + an outlined date box (small month over big day) +
-the current moon-phase glyph, monochrome in `zetta-tab-bar-calendar-color'."
-  (let* ((col zetta-tab-bar-calendar-color)
-         (h 30) (gap (round (* h 0.24))) (wd-w (round (* h 1.05))) (pw (round (* h 0.98)))
-         (rx (max 2 (round (* h 0.16))))
-         ;; vertical inset so the outline stroke isn't clipped at the bar edge
-         (vm 2) (bh (- h (* 2 vm)))
-         (svg (svg-create 600 h)) (x 0))
-    ;; weekday -- outlined
-    (svg-rectangle svg x vm wd-w bh :rx rx :fill "none" :stroke col :stroke-width 1.5)
-    (svg-text svg (upcase (format-time-string "%a")) :x (+ x (/ wd-w 2)) :y (round (* h 0.69))
-              :text-anchor "middle" :font-family "Helvetica" :font-size (round (* h 0.46)) :font-weight "bold" :fill col)
-    (setq x (+ x wd-w gap))
-    ;; date -- outlined box, small month over big day
-    (svg-rectangle svg x vm pw bh :rx rx :fill "none" :stroke col :stroke-width 1.5)
-    (svg-text svg (upcase (format-time-string "%b")) :x (+ x (/ pw 2)) :y (round (* h 0.36))
-              :text-anchor "middle" :font-family "Helvetica" :font-size (round (* h 0.27)) :font-weight "bold" :fill col)
-    (svg-text svg (format-time-string "%-d") :x (+ x (/ pw 2)) :y (round (* h 0.88))
-              :text-anchor "middle" :font-family "Helvetica" :font-size (round (* h 0.5)) :font-weight "bold" :fill col)
-    (setq x (+ x pw))
-    ;; moon phase -- nerd-font glyph to the right of the date box
-    (let ((moon (zetta-tab-bar--moon-glyph)))
-      (when moon
-        (setq x (+ x gap))
-        (svg-text svg moon :x (+ x (round (* h 0.34))) :y (round (* h 0.74))
-                  :text-anchor "middle" :font-family "Terminess Nerd Font Mono"
-                  :font-size (round (* h 0.78)) :fill col)
-        (setq x (+ x (round (* h 0.68))))))
-    (dom-set-attribute svg 'width (number-to-string x))
-    svg))
-
-(defvar zetta-tab-bar-calendar--cache nil
-  "Cons of (DAY-KEY . SVG-DOM) so the date widget is rebuilt at most once a day.")
-(defun zetta-tab-bar-calendar-image ()
-  "The date-widget SVG DOM, rebuilt only when the day changes."
-  (let ((key (format-time-string "%Y%m%d")))
-    (if (equal (car zetta-tab-bar-calendar--cache) key)
-        (cdr zetta-tab-bar-calendar--cache)
-      (cdr (setq zetta-tab-bar-calendar--cache (cons key (zetta-tab-bar-calendar--build)))))))
-
-;;; ------------------------------------------------------------------
-;;; Sunrise / sunset (flanking the clock on the first row).  Needs a
-;;; location for `solar-sunrise-sunset'; set it here (only when unset, so
-;;; an explicit setting elsewhere wins) so the feature works at startup.
-;;; ------------------------------------------------------------------
-(with-eval-after-load 'solar
-  (unless (numberp (bound-and-true-p calendar-latitude))
-    (setq calendar-latitude 39.95
-          calendar-longitude -75.17
-          calendar-location-name "Philadelphia, PA"
-          calendar-time-zone -300
-          calendar-standard-time-zone-name "EST"
-          calendar-daylight-time-zone-name "EDT")))
-
-(defun zetta-tab-bar--fmt-suntime (decimal)
-  "Format DECIMAL hours (0-24) as a 24-hour \"HH:MM\" string."
-  (let* ((h24 (floor decimal))
-         (m (round (* 60 (- decimal h24)))))
-    (when (= m 60) (setq m 0 h24 (1+ h24)))
-    (format "%02d:%02d" (mod h24 24) m)))
-
-(defun zetta-tab-bar--compute-sun ()
-  "Compute ((SUNRISE . GLYPH) . (SUNSET . GLYPH)) for the clock flank.
-Returns nil if `solar'/`nerd-icons' or a location is unavailable."
-  (when (and (require 'solar nil t) (require 'nerd-icons nil t)
-             (numberp (bound-and-true-p calendar-latitude))
-             (numberp (bound-and-true-p calendar-longitude)))
-    (let* ((ss (ignore-errors (solar-sunrise-sunset (calendar-current-date))))
-           (rise (car ss)) (set (cadr ss))
-           (rise-s (and (numberp (car rise)) (zetta-tab-bar--fmt-suntime (car rise))))
-           (set-s  (and (numberp (car set))  (zetta-tab-bar--fmt-suntime (car set))))
-           (gr (ignore-errors (substring-no-properties (nerd-icons-wicon "nf-weather-sunrise"))))
-           (gs (ignore-errors (substring-no-properties (nerd-icons-wicon "nf-weather-sunset")))))
-      ;; Each side is (TIME . GLYPH); the `:flank' span draws the glyph nearest
-      ;; the clock at a larger size and the time on its outer side.
-      (cons (and rise-s gr (cons rise-s gr))
-            (and set-s gs (cons set-s gs))))))
-
-(defvar zetta-tab-bar--sun-cache nil
-  "Cons of (DAY-KEY . (LEFT . RIGHT)) so sunrise/sunset compute once a day.")
-(defun zetta-tab-bar--sun-strings ()
-  "The (LEFT . RIGHT) sunrise/sunset flank strings, recomputed once a day."
-  (let ((key (format-time-string "%Y%m%d")))
-    (if (equal (car zetta-tab-bar--sun-cache) key)
-        (cdr zetta-tab-bar--sun-cache)
-      (cdr (setq zetta-tab-bar--sun-cache (cons key (zetta-tab-bar--compute-sun)))))))
-
 (defun zetta-tab-bar-svg-spans ()
-  "Analog clock spanning lines 1-2 (centre), sunrise/sunset flanking it on the
-first row; the date widget (with moon phase) below, on the last row."
-  (let* ((gray zetta-tab-bar-calendar-color)
-         (cal (zetta-tab-bar-calendar-image))
-         (sun (zetta-tab-bar--sun-strings)))
-    (append
-     (list (list :clock '(0 . 1) gray gray))
-     (and sun (or (car sun) (cdr sun))
-          (list (list :flank '(0 . 1) (car sun) (cdr sun) gray)))
-     (and cal (list (list :image '(2 . 2) cal 'center))))))
+  "Analog clock spanning all three rows in the centre.
+The sunrise/sunset flank and the date/moon-phase widget were removed."
+  (let ((gray zetta-tab-bar-calendar-color))
+    (list (list :clock '(0 . 2) gray gray))))
 
 (defvar zetta-tab-bar-svg--clock-timer nil
   "Periodic timer that re-renders the SVG tab bar so the analog clock ticks.")
@@ -292,8 +166,8 @@ first row; the date widget (with moon phase) below, on the last row."
                  :line-pad (lambda () zetta-tab-bar-svg-line-pad)
                  :char-advance (lambda () zetta-tab-bar-svg-char-advance)
                  :icon (lambda () (and zetta-tab-bar-svg-icon
-                                       (fboundp 'zetta-tab-bar-emacs-icon)
-                                       (zetta-tab-bar-emacs-icon)))
+                                       (fboundp 'zetta-tab-bar-mode-icon)
+                                       (zetta-tab-bar-mode-icon)))
                  :icon-color (lambda () zetta-tab-bar-svg-icon-color)
                  :icon-width (lambda () zetta-tab-bar-svg-icon-width)
                  :icon-scale (lambda () zetta-tab-bar-svg-icon-scale)

--- a/source/bootstrap/bootstrap-gcmh.el
+++ b/source/bootstrap/bootstrap-gcmh.el
@@ -1,0 +1,30 @@
+;;; bootstrap-gcmh.el --- GC management via gcmh -*- lexical-binding: t; -*-
+
+;; The intermittent ~1s buffer-switch lag in long sessions is garbage
+;; collection: with `gc-cons-threshold' reset to 16MB after init, GC fires
+;; often, and on a large heap (a day-long session, many buffers, lots of SVG
+;; margin/modeline images) a single collection costs 141ms-1.5s.  Roughly a
+;; third of switches trip one mid-redisplay -> the hitch.
+;;
+;; gcmh keeps `gc-cons-threshold' high during activity so GC almost never
+;; fires mid-command, and collects during idle instead -- moving the pause
+;; off the interaction path.  gcmh owns GC from here, so the early-init
+;; `zetta--restore-gc' (which would reset to 16MB) is cancelled.
+
+(use-package gcmh
+  :ensure t
+  :init
+  ;; Cancel the early-init reset to 16MB and hold a safe baseline until
+  ;; `gcmh-mode' takes over (this also covers the case where gcmh fails to
+  ;; build -- the threshold stays sane rather than 16MB or unbounded).
+  (when (fboundp 'zetta--restore-gc)
+    (remove-hook 'emacs-startup-hook #'zetta--restore-gc))
+  (setq gc-cons-threshold (* 128 1024 1024))
+  :config
+  (setq gcmh-idle-delay 'auto                 ; scale idle delay to GC cost
+        gcmh-auto-idle-delay-factor 10
+        gcmh-high-cons-threshold (* 256 1024 1024))
+  (gcmh-mode 1))
+
+(provide 'bootstrap-gcmh)
+;;; bootstrap-gcmh.el ends here

--- a/source/bootstrap/bootstrap.el
+++ b/source/bootstrap/bootstrap.el
@@ -1,6 +1,7 @@
 ;;; bootstrap.el --- Configure bootstrap loader -*- lexical-binding: t; -*-
 
 (require 'bootstrap-elpaca)
+(require 'bootstrap-gcmh)
 (require 'bootstrap-compile-angel)
 (require 'bootstrap-use-package-keywords)
 (require 'bootstrap-utils)

--- a/source/zettapkg/embark-scope/embark-scope.el
+++ b/source/zettapkg/embark-scope/embark-scope.el
@@ -179,6 +179,103 @@ per `embark-scope-word-finder-modes' +
                   (cons beg end))))))
 
 
+;;;; Expansion-ladder finder (expand-region nesting levels)
+;; ----------------------------------------------------------------
+;; Surface every expand-region nesting level at point as an
+;; `expansion' target, so the bounds-sorted target cycle (`C-.' /
+;; `C-,') steps through fine syntactic nesting -- the rungs embark's
+;; coarse finders skip (they give one `expression', then `defun', and
+;; nothing in between).  Soft dependency on expand-region: a no-op
+;; when it isn't installed.  Add the finder to `embark-target-finders'
+;; to enable (see the README); `embark-scope--dedup-expansion-bounds'
+;; (folded into the sort) then drops levels that coincide with a named
+;; target so expand-region only fills the gaps.
+
+(defvar er/history)
+(defvar expand-region-fast-keys-enabled)
+(declare-function er/expand-region "expand-region" (arg))
+
+(defcustom embark-scope-expansion-finder-modes '(prog-mode text-mode)
+  "Major modes (and derivatives) where `embark-scope-target-expansions' fires."
+  :type '(repeat symbol)
+  :group 'embark-scope)
+
+(defcustom embark-scope-expansion-max-levels 24
+  "Hard cap on the number of nesting levels the expansion finder enumerates."
+  :type 'integer
+  :group 'embark-scope)
+
+(defun embark-scope--enumerate-expansions (cap)
+  "Return up to CAP expand-region levels at point as (BEG . END), innermost first.
+Drives `er/expand-region' inside `save-mark-and-excursion' so the
+user's point, mark and region are left untouched.  Trailing
+whitespace is trimmed from each level's end and exact duplicates are
+dropped."
+  (when (fboundp 'er/expand-region)
+    (let* ((win (selected-window))
+           (wstart (and (eq (window-buffer win) (current-buffer))
+                        (window-start win))))
+      (unwind-protect
+          ;; `inhibit-redisplay' keeps er's far point excursions (expanding an
+          ;; org list/subtree, say) from tripping a redisplay that scrolls the
+          ;; window mid-walk -- `save-mark-and-excursion' restores point but not
+          ;; `window-start', which left `embark-act' repositioning the buffer.
+          (let ((inhibit-redisplay t))
+            (save-mark-and-excursion
+              (let ((er/history (list)) (levels '()) (prev nil)
+                    ;; Drive er purely as a query.  With fast-keys on (default),
+                    ;; `er/expand-region' runs `er/prepare-for-more-expansions'
+                    ;; every call -- it sets `overriding-terminal-local-map' to a
+                    ;; transient map bound to the last key and echoes a hint.
+                    ;; That leftover map hijacked the next keystroke into an
+                    ;; interactive expand+recenter; disabling fast-keys stops it.
+                    (expand-region-fast-keys-enabled nil)
+                    ;; er also `push-mark's during expansion; keep it off the ring.
+                    (mark-ring mark-ring))
+                (deactivate-mark)
+                (catch 'done
+                  (dotimes (_ cap)
+                    (condition-case nil (er/expand-region 1) (error (throw 'done nil)))
+                    (unless (region-active-p) (throw 'done nil))
+                    (let ((raw (cons (region-beginning) (region-end))))
+                      ;; er stopped growing -> ladder exhausted.
+                      (when (equal raw prev) (throw 'done nil))
+                      (setq prev raw)
+                      (let* ((beg (car raw))
+                             (end (save-excursion
+                                    (goto-char (cdr raw))
+                                    (skip-chars-backward " \t\n" beg)
+                                    (point)))
+                             (b (cons beg end)))
+                        (when (and (< beg end) (not (member b levels)))
+                          (push b levels))))))
+                (nreverse levels))))
+        ;; Belt and suspenders: er can still leave the viewport scrolled;
+        ;; restore the original window-start.
+        (when (and wstart (window-live-p win)
+                   (eq (window-buffer win) (current-buffer)))
+          (set-window-start win wstart t))))))
+
+(defun embark-scope-target-expansions ()
+  "Embark target finder: expand-region nesting levels at point.
+Returns a LIST of `expansion' targets (innermost first) so the
+bounds-sorted cycle (`C-.' / `C-,') walks fine syntactic nesting.
+No-op without expand-region, in the minibuffer / pop-up UIs, or
+outside `embark-scope-expansion-finder-modes'."
+  (when (and (fboundp 'er/expand-region)
+             (not (or (minibufferp)
+                      (derived-mode-p 'completion-list-mode
+                                      'embark-collect-mode)))
+             (apply #'derived-mode-p embark-scope-expansion-finder-modes))
+    (let ((levels (embark-scope--enumerate-expansions
+                   embark-scope-expansion-max-levels)))
+      (mapcar (lambda (b)
+                (cons 'expansion
+                      (cons (buffer-substring-no-properties (car b) (cdr b))
+                            (cons (car b) (cdr b)))))
+              levels))))
+
+
 ;;;; Cycle sort
 ;; ----------------------------------------------------------------
 
@@ -192,11 +289,42 @@ target cycle by bounds size (ascending)."
   "Dynamic flip controlling sort direction.  Bound by
 `embark-scope-act-contract'.")
 
+(defcustom embark-scope-expansion-dedup-p t
+  "When non-nil, drop `expansion' targets whose bounds duplicate a
+non-`expansion' target.  This lets the expand-region ladder
+(`embark-scope-target-expansions') fill only the rungs embark's
+named finders leave empty: a level that coincides with the
+`identifier', `expression' or `defun' target is removed so the named
+type -- and its keymap -- wins.  Applied by
+`embark-scope--sort-targets-by-bounds'."
+  :type 'boolean
+  :group 'embark-scope)
+
+(defun embark-scope--dedup-expansion-bounds (targets)
+  "Remove `expansion' TARGETS whose bounds match a non-expansion target."
+  (if embark-scope-expansion-dedup-p
+      (let ((named-bounds
+             (delq nil (mapcar
+                        (lambda (tgt)
+                          (unless (eq (plist-get tgt :type) 'expansion)
+                            (plist-get tgt :bounds)))
+                        targets))))
+        (if named-bounds
+            (cl-remove-if
+             (lambda (tgt)
+               (and (eq (plist-get tgt :type) 'expansion)
+                    (member (plist-get tgt :bounds) named-bounds)))
+             targets)
+          targets))
+    targets))
+
 (defun embark-scope--sort-targets-by-bounds (targets)
   "Sort TARGETS by bounds size ascending (innermost first).
 Targets without bounds keep their relative order at the end of the
 list.  When `embark-scope--sort-reverse' is non-nil, the cycle
-order flips (outermost first)."
+order flips (outermost first).  Duplicate-bounds `expansion' targets
+are dropped first per `embark-scope-expansion-dedup-p'."
+  (setq targets (embark-scope--dedup-expansion-bounds targets))
   (if embark-scope-sort-by-bounds-p
       (let* ((with-bounds (cl-remove-if-not
                            (lambda (tgt) (plist-get tgt :bounds))
@@ -679,6 +807,24 @@ no-op.  Returns ROTATED-TARGETS unchanged."
 ;;;; Pick: target type (consult)
 ;; ----------------------------------------------------------------
 
+(defcustom embark-scope-pick-exclude-types '(expansion)
+  "Target types hidden from the by-type pickers.
+`embark-scope-pick-target-type' and
+`embark-scope-pick-target-type-key' drop targets of these types.
+
+expand-region's `expansion' levels are concentric and all share one
+type, so they belong to the `C-.' / `C-,' expand/contract cycle, not
+the by-type pickers: the single-key picker assigns one key per type,
+which would leave every expansion level but the first unreachable."
+  :type '(repeat symbol)
+  :group 'embark-scope)
+
+(defun embark-scope--pickable-targets ()
+  "`embark--targets' with `embark-scope-pick-exclude-types' removed."
+  (cl-remove-if (lambda (tgt)
+                  (memq (plist-get tgt :type) embark-scope-pick-exclude-types))
+                (embark--targets)))
+
 (defun embark-scope--pick-target-type-do (candidates)
   "Open `consult--read' to pick from CANDIDATES, re-enter
 `embark-act' on the chosen target.  Preview paints the focused
@@ -721,7 +867,7 @@ candidate's bounds with `embark-scope-other-instance-face'."
 Uses `consult--read' with preview.  Defers via `run-at-time' so the
 consult UI opens cleanly after embark-act's prompt exits."
   (interactive)
-  (let* ((targets (embark--targets))
+  (let* ((targets (embark-scope--pickable-targets))
          (candidates
           (cl-loop for tgt in targets
                    when (plist-get tgt :bounds)
@@ -803,7 +949,7 @@ embark-act's prompt exits."
   (interactive)
   (let* ((targets (cl-remove-if-not
                    (lambda (tgt) (plist-get tgt :bounds))
-                   (embark--targets)))
+                   (embark-scope--pickable-targets)))
          (types (mapcar (lambda (tgt) (plist-get tgt :type)) targets))
          (key->type (embark-scope--assign-type-keys types))
          (choices (mapcar


### PR DESCRIPTION
## Problem

`zetta-consult-elfeed` froze and logged `prog1: Symbol's value as variable is void: state-fn` on first use — recurring even after the earlier fix.

`zetta--consult-preview-hide-tabline` (PR #56) returned a lambda that closes over `STATE-FN`. That requires the file to be loaded **lexically**. If the function is ever (re)defined in a dynamic-binding context (e.g. a stray `emacsclient --eval` reload, or any non-lexical load path), the closure's `STATE-FN` is a void free variable. consult calls the state function with `'setup` the instant a picker opens, so the broken advice errors immediately — which both logs the void-variable message and hangs the picker (the "freeze").

## Fix

Split into a plain helper (`…-hide-tabline-1`, takes STATE-FN + SAVED as args) and an `apply-partially` wrapper. `apply-partially` is defined lexically in subr.el, so the partial it returns captures STATE-FN/SAVED correctly **regardless of how this file was loaded** — no lexical-capture dependency in our own code.

## Testing

Loaded the new defuns under **dynamic binding** (the exact failing condition) and exercised the wrapper with `'setup`/`'exit`: no error (previously `void-variable state-fn`). Already live in the session. Parens balance.