### PR TITLE
fix(svg-margin): use the installed Terminess Nerd Font for margin icons

### DIFF
--- a/modules/ui/svg-margin.el
+++ b/modules/ui/svg-margin.el
@@ -94,8 +94,9 @@
 ;; Each returns a list of indicator plists; :side and :priority are set at
 ;; registration (below), so the providers only describe what/where to draw.
 
-(defvar zetta-svg-margin-icon-font "Symbols Nerd Font Mono"
-  "Font family used to draw Nerd-Font icon glyphs in the margin.")
+(defvar zetta-svg-margin-icon-font "Terminess Nerd Font Mono"
+  "Font family used to draw Nerd-Font icon glyphs in the margin.
+Must be a Nerd Font that librsvg can resolve by this exact family name.")
 
 (defun zetta-svg-margin--glyph (name &optional collection)
   "Return the Nerd-Font glyph NAME (via COLLECTION fn, default mdicon), or nil."


### PR DESCRIPTION
Regression from the svg-line decoupling: dropping the `zetta-svg-line-font` fallback left the icon font as `"Symbols Nerd Font Mono"`, which librsvg can't resolve on this system, so margin icon glyphs (org headings/blocks, trailing-ws, todo, flycheck, etc.) rendered as tofu. Point it at `"Terminess Nerd Font Mono"` (the font svg-line uses) directly — still no svg-line reference, just the correct family name.