### PR TITLE
feat(ui): circled-number glyphs, coloured active space, modal glyphs, tab-line polish

### DIFF
--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -889,17 +889,28 @@ recolours it via `zetta-tab-bar-svg-icon-color', so the raw glyph is returned."
                           (cons "Recent files…" #'consult-recent-file))
                      (cons "Save buffer" #'save-buffer)))))
 
+(defun zetta-tab-bar-modal-glyph ()
+  "Nerd-Font glyph for the active modal SYSTEM: vim for evil, cat for meow,
+the Emacs logo for emacs.  Falls back to the `zetta-tab-bar-modal' string when
+nerd-icons or the glyph is unavailable."
+  (or (and (featurep 'nerd-icons)
+           (zetta-line--glyph
+            (ignore-errors
+              (pcase (zetta-tab-bar-modal)
+                ("evil" (nerd-icons-sucicon "nf-custom-vim"))
+                ("meow" (nerd-icons-mdicon  "nf-md-cat"))
+                (_      (nerd-icons-sucicon "nf-custom-emacs"))))))
+      (zetta-tab-bar-modal)))
+
 (defun zetta-tab-bar-svg--modal ()
-  "Clickable tab-bar modal-system indicator (keyboard glyph; describe bindings)."
-  (let ((kbd (and (featurep 'nerd-icons)
-                  (zetta-line--glyph (ignore-errors (nerd-icons-mdicon "nf-md-keyboard_variant"))))))
-    (zetta-svg-seg
-     (concat (and kbd (concat kbd " ")) (zetta-tab-bar-modal)) 'tb-modal
-     :help "modal system"
-     :action-help "describe bindings"
-     :action #'describe-bindings
-     :menu (list (cons "Describe bindings" #'describe-bindings)
-                 (cons "Command (M-x)" #'execute-extended-command)))))
+  "Clickable tab-bar modal-system indicator (vim/cat/Emacs glyph; describe bindings)."
+  (zetta-svg-seg
+   (zetta-tab-bar-modal-glyph) 'tb-modal
+   :help (format "modal system: %s" (zetta-tab-bar-modal))
+   :action-help "describe bindings"
+   :action #'describe-bindings
+   :menu (list (cons "Describe bindings" #'describe-bindings)
+               (cons "Command (M-x)" #'execute-extended-command))))
 
 (defun zetta-tab-bar--left-of-clock-chars ()
   "How many characters a line-3 LEFT segment may use before the centred clock.

--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -619,6 +619,23 @@ keep their own font (`zetta-font').")
        (with-current-buffer (or buffer (current-buffer))
          (zetta-line--glyph (ignore-errors (nerd-icons-icon-for-buffer))))))
 
+(defun zetta-circle-number (n)
+  "Return a Nerd-Font circled-number glyph for integer N, or nil.
+0-9 use `nf-md-numeric_N_circle'; 10 uses `nf-md-numeric_10_circle'; anything
+higher falls back to `nf-md-numeric_9_plus_circle'.  The glyph carries
+`:family' `zetta-svg-line-font' so it renders even in a plain-text context (an
+SVG bar uses the engine's own font instead, so the face is harmless there).
+This is the single source of the numbered-circle glyphs shared by the tab-line,
+the space-tree tab-bar lighter, and (visually) svg-margin's org-heading rail."
+  (and (featurep 'nerd-icons)
+       (integerp n)
+       (let ((g (zetta-line--glyph
+                 (ignore-errors
+                   (cond ((<= 0 n 9) (nerd-icons-mdicon (format "nf-md-numeric_%d_circle" n)))
+                         ((= n 10)   (nerd-icons-mdicon "nf-md-numeric_10_circle"))
+                         (t          (nerd-icons-mdicon "nf-md-numeric_9_plus_circle")))))))
+         (and g (propertize g 'face (list :family zetta-svg-line-font))))))
+
 ;;; mode line
 (defun zetta-modeline-svg--file-icon ()
   "File-type glyph for the current buffer."
@@ -1031,31 +1048,71 @@ the full battery status."
              :menu (list (cons "Battery status" #'battery)
                          (cons "Toggle battery display" #'display-battery-mode)))))))))
 
+(defcustom zetta-tab-bar-svg-active-space-color "#6c4dab"
+  "Colour for the active (selected) space-tree space in the tab-bar workspace.
+Replaces space-tree's trailing-apostrophe marker; matches the masthead
+Emacs-icon purple (`zetta-tab-bar-svg-icon-color')."
+  :type 'color :group 'zetta)
+
+(defcustom zetta-tab-bar-svg-inactive-space-color "#b0b5be"
+  "Colour for the non-active tokens (spaces, braces, level bars) of the
+tab-bar workspace cluster.  A light gray that recedes against the white bar so
+the active space (`zetta-tab-bar-svg-active-space-color') stands out."
+  :type 'color :group 'zetta)
+
 (defun zetta-tab-bar-svg--workspace ()
-  "Clickable workspace cluster (glyph + name): switch space; space-tree menu."
+  "Clickable workspace cluster (glyph + spaces) for the SVG tab bar.
+space-tree's lighter marks each level's selected space with a trailing
+apostrophe; we render those labels in `zetta-tab-bar-svg-active-space-color'
+and drop the apostrophe, since svg-line colours per-segment, not per-character.
+
+We split on whitespace into one segment per token (space label / brace / level
+bar), separators included as their own segments.  Those boundaries don't move
+as you cycle spaces -- dropping the apostrophe keeps every token's width fixed,
+so only one token's colour changes.  A shifting split point would instead jitter
+its neighbours: svg-line starts each run on a fixed char-advance grid but flows
+text by the font's natural advance within a run, so where that boundary lands
+matters.  Every piece shares one hover id and the workspace action/menu, so the
+cluster still behaves as one clickable unit."
   (let* ((icon (ignore-errors (zetta-tab-bar-workspace-icon)))
-         (txt  (zetta-tab-bar-workspace-text))
-         (label (concat (and icon (concat icon " ")) (and (stringp txt) txt))))
-    (when (and label (> (length (string-trim label)) 0))
-      (zetta-svg-seg
-       label 'tb-workspace
-       :help "workspace"
-       :action-help "switch workspace"
-       :action (cond ((fboundp 'space-tree-switch-space-by-name) #'space-tree-switch-space-by-name)
-                     ((fboundp 'space-tree-switch-current-level) #'space-tree-switch-current-level)
-                     (t #'ignore))
-       :menu (delq nil
-                   (list (and (fboundp 'space-tree-switch-space-by-name)
-                              (cons "Switch by name…" #'space-tree-switch-space-by-name))
-                         (and (fboundp 'space-tree-go-left) (cons "Previous space" #'space-tree-go-left))
-                         (and (fboundp 'space-tree-go-right) (cons "Next space" #'space-tree-go-right))
-                         (and (fboundp 'space-tree-create-space-current-level)
-                              (cons "New space (here)" #'space-tree-create-space-current-level))
-                         (and (fboundp 'space-tree-create-space-top-level)
-                              (cons "New space (top)" #'space-tree-create-space-top-level))
-                         (and (fboundp 'space-tree-name-current-space)
-                              (cons "Rename space…" #'space-tree-name-current-space))
-                         (and (fboundp 'space-tree-delete-space)
-                              (cons "Delete space" #'space-tree-delete-space))))))))
+         (txt  (zetta-tab-bar-workspace-text)))
+    (when (and (stringp txt) (> (length (string-trim txt)) 0))
+      (let* ((action (cond ((fboundp 'space-tree-switch-space-by-name) #'space-tree-switch-space-by-name)
+                           ((fboundp 'space-tree-switch-current-level) #'space-tree-switch-current-level)
+                           (t #'ignore)))
+             (menu (delq nil
+                         (list (and (fboundp 'space-tree-switch-space-by-name)
+                                    (cons "Switch by name…" #'space-tree-switch-space-by-name))
+                               (and (fboundp 'space-tree-go-left) (cons "Previous space" #'space-tree-go-left))
+                               (and (fboundp 'space-tree-go-right) (cons "Next space" #'space-tree-go-right))
+                               (and (fboundp 'space-tree-create-space-current-level)
+                                    (cons "New space (here)" #'space-tree-create-space-current-level))
+                               (and (fboundp 'space-tree-create-space-top-level)
+                                    (cons "New space (top)" #'space-tree-create-space-top-level))
+                               (and (fboundp 'space-tree-name-current-space)
+                                    (cons "Rename space…" #'space-tree-name-current-space))
+                               (and (fboundp 'space-tree-delete-space)
+                                    (cons "Delete space" #'space-tree-delete-space)))))
+             (mkseg (lambda (s color)
+                      (and (stringp s) (> (length s) 0)
+                           (apply #'zetta-svg-seg s 'tb-workspace
+                                  :help "workspace" :action-help "switch workspace"
+                                  :action action :menu menu
+                                  (and color (list :color color))))))
+             (items (list (funcall mkseg (and icon (concat icon " ")) nil)))
+             (first t))
+        ;; One segment per whitespace-delimited token, with a fixed " " segment
+        ;; between them.  A token ending in "'" is the selected space: strip the
+        ;; apostrophe and colour it.  Boundaries stay put as the selection moves.
+        (dolist (tok (split-string (string-trim txt) " " t))
+          (unless first (push (funcall mkseg " " nil) items))
+          (setq first nil)
+          (let ((active (string-suffix-p "'" tok)))
+            (push (funcall mkseg (if active (substring tok 0 -1) tok)
+                           (if active
+                               zetta-tab-bar-svg-active-space-color
+                             zetta-tab-bar-svg-inactive-space-color))
+                  items)))
+        (apply #'svg-line-segs (nreverse (delq nil items)))))))
 
 ;;; line-utils.el ends here

--- a/modules/ui/spacetree.el
+++ b/modules/ui/spacetree.el
@@ -43,3 +43,29 @@
    "gT" 'space-tree-switch-space-by-digit-arg
    "g+" 'space-tree-create-space-top-level
    "gn" 'space-tree-create-space-current-level))
+
+;;; ------------------------------------------------------------------
+;;; Circled-number lighter -- render the space-tree tab-bar numbers as
+;;; the same nf-md-numeric_N_circle glyphs the tab-line and svg-margin
+;;; use.  space-tree's per-level renderer calls `number-to-string' for an
+;;; unnamed space; we rebind that, for the duration of just that one
+;;; function, so the display number becomes a circle glyph.  Its only
+;;; `number-to-string' use is the display number, and NAMED spaces never
+;;; reach it -- so names and the package's internals are untouched.
+;;; ------------------------------------------------------------------
+(require 'cl-lib)
+(declare-function zetta-circle-number "line-utils")
+(declare-function space-tree--modeline-string-for-level "space-tree")
+
+(defun zetta-space-tree--circle-numbers (orig &rest args)
+  "Around-advice for `space-tree--modeline-string-for-level': circle the numbers.
+Falls back to the real `number-to-string' when nerd-icons is unavailable or the
+value isn't an integer (`zetta-circle-number' returns nil in those cases)."
+  (cl-letf* ((nts (symbol-function 'number-to-string))
+             ((symbol-function 'number-to-string)
+              (lambda (n) (or (zetta-circle-number n) (funcall nts n)))))
+    (apply orig args)))
+
+(with-eval-after-load 'space-tree
+  (advice-add 'space-tree--modeline-string-for-level
+              :around #'zetta-space-tree--circle-numbers))

--- a/modules/ui/svg-line.el
+++ b/modules/ui/svg-line.el
@@ -14,5 +14,11 @@
 ;; svg-line before those `(require 'svg-line)' calls run.
 
 (use-package svg-line
-  :ensure (:host github :repo "chiply/svg-line" :wait t))
+  :ensure (:host github :repo "chiply/svg-line" :wait t)
+  :custom
+  ;; Enlarge Nerd-Font icon glyphs (numbers, buffer/calendar icons, ...) a
+  ;; touch over the 1.3 default.  This only scales the glyph tspans, not the
+  ;; fixed char-advance grid, so the reserved width is unchanged and nothing
+  ;; is pushed off the right edge.
+  (svg-line-glyph-scale 1.4))
 ;;; svg-line.el ends here

--- a/modules/ui/tab-line-svg.el
+++ b/modules/ui/tab-line-svg.el
@@ -79,11 +79,11 @@ Lastly, if no tabs are left in the window, it is deleted with the `delete-window
       (force-mode-line-update)))
 
   (defun ct/circle-number (n)
-    "Circled-number glyph for tab index N (1-based) plus a trailing space.
-A thin wrapper over `zetta-circle-number' (the shared glyph source); the
-trailing space separates the number from the file glyph that follows."
-    (when-let ((g (zetta-circle-number n)))
-      (concat g " ")))
+    "Circled-number glyph for tab index N (1-based), or nil.
+A thin wrapper over `zetta-circle-number' (the shared glyph source).  No
+trailing space -- the number sits flush against the file/mode glyph that
+follows; callers add their own separator before the buffer name."
+    (zetta-circle-number n))
 
   (defun zetta-tab-line-tab-name-buffer (buffer &optional _buffers)
     (let* ((buffer-name (buffer-name buffer))
@@ -258,8 +258,8 @@ Because the glyph is part of the label text it needs no separate icon."
              ;; binding for `real', so action/menu closures must not close over
              ;; it directly (they would all see the last tab's buffer).
              collect (let ((b real) (nm name))
-                       (cons (concat (or (ct/circle-number i) (format "%d " i))
-                                     (if glyph (concat glyph " ") "")
+                       (cons (concat (or (ct/circle-number i) (format "%d" i))
+                                     (if glyph (concat glyph " ") " ")
                                      short
                                      (if modifiedp zetta-tab-line-svg-modified-marker ""))
                              (list :current currentp :modified modifiedp
@@ -311,6 +311,32 @@ Because the glyph is part of the label text it needs no separate icon."
   :inactive-current-foreground (lambda () zetta-tab-line-svg-inactive-current-foreground)
   :inactive-current-background (lambda () zetta-tab-line-svg-inactive-current-background)
   :inactive-modified-foreground (lambda () zetta-tab-line-svg-inactive-modified-foreground))
+
+;;; ------------------------------------------------------------------
+;;; Left padding.  The `wrap' layout starts its content flush at x=0, so the
+;;; first tab sits against the window's left edge.  svg-line installs the tab
+;;; line by `:override'-advising `tab-line-format' to return a one-space
+;;; display-image string; we `:filter-return' that to prepend a fixed-width
+;;; space.  Safe for clicks: window-level bars hit-test with IMAGE-relative
+;;; `posn-object-x-y', and the margin space is a separate display object, so it
+;;; doesn't shift the image's internal coordinates.
+;;; ------------------------------------------------------------------
+(defcustom zetta-tab-line-svg-left-pad 8
+  "Left padding, in pixels, before the SVG tab-line content (0 to disable)."
+  :type 'integer :group 'zetta)
+
+(defun zetta-tab-line-svg--pad-left (result)
+  "Prepend `zetta-tab-line-svg-left-pad' px of margin to RESULT.
+A `:filter-return' advice on `tab-line-format'; passes RESULT through
+unchanged when it is not the svg-line image string or padding is disabled."
+  (if (and (stringp result) (> zetta-tab-line-svg-left-pad 0)
+           (zetta-tab-line-using-svg-p))
+      (concat (propertize " " 'display
+                          (list 'space :width (list zetta-tab-line-svg-left-pad)))
+              result)
+    result))
+
+(advice-add 'tab-line-format :filter-return #'zetta-tab-line-svg--pad-left)
 
 ;;; ------------------------------------------------------------------
 ;;; Switching.  svg-line installs the tab line by advising the

--- a/modules/ui/tab-line-svg.el
+++ b/modules/ui/tab-line-svg.el
@@ -27,6 +27,13 @@
 
 (require 'svg-line)
 
+;; `ct/circle-number' (defined in the `tab-line' use-package :config below)
+;; wraps `zetta-circle-number' (line-utils) -- the shared source of the
+;; numbered-circle glyphs also used by svg-margin's org rail.  Declared here so
+;; the top-level SVG content function compiles cleanly.
+(declare-function ct/circle-number "tab-line-svg")
+(declare-function zetta-circle-number "line-utils")
+
 ;;; ==================================================================
 ;;; Tab-line SYSTEM (merged from the former tab-line.el): enables
 ;;; global-tab-line-mode, the buffer selector + scopes, close commands,
@@ -72,21 +79,11 @@ Lastly, if no tabs are left in the window, it is deleted with the `delete-window
       (force-mode-line-update)))
 
   (defun ct/circle-number (n)
-    "Return a Nerd Font circled-number glyph for tab index N (1-based).
-1-9 use `nf-md-numeric_N_circle'; 10 uses `nf-md-numeric_10_circle';
-anything higher falls back to `nf-md-numeric_9_plus_circle'.  The glyph is
-re-faced to \"Terminess Nerd Font Mono\" (installed) rather than nerd-icons'
-default \"Symbols Nerd Font Mono\" (NOT installed here) so it renders in the
-plain-text tab line instead of tofu.  Trailing space keeps it off the icon."
-    (when (require 'nerd-icons nil t)
-      (let ((glyph (cond ((<= 1 n 9)
-                          (nerd-icons-mdicon (format "nf-md-numeric_%d_circle" n)))
-                         ((= n 10) (nerd-icons-mdicon "nf-md-numeric_10_circle"))
-                         (t (nerd-icons-mdicon "nf-md-numeric_9_plus_circle")))))
-        (when glyph
-          (concat (propertize (substring-no-properties glyph)
-                              'face '(:family "Terminess Nerd Font Mono"))
-                  " ")))))
+    "Circled-number glyph for tab index N (1-based) plus a trailing space.
+A thin wrapper over `zetta-circle-number' (the shared glyph source); the
+trailing space separates the number from the file glyph that follows."
+    (when-let ((g (zetta-circle-number n)))
+      (concat g " ")))
 
   (defun zetta-tab-line-tab-name-buffer (buffer &optional _buffers)
     (let* ((buffer-name (buffer-name buffer))
@@ -261,8 +258,7 @@ Because the glyph is part of the label text it needs no separate icon."
              ;; binding for `real', so action/menu closures must not close over
              ;; it directly (they would all see the last tab's buffer).
              collect (let ((b real) (nm name))
-                       (cons (format "%d %s%s%s"
-                                     i
+                       (cons (concat (or (ct/circle-number i) (format "%d " i))
                                      (if glyph (concat glyph " ") "")
                                      short
                                      (if modifiedp zetta-tab-line-svg-modified-marker ""))


### PR DESCRIPTION
Tab-bar / tab-line glyph and colour work.

## Circled-number glyphs
- Shared `zetta-circle-number' helper renders `nf-md-numeric_N_circle' glyphs (the same ones the svg-margin org-heading indicator uses) as the numbers in the tab-line and the space-tree tab-bar indicator.

## Coloured active space-tree space
- Replace space-tree's trailing-apostrophe active marker with colour. The SVG tab-bar workspace cluster now renders one segment per whitespace token (fixed boundaries, so cycling spaces doesn't jitter the font's natural advance against svg-line's char grid).
- Active space painted purple (`zetta-tab-bar-svg-active-space-color', matching the masthead Emacs icon); the rest light gray (`zetta-tab-bar-svg-inactive-space-color') for contrast.

## Tab-line polish
- Index number now sits flush against the mode/file glyph (dropped the trailing space `ct/circle-number' added; separator moved before the buffer name).
- Left padding via `zetta-tab-line-svg-left-pad' (8px) -- a `:filter-return' advice on `tab-line-format' that prepends a margin space before svg-line's image. Image-relative hit-testing keeps tab clicks aligned.

## Bigger glyphs
- `svg-line-glyph-scale' 1.3 -> 1.4 (scales glyph tspans only, not the char-advance grid, so reserved width is unchanged).

## Modal system indicator
- Render the active modal system as a glyph instead of a word: vim (evil), cat (meow), Emacs logo (emacs); dropped the generic keyboard prefix.