### PR TITLE
fix(embark-vc): make forge PR the default embark target so `r` opens pr-review

### DIFF
--- a/modules/tools/embark-vc.el
+++ b/modules/tools/embark-vc.el
@@ -7,5 +7,37 @@
   (general-define-key
    :keymaps '(consult-gh-embark-prs-edit-menu-map)
    "R" 'embark-vc-start-review)
+
+  ;; Make the forge topic the DEFAULT embark target on a PR/issue line.
+  ;;
+  ;; `embark-vc-target-topic-at-point' returns an UNBOUNDED target (no
+  ;; START . END).  Our `embark-scope-sort-by-bounds-mode' installs a
+  ;; `:filter-return' advice on `embark--targets' that sorts bounded targets
+  ;; innermost-first and appends every unbounded target at the very END of the
+  ;; cycle (see `embark-scope--sort-targets-by-bounds').  So on a PR line the
+  ;; default target was always a scope target (line/brick/word/...), never the
+  ;; `pull-request' -- `embark-act' then `r' hit the general map, where `r' is
+  ;; unbound, and fell through to `magit-rebase'.
+  ;;
+  ;; Fix: a drop-in finder that returns the SAME topic target WITH bounds -- the
+  ;; `#N' reference when point is on it, else a zero-width span at line start
+  ;; (size 0, so it sorts first).  Now `pull-request'/`issue' is the default
+  ;; target anywhere on the line, and `C-.' then `r' opens the PR in pr-review.
+  (defun zetta-embark-vc-target-topic-at-point ()
+    "Target the forge topic at point, WITH bounds (see comment above)."
+    (when (and (derived-mode-p 'magit-mode)
+               (fboundp 'forge-topic-at-point))
+      (when-let* ((topic (forge-topic-at-point)))
+        (let* ((type (if (and (fboundp 'forge-issue-at-point)
+                              (forge-issue-at-point))
+                         'issue 'pull-request))
+               (beg (line-beginning-position))
+               (bounds (or (ignore-errors (bounds-of-thing-at-point 'forge-topic))
+                           (cons beg beg))))
+          `(,type ,(oref topic number) ,(car bounds) . ,(cdr bounds))))))
+  ;; Swap our bounded finder in for embark-vc's unbounded one.
+  (setq embark-target-finders
+        (cons 'zetta-embark-vc-target-topic-at-point
+              (remq 'embark-vc-target-topic-at-point embark-target-finders)))
   )
 ;;; embark-vc.el ends here


### PR DESCRIPTION
## Problem

Acting on a pull request in a magit/forge buffer via `embark-act` and pressing `r` to open it in **pr-review** never worked — `r` fell through to `magit-rebase` (and `R` to other magit commands).

The wiring was all correct (`embark-vc` target finder, `pull-request` keymap with `r` → `embark-vc-start-review`, `embark-vc-review-provider` = `pr-review`). The failure was **target priority**:

- `embark-vc-target-topic-at-point` returns an **unbounded** target `(pull-request N)` — no `START . END`.
- This config's `embark-scope-sort-by-bounds-mode` installs a `:filter-return` advice on `embark--targets` that sorts *bounded* targets innermost-first and **appends all unbounded targets at the very end** of the cycle.

So on a PR line the default embark target was always a scope target (`line`/`word`/`brick`/…), and `pull-request` sank to the bottom every time. `r` isn't bound in the general map → fell through to magit.

```
targets on a PR line (before):  (line sentence paragraph brick orgtree pull-request)   ← last
```

## Fix

Swap `embark-vc`'s finder for a drop-in that returns the **same** topic target **with bounds** — the `#N` reference when point is on it, else a zero-width span at line start (size 0, so it sorts first). Handles issues too.

```
targets on a PR line (after):   (pull-request identifier line sentence paragraph brick orgtree)   ← default
```

## Verification (live daemon)

- At every offset along a real PR line (`magit: hyperbole-posts`, PR #3), the default target is now `pull-request`, and its keymap's `r` resolves to `embark-vc-start-review`:
  ```
  :default-type  pull-request
  :r-action      embark-vc-start-review
  ```
- `forge-get-url` on the topic resolves the correct PR URL, which is what `embark-vc-start-review` hands to `pr-review`.
- File parses cleanly.

Now: point on a PR line → `embark-act` (`C-.`) → `r` opens it in pr-review. Scope targets remain reachable by cycling; only the default changed.
