### PR TITLE
fix(svg-margin): draw wrap + scroll indicators in the fringe, not the margin

### DIFF
--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -313,58 +313,6 @@
           (forward-line 1)))
       out)))
 
-(defcustom zetta-svg-margin-wrap-color "#6b7280"
-  "Colour of the margin line-wrap / visual-line indicator."
-  :type 'color :group 'zetta)
-
-(defcustom zetta-svg-margin-wrap-glyph "nf-md-keyboard_return"
-  "Nerd-Font glyph for a char-wrapped line (`truncate-lines' nil)."
-  :type 'string :group 'zetta)
-
-(defcustom zetta-svg-margin-visual-line-glyph "nf-md-wrap"
-  "Nerd-Font glyph for a wrapped line under `visual-line-mode'."
-  :type 'string :group 'zetta)
-
-(defcustom zetta-svg-margin-wrap-max-lines 10000
-  "Skip the wrap provider in buffers with more than this many lines."
-  :type 'integer :group 'zetta)
-
-(defun zetta-svg-margin-wrap (buffer)
-  "Right-margin glyph on each logical line that wraps in BUFFER's window.
-Replaces the right-fringe continuation/visual-line arrows, which vanish once
-the right fringe is zeroed (see `svg-margin-disable-fringe').  One indicator
-per wrapped logical line, drawn at its first screen row; a distinct glyph is
-used under `visual-line-mode'.  No-op when lines are truncated (no wrap) or the
-buffer is huge (`zetta-svg-margin-wrap-max-lines').
-
-A line is judged to wrap when its display-column width exceeds the displaying
-window's body width -- a cheap, fixed-pitch approximation; exact pixel layout
-(variable-pitch, `wrap-prefix') is not consulted."
-  (with-current-buffer buffer
-    (when (and (not truncate-lines)
-               (<= (count-lines (point-min) (point-max))
-                   zetta-svg-margin-wrap-max-lines))
-      (let* ((win (get-buffer-window buffer))
-             (cols (and win (window-body-width win)))
-             (vlm (bound-and-true-p visual-line-mode))
-             (glyph (zetta-svg-margin--glyph
-                     (if vlm zetta-svg-margin-visual-line-glyph
-                       zetta-svg-margin-wrap-glyph)))
-             out)
-        (when (and cols glyph)
-          (save-excursion
-            (goto-char (point-min))
-            (while (not (eobp))
-              (when (> (progn (end-of-line) (current-column)) cols)
-                (let ((bol (line-beginning-position)))
-                  (push (list :pos bol :text glyph
-                              :color zetta-svg-margin-wrap-color
-                              :font zetta-svg-margin-icon-font :scale 1.0
-                              :help (if vlm "visual-line wrap" "line wraps"))
-                        out)))
-              (forward-line 1))))
-        out))))
-
 (defun zetta-svg-margin-org-headings (buffer)
   "A numbered-circle level marker per Org heading in the left margin.
 This is the org-margin idea delivered through an svg-margin provider: each
@@ -453,204 +401,6 @@ edit/execute from the menu."
                           out)))))))
         out))))
 
-;;;; Scroll thumb -- window-anchored, pixel-smooth, synchronous
-;; A yascroll-style thumb in the right margin, done right.  The old version
-;; was a buffer-anchored `:background' provider rendered on svg-margin's 0.1s
-;; IDLE debounce, so during a continuous scroll it never re-rendered: the
-;; thumb (pinned to text) scrolled away and only snapped back on pause
-;; (hence the flash + no ultra-scroll response), and line-number math made it
-;; jitter and vary in height.  This is anchored to the WINDOW, recomputed from
-;; the live viewport and drawn SYNCHRONOUSLY on every scroll (no idle debounce
-;; -- tracks ultra-scroll, never flashes).  Position/size come from the
-;; viewport's CHAR-fraction (O(1), smooth); the top/bottom rows get a PARTIAL
-;; SVG fill for sub-line precision.  It re-composites visible lines from
-;; svg-margin's render cache, so providers never re-run while scrolling.
-
-(defcustom zetta-svg-margin-scroll-color "#7c828c"
-  "Colour of the margin scroll thumb." :type 'color :group 'zetta)
-(defcustom zetta-svg-margin-scroll-opacity 0.6
-  "Opacity (0..1) of the margin scroll thumb." :type 'number :group 'zetta)
-(defcustom zetta-svg-margin-scroll-width 0.55
-  "Thumb width: a fraction of the right margin when < 1, else pixels."
-  :type 'number :group 'zetta)
-(defcustom zetta-svg-margin-scroll-min-pixels 18
-  "Minimum thumb height in pixels." :type 'integer :group 'zetta)
-(defcustom zetta-svg-margin-scroll-hide-delay 1.0
-  "Seconds the thumb stays visible after scrolling stops."
-  :type 'number :group 'zetta)
-
-(defvar-local zetta-svg-margin-scroll--ovs nil
-  "Thumb-only overlays created on the current tick.")
-(defvar-local zetta-svg-margin-scroll--saved nil
-  "Alist (CONTENT-OVERLAY . ORIG-BEFORE-STRING) composited onto this tick.")
-(defvar-local zetta-svg-margin-scroll--until nil
-  "Time until which the thumb is shown, or nil.")
-(defvar-local zetta-svg-margin-scroll--hide-timer nil)
-
-(defun zetta-svg-margin-scroll--clear ()
-  "Undo this tick's thumb layer: restore composited overlays, delete ours."
-  (dolist (pair zetta-svg-margin-scroll--saved)
-    (when (overlayp (car pair))
-      (overlay-put (car pair) 'before-string (cdr pair))))
-  (setq zetta-svg-margin-scroll--saved nil)
-  (dolist (ov zetta-svg-margin-scroll--ovs)
-    (when (overlayp ov) (delete-overlay ov)))
-  (setq zetta-svg-margin-scroll--ovs nil))
-
-(defun zetta-svg-margin-scroll--line-y (pos win)
-  "Top pixel Y of POS within WIN's body, or nil if POS is not visible."
-  (let ((v (pos-visible-in-window-p pos win t)))
-    (and v (nth 1 v))))
-
-(defun zetta-svg-margin-scroll--rows (win start lh)
-  "Return (BOL Y0 Y1) per LOGICAL line WIN's thumb covers, from START.
-Each entry becomes ONE LH-tall (single screen row) margin image at a line's
-bol.  Margin images MUST be one screen row tall -- a taller one (e.g. a whole
-wrapped line) does not fit and Emacs falls back to rendering the overlay
-string INLINE, inserting whitespace into the buffer.  So each line contributes
-only its FIRST screen row; on wrapped lines the continuation rows stay unpainted
-\(a margin limitation), but the buffer is never disturbed.  The viewport's
-char-fraction is intersected with each first row for sub-line partial fills."
-  (let ((total (- (point-max) (point-min)))
-        (track (window-body-height win t)))
-    (when (> total 0)
-      (let (lines (end start))
-        (save-excursion
-          (goto-char start)
-          (catch 'done
-            (while (not (eobp))
-              (let* ((bol (line-beginning-position))
-                     (y (zetta-svg-margin-scroll--line-y bol win)))
-                (when (or (null y) (>= y track)) (throw 'done nil))
-                (push (cons bol (float y)) lines)
-                (forward-line 1)
-                (setq end (point))
-                (when (eobp) (throw 'done nil))))))
-        (setq lines (nreverse lines))
-        (let* ((tp (* track (/ (float (- start (point-min))) total)))
-               (bp (* track (/ (float (- end (point-min))) total))))
-          (when (< (- bp tp) zetta-svg-margin-scroll-min-pixels)
-            (let ((g (/ (- zetta-svg-margin-scroll-min-pixels (- bp tp)) 2.0)))
-              (setq tp (- tp g) bp (+ bp g))))
-          (setq tp (max 0.0 (min tp (float track)))
-                bp (max 0.0 (min bp (float track))))
-          (when (> bp (+ tp 0.5))
-            (let (rows)
-              (dolist (ln lines)
-                (let* ((bol (car ln)) (ytop (cdr ln))
-                       (ybot (+ ytop lh))            ; first screen row only
-                       (o0 (max tp (max 0.0 ytop))) (o1 (min bp ybot)))
-                  (when (> o1 o0)
-                    (push (list bol (- o0 ytop) (- o1 ytop)) rows))))
-              (nreverse rows))))))))
-
-(defun zetta-svg-margin-scroll--image (rcols cw rh y0 y1 right-packed)
-  "SVG for one thumb row: a partial fill (Y0..Y1) plus cached RIGHT-PACKED icons."
-  (let* ((w (max 1 (* rcols cw)))
-         (h (max 1 (round rh)))
-         (svg (svg-create w h))
-         (tw (if (>= zetta-svg-margin-scroll-width 1)
-                 (round zetta-svg-margin-scroll-width)
-               (max 2 (round (* w zetta-svg-margin-scroll-width)))))
-         (tx (max 0 (- w tw)))
-         (fy (max 0 (round y0)))
-         (fh (max 1 (round (- y1 y0)))))
-    ;; Square corners: each line is a separate image, so rounding every row
-    ;; would pinch the bar into a stack of pills.  A flat bar reads as one
-    ;; continuous thumb.
-    (svg-rectangle svg tx fy tw fh
-                   :fill (if (fboundp 'svg-margin--color)
-                             (svg-margin--color zetta-svg-margin-scroll-color)
-                           zetta-svg-margin-scroll-color)
-                   :fill-opacity zetta-svg-margin-scroll-opacity)
-    (dolist (cell right-packed)
-      (let ((col (plist-get cell :column)) (ind (plist-get cell :indicator)))
-        (when (and col (fboundp 'svg-margin--draw))
-          (ignore-errors (svg-margin--draw ind svg (* col cw) 0 cw h)))))
-    (svg-image svg :ascent 'center :scale 1.0)))
-
-(defun zetta-svg-margin-scroll--right-overlay (pos)
-  "The svg-margin RIGHT-margin content overlay at POS, if any."
-  (cl-find-if
-   (lambda (o)
-     (and (overlay-get o 'svg-margin)
-          (let ((bs (overlay-get o 'before-string)))
-            (and (stringp bs) (> (length bs) 0)
-                 (let ((d (get-text-property 0 'display bs)))
-                   (and (consp d) (consp (car d))
-                        (eq (cadr (car d)) 'right-margin)))))))
-   (overlays-in pos pos)))
-
-(defun zetta-svg-margin-scroll--update (win start)
-  "Redraw WIN's scroll thumb now (window-anchored, synchronous)."
-  (when (window-live-p win)
-    (let ((buf (window-buffer win)))
-      (when (buffer-local-value 'svg-margin-mode buf)
-        (with-current-buffer buf
-          (zetta-svg-margin-scroll--clear)
-          (when (and zetta-svg-margin-scroll--until
-                     (time-less-p nil zetta-svg-margin-scroll--until)
-                     (bound-and-true-p svg-margin--render-cache))
-            (let* ((cache svg-margin--render-cache)
-                   (content (plist-get cache :content))
-                   (cw (or (plist-get cache :cw) (frame-char-width)))
-                   (lh (or (plist-get cache :lh) (default-line-height)))
-                   (rcols (max 1 (or (plist-get cache :right) 2)))
-                   (rows (zetta-svg-margin-scroll--rows
-                          win (or start (window-start win)) lh)))
-              (dolist (r rows)
-                (cl-destructuring-bind (pos y0 y1) r
-                  (let* ((cell (and content (gethash pos content)))
-                         (right (and (consp cell) (cdr cell)))
-                         (img (zetta-svg-margin-scroll--image rcols cw lh y0 y1 right))
-                         (str (propertize " " 'display
-                                          (list '(margin right-margin) img)
-                                          'face 'svg-margin-cell))
-                         (ex (and right (zetta-svg-margin-scroll--right-overlay pos))))
-                    (if ex
-                        (progn
-                          (push (cons ex (overlay-get ex 'before-string))
-                                zetta-svg-margin-scroll--saved)
-                          (overlay-put ex 'before-string str))
-                      (let ((ov (make-overlay pos pos)))
-                        (overlay-put ov 'svg-margin-scroll t)
-                        (overlay-put ov 'before-string str)
-                        (push ov zetta-svg-margin-scroll--ovs)))))))))))))
-
-(defun zetta-svg-margin-scroll--hide (buf)
-  "Drop the thumb in BUF after the hide delay."
-  (when (buffer-live-p buf)
-    (with-current-buffer buf
-      (setq zetta-svg-margin-scroll--until nil)
-      (zetta-svg-margin-scroll--clear))))
-
-(defvar zetta-svg-margin-scroll--last (make-hash-table :test 'eq :weakness 'key)
-  "Window -> (WINDOW-START . VSCROLL) at the last check, to detect scrolling.")
-
-(defun zetta-svg-margin-scroll--post-command ()
-  "Show + redraw the thumb whenever the selected window's viewport moved.
-Keyed off `window-start'/`window-vscroll', so it catches keyboard, mouse-wheel,
-pixel- and ultra-scroll alike -- the old `window-scroll-functions' trigger
-missed pure-pixel and some wheel scrolls (so the thumb only appeared after a
-big jump, and vanished at the bottom).  Runs post-redisplay, so
-`pos-visible-in-window-p'/overlay edits here are safe."
-  (let* ((win (selected-window))
-         (buf (window-buffer win)))
-    (when (buffer-local-value 'svg-margin-mode buf)
-      (let ((cur (cons (window-start win) (window-vscroll win t)))
-            (prev (gethash win zetta-svg-margin-scroll--last)))
-        (unless (equal cur prev)
-          (puthash win cur zetta-svg-margin-scroll--last)
-          (with-current-buffer buf
-            (setq zetta-svg-margin-scroll--until
-                  (time-add nil zetta-svg-margin-scroll-hide-delay))
-            (when (timerp zetta-svg-margin-scroll--hide-timer)
-              (cancel-timer zetta-svg-margin-scroll--hide-timer))
-            (setq zetta-svg-margin-scroll--hide-timer
-                  (run-at-time (+ zetta-svg-margin-scroll-hide-delay 0.02) nil
-                               #'zetta-svg-margin-scroll--hide buf)))
-          (zetta-svg-margin-scroll--update win (window-start win)))))))
-
 (defvar zetta-svg-margin--last-symbol nil
   "Last symbol at point, to refresh only when it changes.")
 
@@ -722,12 +472,12 @@ the recompute yields the same hunks we skip, breaking the cycle."
 ;;;; Configuration + registration
 ;; ----------------------------------------------------------------
 
-;; Reclaim BOTH fringes.  Left was evil-fringe-mark's old home; right hosted
-;; the line-continuation / visual-line arrows.  Those arrows now come from the
-;; `zetta-svg-margin-wrap' provider in the right margin, so the right fringe is
-;; redundant -- zero it too (`zetta-svg-margin-visual-line-glyph' /
-;; `-wrap-glyph' replace `top-right-angle' and the continuation arrow).
-(setq svg-margin-disable-fringe 'both)
+;; Reclaim only the LEFT fringe (evil-fringe-mark's old home; evil marks come
+;; from the margin provider now).  The RIGHT fringe stays: it natively hosts the
+;; per-row line-continuation / visual-line wrap arrows -- which the margin can't
+;; do (right-margin annotations collapse onto a logical line's first screen row,
+;; so per-continuation-row glyphs are impossible there) -- and yascroll's thumb.
+(setq svg-margin-disable-fringe 'left)
 
 ;; Reserve a baseline margin width so buffer text doesn't shift as indicators
 ;; come and go (the margin still grows past this when a line needs more).
@@ -746,10 +496,6 @@ the recompute yields the same hunks we skip, breaking the cycle."
 (svg-margin-register-provider 'long-lines   #'zetta-svg-margin-long-lines   :side 'right :priority 3)
 (svg-margin-register-provider 'symbol       #'zetta-svg-margin-symbol       :side 'left  :priority 2)
 (svg-margin-register-provider 'trailing-ws  #'zetta-svg-margin-trailing-ws  :side 'right :priority 1)
-(svg-margin-register-provider 'wrap         #'zetta-svg-margin-wrap         :side 'right :priority 0)
-;; The scroll thumb is NOT a provider -- it is a window-anchored layer driven
-;; synchronously from `post-command-hook' (`zetta-svg-margin-scroll--post-command'
-;; below), not the debounced per-buffer render.
 
 ;; Refresh triggers, deferred until each source package loads.
 (with-eval-after-load 'evil
@@ -760,11 +506,6 @@ the recompute yields the same hunks we skip, breaking the cycle."
 (with-eval-after-load 'flycheck
   (add-hook 'flycheck-after-syntax-check-hook #'zetta-svg-margin--refresh))
 (add-hook 'post-command-hook #'zetta-svg-margin--symbol-watch)
-(add-hook 'post-command-hook #'zetta-svg-margin-scroll--post-command)
-;; Wrap state depends on `truncate-lines' / `visual-line-mode'; window resize is
-;; already covered by the package's `window-configuration-change-hook'.
-(add-hook 'visual-line-mode-hook #'zetta-svg-margin--refresh)
-(advice-add 'toggle-truncate-lines :after #'zetta-svg-margin--refresh)
 
 ;;;; Activation
 ;; ----------------------------------------------------------------
@@ -788,11 +529,10 @@ calling both is safe; this is the single `show-help-function' both hook into."
   ;; evil marks now come from the margin provider, not the fringe.
   (when (fboundp 'global-evil-fringe-mark-mode)
     (global-evil-fringe-mark-mode -1))
-  ;; The scrollbar now comes from the margin provider, not yascroll's fringe
-  ;; thumb (the yascroll module still loads -- its brushup-themed faces
-  ;; colour the margin thumb).
+  ;; yascroll draws the scrollbar thumb in the (right) fringe -- enable it
+  ;; (the margin scroll thumb that used to replace it has been removed).
   (when (fboundp 'global-yascroll-bar-mode)
-    (global-yascroll-bar-mode -1))
+    (global-yascroll-bar-mode 1))
   ;; Let git-gutter keep computing hunks, but stop it drawing (svg-margin draws).
   (when (and (fboundp 'git-gutter:view-diff-infos)
              (not (advice-member-p #'zetta-svg-margin--gg-feed 'git-gutter:view-diff-infos)))


### PR DESCRIPTION
The right margin can't host per-continuation-row indicators — Emacs collapses right-margin annotations onto a logical line's first screen row, so the window-anchored wrap rail couldn't put a glyph on every wrapped row (they stacked on row 1).

So: remove the wrap rail **and** the margin scroll thumb, re-enable the **right fringe** (native per-row continuation + visual-line arrows), and re-enable **yascroll** (scrollbar thumb in the fringe). The left fringe stays reclaimed (evil marks in the margin); all other margin providers (git-gutter, flycheck, TODO, bookmarks, org rail, long-lines, trailing-ws, symbol) are unchanged.