### PR TITLE
feat(hywiki-alias): alias single-word WikiWords by default

### DIFF
--- a/modules/app/hywiki-alias.README.md
+++ b/modules/app/hywiki-alias.README.md
@@ -31,9 +31,9 @@ M-x zetta-hywiki-alias-mode
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `zetta-hywiki-alias-min-segments` | `2` | Minimum CamelCase segments to alias. `2` skips single-word pages like `Emacs` (case-insensitive matching of those lights up ordinary prose). Set `1` to include them. |
-| `zetta-hywiki-alias-min-length` | `5` | Minimum WikiWord length to alias. |
-| `zetta-hywiki-alias-deny-list` | `nil` | WikiWords that should never get a derived alias (e.g. a page named after a common phrase). |
+| `zetta-hywiki-alias-min-segments` | `1` | Minimum CamelCase segments to alias. `1` aliases every page, including single-word ones like `Emacs` (so `emacs` highlights and activates). Set `2` to skip single-word pages, whose case-insensitive match tends to light up prose. |
+| `zetta-hywiki-alias-min-length` | `1` | Minimum WikiWord length to alias. `1` imposes no real floor; raise it to drop very short, prose-prone names. |
+| `zetta-hywiki-alias-deny-list` | `nil` | WikiWords that should never get a derived alias (e.g. a page named after a common word or phrase). |
 
 ## How it works (thin, reversible layer)
 
@@ -91,13 +91,15 @@ day-to-day highlight + jump, kept entirely outside HyWiki's core.
 
 ## False positives
 
-Case-insensitive matching turns every aliased page name into a prose magnet.
-`DataModelTesting` is safe, but a page like `DesignDecisions` will highlight
-every "design decisions" in prose. Guards, in order of bluntness:
+Case-insensitive matching turns every aliased page name into a prose magnet,
+and the defaults alias **every** page — including short, single-word ones like
+`Emacs`, so ordinary "emacs" lights up throughout your notes. That is the
+intended trade-off here (single-word pages are wanted); to tighten it, in order
+of bluntness:
 
-- Single-word pages are excluded by default (`min-segments = 2`).
-- Raise `zetta-hywiki-alias-min-length`.
-- Add specific offenders to `zetta-hywiki-alias-deny-list`.
+- Add specific offenders to `zetta-hywiki-alias-deny-list` (surgical).
+- Raise `zetta-hywiki-alias-min-length` to drop short page names.
+- Set `zetta-hywiki-alias-min-segments` to `2` to skip single-word pages entirely.
 
-If the highlighting feels too eager, that's the knob set to tune — or just turn
-the mode off; it's designed to be A/B'd against plain HyWiki.
+If the highlighting feels too eager, those are the knobs — or just turn the
+mode off; it's designed to be A/B'd against plain HyWiki.

--- a/modules/app/hywiki-alias.el
+++ b/modules/app/hywiki-alias.el
@@ -33,14 +33,18 @@
   "Derived case/space aliases for HyWikiWords."
   :group 'hyperbole-hywiki)
 
-(defcustom zetta-hywiki-alias-min-length 5
-  "Only HyWikiWords at least this many characters get a derived alias."
+(defcustom zetta-hywiki-alias-min-length 1
+  "Only HyWikiWords at least this many characters get a derived alias.
+The default, 1, imposes no real length floor; raise it to suppress aliases
+for very short page names, whose lowercase forms are the most prose-prone."
   :type 'integer :group 'zetta-hywiki-alias)
 
-(defcustom zetta-hywiki-alias-min-segments 2
+(defcustom zetta-hywiki-alias-min-segments 1
   "Minimum CamelCase segments a HyWikiWord needs to get a derived alias.
-The default, 2, skips single-word pages like `Emacs' -- matching those
-case-insensitively would light up ordinary prose.  Set to 1 to include them."
+The default, 1, aliases every page including single-word ones like `Emacs',
+so lowercase `emacs' is highlighted and activates.  Set to 2 to skip
+single-word pages, whose case-insensitive match tends to light up prose; use
+`zetta-hywiki-alias-deny-list' to exclude specific offenders either way."
   :type 'integer :group 'zetta-hywiki-alias)
 
 (defcustom zetta-hywiki-alias-deny-list nil


### PR DESCRIPTION
## Summary

Single-word WikiWords like `Emacs` were excluded from aliasing, so lowercase
`emacs` never highlighted. This flips the module defaults to alias **every**
page, single-word ones included:

- `zetta-hywiki-alias-min-segments`: `2` → `1` (include single-word pages)
- `zetta-hywiki-alias-min-length`: `5` → `1` (no length floor)

`emacs`, `gui`, etc. now highlight and jump via the Action Key. On my page set
the alias count went 56 → 74.

## Trade-off

Case-insensitive matching of common single words (`emacs`, `extension`, …)
lights up prose — that's the intended behavior now. Tightening knobs remain:

- `zetta-hywiki-alias-deny-list` — exclude specific offenders (surgical)
- `zetta-hywiki-alias-min-length` — drop short page names
- `zetta-hywiki-alias-min-segments` = `2` — skip single-word pages again

README updated (options table + false-positives section).
