### PR TITLE
fix(pdf-tools): hide hl-line band and evil cursor over the PDF page

### DIFF
--- a/modules/org/pdf-tools.el
+++ b/modules/org/pdf-tools.el
@@ -21,7 +21,19 @@
   (add-hook 'pdf-view-mode-hook 'pdf-view-fit-height-to-window)
   (add-hook 'pdf-view-mode-hook (lambda ()
                                   (display-fill-column-indicator-mode -1)
-                                  (display-line-numbers-mode -1)))
+                                  (display-line-numbers-mode -1)
+                                  ;; Horizontal band: hl-line highlighting point's line over the page.
+                                  (setq global-hl-line-mode nil)
+                                  (when (fboundp 'hl-line-mode) (hl-line-mode -1))
+                                  ;; Vertical bar: pdf-view sets `cursor-type' nil, but evil re-applies
+                                  ;; its state cursor (and our evil state cursors are nil, so it falls
+                                  ;; back to `evil-default-cursor', a box).  Over the one tall page
+                                  ;; "line" that box renders as a full-height vertical bar.  Force
+                                  ;; evil's default cursor to keep the cursor hidden in PDF buffers.
+                                  (setq-local cursor-type nil)
+                                  (when (boundp 'evil-default-cursor)
+                                    (setq-local evil-default-cursor (lambda () (setq cursor-type nil))))
+                                  (when (fboundp 'evil-refresh-cursor) (evil-refresh-cursor))))
   ;; Sharp rendering on retina displays
   (setq pdf-view-use-scaling t)
   ;; Midnight mode colors for dark reading (toggle with M-x pdf-view-midnight-minor-mode)


### PR DESCRIPTION
## Problem

In `pdf-view-mode` buffers, two artifacts were drawn over the page image:

- **Horizontal band** — `global-hl-line-mode` highlighting point's line, spanning the full window width (it ran into the gray margins beside the page).
- **Vertical bar** — a full-height bar at the page edge. `pdf-view` sets `cursor-type` to `nil`, but `evil-refresh-cursor` runs afterward and, because our evil state cursors are `nil`, it falls back to `evil-default-cursor` (a box). Over the single tall page "line", that box renders as a full-height vertical bar.

## Fix

In the `pdf-view-mode-hook`:
- Disable `hl-line` (`global-hl-line-mode` buffer-local + `hl-line-mode -1`).
- Force evil's default cursor to keep `cursor-type` `nil`, so the cursor stays hidden across re-renders and evil state changes.

## Testing

Verified live in the running daemon: after the change, `cursor-type` stays `nil` even after `pdf-view-redisplay` *and* `evil-refresh-cursor`, and `global-hl-line-mode` is `nil` in PDF buffers. Module byte-compiles clean.

Note: if a PDF buffer is switched to meow (the other modal system), meow manages the cursor differently and may need a separate guard — out of scope here.