### PR TITLE
fix(elfeed): unjam stuck curl queue before background pulls

### DIFF
--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -587,6 +587,18 @@ Deferred so the one-time db load doesn't run during active startup."
 Indicators refresh via the (debounced) update hooks; the db is persisted on
 the next idle, since `elfeed-update-background' does not save it itself."
   (require 'elfeed)
+  ;; A healthy background pull drains well within the interval, so a non-zero
+  ;; queue at tick time means a curl sentinel never decremented the active
+  ;; counter (sleep/wake, network drop, killed process) -- once that happens
+  ;; `elfeed-update-background' silently no-ops forever (its guard skips when
+  ;; `elfeed-queue-count-total' > 0, and it logs nothing in that case), so the
+  ;; timer keeps looking healthy while updates quietly stop.  Clear the stuck
+  ;; connection pool before pulling.
+  (when (and (fboundp 'elfeed-queue-count-total)
+             (> (elfeed-queue-count-total) 0))
+    (elfeed-log 'warn "auto-update: queue jammed (%d), unjamming"
+                (elfeed-queue-count-total))
+    (when (fboundp 'elfeed-unjam) (elfeed-unjam)))
   (cond
    ((fboundp 'elfeed-update-background)
     (elfeed-update-background)


### PR DESCRIPTION
## Problem

The elfeed background-refresh timer is healthy and reschedules every 15 minutes, but the `*elfeed-search*` "Updated N ago" header had been frozen for ~6 days despite only ~15h of Emacs uptime.

Root cause: `elfeed-update-background` (elfeed's own code) silently no-ops whenever `elfeed-queue-count-total > 0`, and logs nothing when it skips. The curl active-connection counter (`elfeed-curl-queue-active`) can get stuck above zero when a curl process dies without its sentinel firing (sleep/wake, network drop, killed process). Once stuck, every subsequent 15-minute tick is a silent no-op while the timer keeps looking perfectly healthy — and nothing lands in `*elfeed-log*`.

## Fix

A healthy background pull drains well within the interval, so a non-zero queue at tick time is definitionally stuck. `zetta-elfeed--auto-update` now detects that, logs a warning, and calls `elfeed-unjam` (elfeed's built-in connection-pool reset) before pulling.

Verified live: firing the updated function through a real timer advances `elfeed-db-last-update` and resumes feed pulls.