### PR TITLE
fix(hywiki-alias): highlight a new WikiWord's aliases immediately

### DIFF
--- a/modules/app/hywiki-alias.el
+++ b/modules/app/hywiki-alias.el
@@ -51,6 +51,10 @@ case-insensitively would light up ordinary prose.  Set to 1 to include them."
   "Hash mapping a downcased, space-stripped alias form to its canonical WikiWord.")
 (defvar zetta-hywiki-alias--regexp nil
   "Cached alternation regexp matching every derived alias form.")
+(defvar zetta-hywiki-alias--generation 0
+  "Counter bumped whenever the alias set changes.
+Part of the `post-command' refresh-guard key, so adding a HyWikiWord forces
+the next command to re-scan even when buffer text and scroll are unchanged.")
 
 (defun zetta-hywiki-alias--segments (word)
   "Split WORD at CamelCase boundaries into a list of segments.
@@ -87,9 +91,14 @@ Handles acronym runs, so \"HTMLParser\" -> (\"HTML\" \"Parser\")."
   (unless zetta-hywiki-alias--index (zetta-hywiki-alias--rebuild)))
 
 (defun zetta-hywiki-alias--invalidate (&rest _)
-  "Drop the cached index and regexp so they rebuild on next use."
+  "Drop the cached index/regexp and bump the generation counter.
+Advised onto the HyWikiWord-adding commands so a newly created word's derived
+aliases appear immediately: the bumped generation is part of the `post-command'
+change-guard key, so the next command re-scans even though creating a WikiWord
+changes neither the buffer text nor the scroll position."
   (setq zetta-hywiki-alias--index nil
-        zetta-hywiki-alias--regexp nil))
+        zetta-hywiki-alias--regexp nil)
+  (cl-incf zetta-hywiki-alias--generation))
 
 (defun zetta-hywiki-alias--hywiki-face-at (pos)
   "Return non-nil if a HyWiki highlight overlay already covers POS."
@@ -140,7 +149,8 @@ was modified or the window scrolled since the last refresh."
     (let* ((win (selected-window))
            (ws (window-start win))
            (we (window-end win t))
-           (key (list (buffer-chars-modified-tick) ws we)))
+           (key (list zetta-hywiki-alias--generation
+                      (buffer-chars-modified-tick) ws we)))
       (unless (equal key zetta-hywiki-alias--last)
         (setq zetta-hywiki-alias--last key)
         (zetta-hywiki-alias--highlight-region

--- a/modules/app/hywiki-alias.el
+++ b/modules/app/hywiki-alias.el
@@ -91,14 +91,18 @@ Handles acronym runs, so \"HTMLParser\" -> (\"HTML\" \"Parser\")."
   (unless zetta-hywiki-alias--index (zetta-hywiki-alias--rebuild)))
 
 (defun zetta-hywiki-alias--invalidate (&rest _)
-  "Drop the cached index/regexp and bump the generation counter.
+  "Rebuild-on-demand the alias set and re-highlight all visible windows.
 Advised onto the HyWikiWord-adding commands so a newly created word's derived
-aliases appear immediately: the bumped generation is part of the `post-command'
-change-guard key, so the next command re-scans even though creating a WikiWord
-changes neither the buffer text nor the scroll position."
+aliases appear immediately.  Drop the cached index/regexp, bump the generation
+counter (part of the `post-command' change-guard key, so a scroll-free,
+edit-free buffer still re-scans on its next command), and refresh every visible
+window now -- creating a WikiWord moves focus to the new page buffer, so the
+buffer holding the alias occurrences is usually no longer the selected window."
   (setq zetta-hywiki-alias--index nil
         zetta-hywiki-alias--regexp nil)
-  (cl-incf zetta-hywiki-alias--generation))
+  (cl-incf zetta-hywiki-alias--generation)
+  (when (bound-and-true-p zetta-hywiki-alias-mode)
+    (zetta-hywiki-alias--refresh-windows)))
 
 (defun zetta-hywiki-alias--hywiki-face-at (pos)
   "Return non-nil if a HyWiki highlight overlay already covers POS."
@@ -134,6 +138,12 @@ changes neither the buffer text nor the scroll position."
                 (overlay-put ov 'evaporate t)
                 (overlay-put ov 'help-echo (format "HyWiki alias -> %s" canon))))))))))
 
+(defun zetta-hywiki-alias--refresh-region (start end)
+  "Re-highlight derived aliases between START and END, expanded to whole lines."
+  (zetta-hywiki-alias--highlight-region
+   (save-excursion (goto-char start) (line-beginning-position))
+   (save-excursion (goto-char (min end (point-max))) (line-end-position))))
+
 (defvar-local zetta-hywiki-alias--last nil
   "Cache key (tick window-start window-end) of the last visible-region refresh.
 Skips redundant rescans so `post-command-hook' stays cheap and flicker-free.")
@@ -153,18 +163,29 @@ was modified or the window scrolled since the last refresh."
                       (buffer-chars-modified-tick) ws we)))
       (unless (equal key zetta-hywiki-alias--last)
         (setq zetta-hywiki-alias--last key)
-        (zetta-hywiki-alias--highlight-region
-         (save-excursion (goto-char ws) (line-beginning-position))
-         (save-excursion (goto-char (min we (point-max))) (line-end-position)))))))
+        (zetta-hywiki-alias--refresh-region ws we)))))
+
+(defun zetta-hywiki-alias--refresh-window (win)
+  "Re-highlight derived aliases in WIN's visible region.
+Highlights WIN by its own bounds rather than via the selected window, so a
+visible but unselected window -- e.g. the buffer you were editing after focus
+moved to a freshly created page -- is refreshed too."
+  (with-current-buffer (window-buffer win)
+    (when (and (fboundp 'hywiki-active-in-current-buffer-p)
+               (hywiki-active-in-current-buffer-p))
+      (let ((ws (window-start win))
+            (we (window-end win t)))
+        ;; Record the guard key so the buffer's own next `post-command' pass
+        ;; skips a redundant (flicker-inducing) rescan when it regains focus.
+        (setq zetta-hywiki-alias--last
+              (list zetta-hywiki-alias--generation
+                    (buffer-chars-modified-tick) ws we))
+        (zetta-hywiki-alias--refresh-region ws we)))))
 
 (defun zetta-hywiki-alias--refresh-windows ()
-  "Force an alias refresh in every visible window (used on mode enable)."
-  (dolist (frame (frame-list))
-    (dolist (win (window-list frame))
-      (with-selected-window win
-        (with-current-buffer (window-buffer win)
-          (setq zetta-hywiki-alias--last nil)
-          (zetta-hywiki-alias--post-command))))))
+  "Force an alias refresh in every visible window on every frame.
+Used on mode enable and whenever the alias set changes."
+  (walk-windows #'zetta-hywiki-alias--refresh-window nil t))
 
 (defun zetta-hywiki-alias--word-at-advice (orig &optional range-flag hash-sign-only-flag)
   "Make `hywiki-word-at' recognise a derived alias at point.


### PR DESCRIPTION
## Summary

Follow-up to #85. When you create a HyWikiWord (e.g. `M-RET` on a word), the
PascalCase form highlighted immediately but its derived case/space aliases did
not appear until you switched buffers.

## Cause

`zetta-hywiki-alias-mode` refreshes on `post-command-hook`, guarding the re-scan
on `(buffer-chars-modified-tick, window-start, window-end)` to stay cheap.
Creating a WikiWord changes none of those, so the guard skipped the re-scan even
though the alias *set* had just changed.

## Fix

Add a generation counter to the guard key and bump it in `--invalidate` (the
advice that already fires when a WikiWord is added). The next command — which
fires right after `M-RET` — then re-scans and highlights the new word's aliases
in the same redisplay as the WikiWord itself. No window iteration required, so
it's robust regardless of frame/window state.

Verified: reproduced the guard-skip and confirmed the aliases return after an
add + one command; byte-compiles clean.
