### PR TITLE
fix(hywiki-alias): highlight the exact WikiWord form HyWiki misses

### DIFF
--- a/modules/app/hywiki-alias.README.md
+++ b/modules/app/hywiki-alias.README.md
@@ -44,7 +44,10 @@ M-x zetta-hywiki-alias-mode
   region (only when the buffer changed or scrolled, so it stays cheap) and
   applies overlays in a face that *inherits* `hywiki-word-face`: visually
   identical, but a distinct object so HyWiki's own face-based dehighlight passes
-  don't clear it. The exact WikiWord form is skipped (HyWiki owns it).
+  don't clear it. The exact WikiWord form is left to HyWiki where HyWiki
+  highlights it, but highlighted here too in buffers HyWiki doesn't manage
+  (e.g. eww, where its buffer-local highlighter never runs) — so the real word
+  is never left dark while its aliases light up.
 - **Activate** — an `:around` advice on `hywiki-word-at` returns the canonical
   WikiWord when point is on an alias overlay; the entire HyWiki display chain
   (`hywiki-referent-exists-p` → `link-to-wikiword`) then works unchanged, so
@@ -75,8 +78,9 @@ blind to them:
 - **Refresh scope** — highlighting is limited to the visible window region
   (like lazy fontification), refreshed on `post-command-hook`; aliases off-screen
   are highlighted when scrolled into view. Overlap with a real WikiWord is
-  resolved by a simple heuristic (skip the exact form, and skip a position
-  HyWiki already highlighted).
+  resolved by skipping any position HyWiki has already highlighted; the exact
+  WikiWord form is otherwise highlighted here too (e.g. in eww, where HyWiki's
+  buffer-local highlighter never runs).
 
 ### Why it can't be more without forking HyWiki
 

--- a/modules/app/hywiki-alias.el
+++ b/modules/app/hywiki-alias.el
@@ -128,8 +128,15 @@ buffer holding the alias occurrences is usually no longer the selected window."
                  (key (downcase (replace-regexp-in-string "[ \t]+" "" text)))
                  (canon (gethash key zetta-hywiki-alias--index)))
             (when (and canon
-                       ;; HyWiki itself owns the exact WikiWord form.
-                       (not (string= text canon))
+                       ;; Skip only where HyWiki has already highlighted this
+                       ;; spot (its overlay's face IS `hywiki-word-face', unlike
+                       ;; our inheriting one).  The exact WikiWord form is
+                       ;; normally left to HyWiki, but in buffers it does not
+                       ;; manage -- e.g. eww, which never gets HyWiki's
+                       ;; buffer-local post-command highlighter -- highlight it
+                       ;; too, so the real word is not left dark while its
+                       ;; aliases light up.  If HyWiki later claims the spot, the
+                       ;; next re-scan drops our now-redundant overlay.
                        (not (zetta-hywiki-alias--hywiki-face-at mb)))
               (let ((ov (make-overlay mb me)))
                 (overlay-put ov 'zetta-hywiki-alias canon)
@@ -140,7 +147,10 @@ buffer holding the alias occurrences is usually no longer the selected window."
                 ;; value) does not sweep our alias overlays away.
                 (overlay-put ov 'face (list :inherit hywiki-word-face))
                 (overlay-put ov 'evaporate t)
-                (overlay-put ov 'help-echo (format "HyWiki alias -> %s" canon))))))))))
+                (overlay-put ov 'help-echo
+                             (if (string= text canon)
+                                 (format "HyWikiWord: %s" canon)
+                               (format "HyWiki alias -> %s" canon)))))))))))
 
 (defun zetta-hywiki-alias--refresh-region (start end)
   "Re-highlight derived aliases between START and END, expanded to whole lines."


### PR DESCRIPTION
## Summary

WikiWord highlighting was inconsistent in some buffers (notably eww): the exact
WikiWord form was highlighted in most spots but dark in others, while its
case/space aliases lit up everywhere.

## Cause

HyWiki highlights WikiWords via a **buffer-local** `post-command-hook`
(installed only in HyWiki-managed buffers, fired only on edit/action commands),
so it leaves gaps — occurrences it skips (e.g. the possessive `Emacs's`) and
buffers it never manages. My alias module runs everywhere via a **global** hook
but deliberately skipped the exact WikiWord form, leaving those gaps dark.

## Fix

Skip the exact form **only where HyWiki has actually highlighted it** (its
overlay's face is `hywiki-word-face` itself, unlike my inheriting face);
elsewhere highlight it too. Self-healing: if HyWiki later claims a spot, my next
re-scan drops the now-redundant overlay.

Verified in a live eww buffer: every `Emacs` occurrence is now highlighted (by
HyWiki where it acts, by this module where it doesn't), including the `Emacs's`
gaps that were previously dark.

## Trade-off

The module will now also highlight a page's references to itself, which HyWiki
deliberately skips — minor and harmless, and consistent with this module's
aggressive-by-default aliasing.
