### PR TITLE
fix(elfeed): enable protocol before elfeed-org to stop direct-fetch fallback

### DIFF
--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -60,7 +60,10 @@
   ;; number or drop "#500" in a live filter to see more.
   (setq-default elfeed-search-filter "@6-months-ago +unread #500")
   (setq elfeed-use-curl t)
-  (elfeed-set-timeout 36000)
+  ;; 60s, not 36000 (10h): with elfeed-protocol active only the Fever feed is
+  ;; fetched, so a hung request should free its slot promptly rather than block
+  ;; for hours.  (The old 10h value dated from the all-feeds direct-fetch era.)
+  (elfeed-set-timeout 60)
   (setq elfeed-curl-extra-arguments '("--insecure"))
   (defun prot-common-crm-exclude-selected-p (input)
     "Filter out INPUT from `completing-read-multiple'.
@@ -254,6 +257,20 @@ minibuffer with something like `exit-minibuffer'."
         (list
          (expand-file-name "elfeed.org" user-emacs-directory)
          ))
+  ;; Enable the protocol HERE, immediately before processing the org file.
+  ;; `elfeed-protocol-enable' installs the advice on `rmh-elfeed-org-process'
+  ;; that keeps the Fever feed in `elfeed-feeds' (set in ~/.private.el) and
+  ;; absorbs the org feeds' tags WITHOUT adding them as fetch targets.  Doing
+  ;; this only in elfeed-protocol's own :config was racy: under elpaca,
+  ;; elfeed-org's :config could run (and call `(elfeed-org)') before that
+  ;; :config executed `elfeed-protocol-enable' -- so the advice didn't exist
+  ;; yet, `(elfeed-org)' cleared `elfeed-feeds' (dropping the Fever feed), 0
+  ;; protocol feeds registered, and elfeed fell back to directly curling all
+  ;; ~193 org feeds (the Reddit 429 / dead-feed 4xx-5xx storm in *elfeed-log*).
+  ;; Enabling here -- idempotent, and `elfeed-feeds' still holds the Fever feed
+  ;; at this point since `(elfeed-org)' has not run yet -- guarantees the advice
+  ;; is in place first.  See also `:after elfeed org elfeed-protocol' above.
+  (when (fboundp 'elfeed-protocol-enable) (elfeed-protocol-enable))
   (elfeed-org)
   (message "loaded elfeed-org")
   )


### PR DESCRIPTION
## Problem

`*elfeed-log*` was full of pull errors — 2,628 Reddit `HTTP 429`, plus ~530 dead-feed `4xx`/`5xx` (medrxiv 503, 14 YouTube 404 channels). Root cause turned out **not** to be rate-limiting per se, but that **elfeed-protocol (Fever → Miniflux) never initialized**, so elfeed was bypassing Miniflux and directly curling all 193 `elfeed.org` feeds every pull.

Diagnosed live: `elfeed-feeds` held **0 Fever feeds + 193 direct HTTP feeds**, `rmh-elfeed-org-process` had **no advice**, and **0 protocol feeds** were registered.

## Cause

A startup ordering race (the one the existing comment at `elfeed.el:245` warns about): under elpaca, elfeed-org's `:config` ran `(elfeed-org)` **before** elfeed-protocol's own `:config` executed `elfeed-protocol-enable`. So the advice that keeps the Fever feed in `elfeed-feeds` and absorbs the org feeds' tags didn't exist yet — `(elfeed-org)` cleared `elfeed-feeds`, dropped the Fever feed, and elfeed fell back to direct-fetching everything.

## Fix

- Call `elfeed-protocol-enable` **inside elfeed-org's `:config`, right before `(elfeed-org)`** — idempotent, and `elfeed-feeds` still holds the Fever feed at that point — so the advice is always installed first. Result: `elfeed-feeds` = Fever feed only; Miniflux does the polling.
- Drop `elfeed-set-timeout` 36000s (10h) → 60s (relic of the direct-fetch era).

## Verified live

After applying the equivalent sequence in the running session: `elfeed-feeds` = Fever feed only, and a full `elfeed-update` produced **0 direct-fetch errors** (was ~40+ Reddit 429s instantly) and synced cleanly via Fever.