### PR TITLE
feat(hywiki-alias): hyphenated forms, manual aliases, and composite WikiWords

### DIFF
--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -92,7 +92,8 @@ drifted apart.  Files with content, or already open in a buffer, are untouched."
                (file-writable-p file)
                (not (get-file-buffer file))
                (or (not (file-exists-p file))
-                   (zerop (or (file-attribute-size (file-attributes file)) 0))))
+                   (let ((size (file-attribute-size (file-attributes file))))
+                     (and size (zerop size)))))
       (let ((title (file-name-sans-extension (file-name-nondirectory file))))
         (write-region (format "#+title: %s\n\n" title) nil file nil 0)))))
 

--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -71,6 +71,31 @@ every file."
           result))
     result))
 
+;; --- HyWiki: make sure a WikiWord always has a real page file on disk ---
+;; HyWiki writes a page file when it first creates the page, but a WikiWord can
+;; end up registered in its referent hash with no file behind it -- the hash and
+;; the on-disk pages drift apart, or the file is deleted later.  Then the Action
+;; Key only opens an empty, file-less buffer that reports "no changes to save",
+;; so nothing is written and the WikiWord stops being highlighted after a
+;; restart.  Every follow/create path funnels through `hywiki-display-page', so
+;; seed a missing (or empty, not-yet-open) page file with an Org title there.
+
+(defun zetta-hywiki-ensure-page-file (&optional wikiword file-name)
+  "Ensure the HyWiki page file for WIKIWORD/FILE-NAME is a real, titled file.
+Advised onto `hywiki-display-page' as `:before'.  Writes the page file with an
+Org `#+title:' line when it is missing, or when it exists but is empty and not
+already open in a buffer -- so following a WikiWord always lands in a real,
+non-empty page, even if HyWiki's referent hash and the on-disk pages have
+drifted apart.  Files with content, or already open in a buffer, are untouched."
+  (let ((file (ignore-errors (hywiki-get-page-file (or file-name wikiword)))))
+    (when (and (stringp file)
+               (file-writable-p file)
+               (not (get-file-buffer file))
+               (or (not (file-exists-p file))
+                   (zerop (or (file-attribute-size (file-attributes file)) 0))))
+      (let ((title (file-name-sans-extension (file-name-nondirectory file))))
+        (write-region (format "#+title: %s\n\n" title) nil file nil 0)))))
+
 (use-package hyperbole
   :defer 1
   :init
@@ -87,19 +112,38 @@ every file."
   (require 'hywiki)
   (hywiki-mode 1)
 
-  ;; --- Relocate the minibuffer menu: {C-h h} -> {C-h H} ---
-  ;; Hyperbole binds `hyperbole' to {C-h h} globally; undo that and rebind.
-  (when (eq (lookup-key (current-global-map) (kbd "C-h h")) 'hyperbole)
-    (global-set-key (kbd "C-h h") #'view-hello-file))
-  (global-set-key (kbd "C-h H") #'hyperbole)
+  ;; Make sure following a WikiWord always lands in a real page file on disk,
+  ;; titled with the WikiWord, even if HyWiki's referent hash and the pages on
+  ;; disk have drifted apart (see `zetta-hywiki-ensure-page-file').
+  (advice-add 'hywiki-display-page :before #'zetta-hywiki-ensure-page-file)
 
-  ;; --- Relocate the keyboard Action/Assist Key: {M-RET} -> {s-H} ---
-  ;; Free the default M-RET variants from `hyperbole-mode-map' (so org-mode's
-  ;; M-RET is no longer shadowed), then bind the Action Key on s-H via the
-  ;; supported `hkey-set-key' helper.  Assist Key = {C-u s-H}.
-  (dolist (k '("M-RET" "M-<return>" "ESC RET" "ESC <return>"))
-    (define-key hyperbole-mode-map (kbd k) nil))
-  (hkey-set-key (kbd "s-H") #'hkey-either)
+  ;;;; --- Relocate the minibuffer menu: {C-h h} -> {C-h H} ---
+  ;;;; Hyperbole binds `hyperbole' to {C-h h} globally; undo that and rebind.
+  ;;(when (eq (lookup-key (current-global-map) (kbd "C-h h")) 'hyperbole)
+    ;;(global-set-key (kbd "C-h h") #'view-hello-file))
+  ;;(global-set-key (kbd "C-h H") #'hyperbole)
+;;
+  ;;;; --- Relocate the keyboard Action/Assist Key: {M-RET} -> {s-H} ---
+  ;;;; Free the default M-RET variants from `hyperbole-mode-map' (so org-mode's
+  ;;;; M-RET is no longer shadowed), then bind the Action Key on s-H via the
+  ;;;; supported `hkey-set-key' helper.  Assist Key = {C-u s-H}.
+  ;;(dolist (k '("M-RET" "M-<return>" "ESC RET" "ESC <return>"))
+    ;;(define-key hyperbole-mode-map (kbd k) nil))
+  ;;(hkey-set-key (kbd "s-H") #'hkey-either)
+
+  ;; --- Give Hyperbole the physical M-<return> in outline buffers ---
+  ;; evil-collection's outline module binds the physical key M-<return> to
+  ;; `outline-insert-heading' in the normal-state aux map of `outline-mode-map'
+  ;; (which `outline-minor-mode' inherits via `set-keymap-parent'), and evil's
+  ;; keymaps sit in `emulation-mode-map-alists', outranking `hyperbole-mode-map'.
+  ;; So in e.g. an elisp buffer (outline-minor-mode + evil normal state) the
+  ;; physical M-<return> ran the outline command while the ASCII {M-RET} still
+  ;; ran Hyperbole's Action Key.  Rebind the physical key to `hkey-either' too so
+  ;; both forms match.  This package is `:defer 1', so `evil-collection-init'
+  ;; (hence the outline setup this overrides) has already run.
+  (when (fboundp 'evil-collection-define-key)
+    (evil-collection-define-key 'normal 'outline-mode-map
+      (kbd "M-<return>") 'hkey-either))
 
   ;; --- HyRolo: search the Logseq pages as the rolo source ---
   (setq hyrolo-file-list '("~/logseq/pages/"))

--- a/modules/app/hywiki-alias.README.md
+++ b/modules/app/hywiki-alias.README.md
@@ -1,62 +1,163 @@
 # hywiki-alias
 
-Highlight and follow **case- and space-variants of your HyWikiWords** without
-typing any aliases. Derived automatically from your existing HyWiki pages.
+Highlight and follow **variants of your HyWikiWords** — different case, spaces,
+hyphens, and hand-written aliases — without leaving HyWiki. A page named
+`DataModelTesting` then lights up on `Data Model Testing`, `data-model-testing`,
+and anything you list in its `Aliases` section, and the Action Key on any of
+them jumps to the page exactly as on the real WikiWord.
 
-A page named `DataModelTesting` is split at its CamelCase boundaries
-(`Data | Model | Testing`). The mode then highlights any case-insensitive
-occurrence with optional single spaces at those boundaries and makes the Action
-Key (`M-RET`) on it jump to the page — exactly as on the real WikiWord:
+It is a thin, reversible layer over HyWiki: overlays plus a little advice. Turn
+it off and you are back to plain HyWiki (see [Enabling / disabling](#enabling--disabling)).
 
-| Text in a buffer      | Highlighted? | Action Key jumps to |
-|-----------------------|:------------:|---------------------|
-| `DataModelTesting`    | (HyWiki does it) | `DataModelTesting` |
-| `Data Model Testing`  | ✅ (this mode) | `DataModelTesting` |
-| `data model testing`  | ✅ | `DataModelTesting` |
-| `DaTa moDel TESTING`  | ✅ | `DataModelTesting` |
+## What gets highlighted
 
-Nothing to maintain: the alias set is rebuilt from `hywiki-get-wikiword-list`
-and refreshed whenever a page is added.
+For a page `DataModelTesting` (with `Emacs` also a page):
 
-## Usage
+| Text in a buffer       | Highlighted? | Action Key → |
+|------------------------|:------------:|--------------|
+| `DataModelTesting`     | HyWiki does it | `DataModelTesting` |
+| `Data Model Testing`   | ✅ this mode | `DataModelTesting` |
+| `data model testing`   | ✅ | `DataModelTesting` |
+| `data-model-testing`   | ✅ | `DataModelTesting` |
+| `DaTa moDel TESTING`    | ✅ | `DataModelTesting` |
+| `emacs`, `EMACS`       | ✅ | `Emacs` |
+| `emacs-foobar`         | ❌ (part of a bigger hyphenated word) | — |
 
-Enabled automatically once HyWiki loads (a `with-eval-after-load` at the bottom
-of the module turns the global mode on). Toggle it off — or back on — any time:
+There are three sources of aliases — [automatic](#automatic-aliases),
+[manual](#manual-aliases--the-aliases-section), and HyWiki's own exact WikiWord
+— and one rule for when they overlap: [the longest match wins](#composite-wikiwords-precedence).
+
+## Enabling / disabling
+
+`zetta-hywiki-alias-mode` is a global minor mode and **is the toggle** between
+this module and HyWiki's native behaviour:
 
 ```
 M-x zetta-hywiki-alias-mode
 ```
 
-### Options
+- **On** — automatic + manual aliases, hyphen variants, and composite handling.
+- **Off** — plain HyWiki. Disabling removes every overlay this module added and
+  **re-runs HyWiki's own highlighter in the visible windows**, so the native
+  view is restored cleanly — even in buffers like eww that HyWiki never
+  re-scans on its own. That makes it a true A/B: flip it and compare.
+
+It is enabled automatically once HyWiki loads (a `with-eval-after-load` at the
+bottom of the module). Bind it for quick flipping if you like:
+
+```elisp
+(keymap-global-set "C-c w" #'zetta-hywiki-alias-mode)
+```
+
+## Automatic aliases
+
+Derived from each WikiWord's own name — nothing to maintain. Each WikiWord is
+split at its CamelCase boundaries (acronym-aware: `HTMLParser` → `HTML |
+Parser`), and every case-insensitive occurrence of those segments, joined
+directly or by a single space or hyphen, is highlighted:
+
+- `EmacsCompletion` → `emacs completion`, `Emacs Completion`, `emacs-completion`, …
+
+The alias set is rebuilt from `hywiki-get-wikiword-list` on enable, whenever a
+page is added, and whenever a page file is saved. Which pages get aliased is
+controlled by three [options](#options) (`min-segments`, `min-length`,
+`deny-list`) — the defaults alias **every** page, including single words.
+
+## Manual aliases — the `Aliases` section
+
+Some aliases can't be derived from the name (`corfu` for `EmacsCompletion`,
+"completion framework", plurals, jargon). List them yourself: add a heading
+titled **`Aliases`** (any level) to the page file and put one alias per line
+beneath it, up to the next heading.
+
+```org
+#+title: EmacsCompletion
+
+* Aliases
+- completion framework
+- minibuffer completion
+- corfu
+
+* Notes
+...the rest of the page...
+```
+
+- Bulleted (`-` `+` `*` `1.`) or plain lines both work; blank lines and Org
+  keyword/comment lines (`#…`) are ignored.
+- Manual aliases highlight and activate exactly like derived ones and inherit
+  the same case / space / hyphen flexibility.
+- They are **always honoured** — they ignore the `min-segments` / `min-length`
+  / `deny-list` filters, since you wrote them deliberately.
+- **Saving the page picks up the change**: an `after-save-hook` rebuilds when
+  any file under `hywiki-directory` is saved, so edit the `Aliases` section,
+  `C-x C-s`, and the new aliases are live immediately.
+
+## Hyphenation
+
+Hyphens are treated as a segment separator, so a multi-segment WikiWord matches
+its hyphenated form (`EmacsCompletion` → `emacs-completion`). But a match that
+is only *part of a larger hyphenated token* is left alone, so a page `Emacs`
+does **not** highlight the `emacs` inside `emacs-foobar` (or `foobar-emacs`). A
+hyphen that falls *between the WikiWord's own segments* is fine — it is consumed
+inside the match, not sitting at its edge.
+
+## Composite WikiWords (precedence)
+
+When one WikiWord is composed of others — say `Emacs`, `Completion`, and
+`EmacsCompletion` are all pages — **the longest match wins**, consistently:
+
+| Text | Highlighted as | Action Key → |
+|------|----------------|--------------|
+| `EmacsCompletion` | one unit | `EmacsCompletion` |
+| `Emacs Completion` | one unit | `EmacsCompletion` |
+| `emacs completion` | one unit | `EmacsCompletion` |
+| `emacs-completion` | one unit | `EmacsCompletion` |
+
+By default HyWiki would read the capitalized `Emacs Completion` as *two*
+separate WikiWords (`Emacs` + `Completion`). This module overrides that: when a
+longer composite WikiWord spans HyWiki's sub-part overlays, it removes them and
+lays down the single composite, so the whole phrase highlights and activates as
+one unit. The exact `EmacsCompletion` form is still left to HyWiki (its overlay
+already covers the whole match).
+
+**Caveat:** in eww and while reading, this is stable. In a *live* HyWiki page
+buffer, HyWiki re-highlights on edits, so it may briefly re-split `Emacs
+Completion` until the next command re-composes it — a momentary flicker on
+edits, never a wrong final state.
+
+## Options
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `zetta-hywiki-alias-min-segments` | `1` | Minimum CamelCase segments to alias. `1` aliases every page, including single-word ones like `Emacs` (so `emacs` highlights and activates). Set `2` to skip single-word pages, whose case-insensitive match tends to light up prose. |
-| `zetta-hywiki-alias-min-length` | `1` | Minimum WikiWord length to alias. `1` imposes no real floor; raise it to drop very short, prose-prone names. |
-| `zetta-hywiki-alias-deny-list` | `nil` | WikiWords that should never get a derived alias (e.g. a page named after a common word or phrase). |
+| `zetta-hywiki-alias-min-segments` | `1` | Minimum CamelCase segments a page needs for a derived alias. `1` aliases every page, including single-word ones like `Emacs`. Set `2` to skip single-word pages, whose case-insensitive match tends to light up prose. (Manual aliases ignore this.) |
+| `zetta-hywiki-alias-min-length` | `1` | Minimum WikiWord length for a derived alias. `1` imposes no real floor; raise it to drop short, prose-prone names. (Manual aliases ignore this.) |
+| `zetta-hywiki-alias-deny-list` | `nil` | WikiWords that should never get a *derived* alias (e.g. a page named after a common word). |
 
 ## How it works (thin, reversible layer)
 
-- **Derivation** — split each WikiWord at CamelCase boundaries (acronym-aware:
-  `HTMLParser` → `HTML | Parser`); build a case-insensitive, word-bounded
-  regexp `Data ?Model ?Testing` and an index `datamodeltesting → DataModelTesting`.
+- **Index + regexp** — segments and manual aliases are collected into a hash
+  (`datamodeltesting → DataModelTesting`) and one case-insensitive, word-bounded
+  alternation regexp, sorted longest-first so a composite pre-empts its parts.
 - **Highlight** — a `post-command-hook` driver re-scans the visible window
-  region (only when the buffer changed or scrolled, so it stays cheap) and
-  applies overlays in a face that *inherits* `hywiki-word-face`: visually
-  identical, but a distinct object so HyWiki's own face-based dehighlight passes
-  don't clear it. The exact WikiWord form is left to HyWiki where HyWiki
-  highlights it, but highlighted here too in buffers HyWiki doesn't manage
-  (e.g. eww, where its buffer-local highlighter never runs) — so the real word
-  is never left dark while its aliases light up. When a WikiWord is also a
-  clickable link (e.g. an eww hyperlink), the overlay keeps the WikiWord colour
-  but takes the link's own colour as its underline and layers above HyWiki's
-  overlay, so it reads as both a WikiWord (text colour) and a link (underline).
+  region (only when the buffer changed or scrolled, so it stays cheap), in a
+  face that *inherits* `hywiki-word-face`: visually identical, but a distinct
+  object so HyWiki's own face-based dehighlight passes don't clear it.
+  - The exact WikiWord form is left to HyWiki where it highlights, but drawn
+    here too where HyWiki is idle (e.g. eww, whose buffer-local highlighter
+    never runs), so the real word is never dark while its aliases glow.
+  - On a link (an eww hyperlink or a button) the overlay keeps the WikiWord's
+    text colour but takes the **link's own colour as its underline** and layers
+    above HyWiki's overlay, so it reads as both a WikiWord and a link.
+  - Where a composite spans HyWiki's sub-part overlays, those are removed so the
+    composite wins (see [precedence](#composite-wikiwords-precedence)).
 - **Activate** — an `:around` advice on `hywiki-word-at` returns the canonical
-  WikiWord when point is on an alias overlay; the entire HyWiki display chain
-  (`hywiki-referent-exists-p` → `link-to-wikiword`) then works unchanged, so
-  both the `hywiki-word` and `hywiki-existing-word` implicit buttons activate.
+  WikiWord when point is on an alias overlay; HyWiki's whole display chain then
+  works unchanged, so both the `hywiki-word` and `hywiki-existing-word` implicit
+  buttons activate.
+- **Refresh** — the alias set rebuilds on enable, after `hywiki-add-page` /
+  `hywiki-add-referent`, and on `after-save-hook` for HyWiki page files.
 
-Disabling the mode removes both advices and every overlay — no residue.
+Disabling the mode removes the advice, every overlay, and the hooks — no residue.
 
 ## ⚠️ What this does NOT do — the missing ~20%
 
@@ -80,10 +181,7 @@ blind to them:
   `Alias:Lnum` are not recognized.
 - **Refresh scope** — highlighting is limited to the visible window region
   (like lazy fontification), refreshed on `post-command-hook`; aliases off-screen
-  are highlighted when scrolled into view. Overlap with a real WikiWord is
-  resolved by skipping any position HyWiki has already highlighted; the exact
-  WikiWord form is otherwise highlighted here too (e.g. in eww, where HyWiki's
-  buffer-local highlighter never runs).
+  are highlighted when scrolled into view.
 
 ### Why it can't be more without forking HyWiki
 
@@ -96,17 +194,16 @@ require changes to HyWiki's private internals — an upstream proposal to the
 Hyperbole maintainers, not a drop-in. This module is the pragmatic 80%: the
 day-to-day highlight + jump, kept entirely outside HyWiki's core.
 
-## False positives
+## Tuning false positives
 
 Case-insensitive matching turns every aliased page name into a prose magnet,
 and the defaults alias **every** page — including short, single-word ones like
 `Emacs`, so ordinary "emacs" lights up throughout your notes. That is the
-intended trade-off here (single-word pages are wanted); to tighten it, in order
-of bluntness:
+intended trade-off here; to tighten it, in order of bluntness:
 
 - Add specific offenders to `zetta-hywiki-alias-deny-list` (surgical).
 - Raise `zetta-hywiki-alias-min-length` to drop short page names.
 - Set `zetta-hywiki-alias-min-segments` to `2` to skip single-word pages entirely.
 
-If the highlighting feels too eager, those are the knobs — or just turn the
-mode off; it's designed to be A/B'd against plain HyWiki.
+If the highlighting ever feels too eager, those are the knobs — or just turn the
+mode off; it is designed to be A/B'd against plain HyWiki.

--- a/modules/app/hywiki-alias.el
+++ b/modules/app/hywiki-alias.el
@@ -100,8 +100,8 @@ are ignored."
       (with-temp-buffer
         (insert-file-contents file)
         (goto-char (point-min))
-        (let (aliases)
-          (when (re-search-forward "^\\*+[ \t]+[Aa]liases[ \t]*$" nil t)
+        (let ((case-fold-search t) aliases)
+          (when (re-search-forward "^\\*+[ \t]+aliases[ \t]*$" nil t)
             (forward-line 1)
             (while (and (not (eobp)) (not (looking-at-p "^\\*+[ \t]")))
               (let ((line (string-trim (buffer-substring-no-properties
@@ -140,7 +140,7 @@ manual aliases listed in a page's `Aliases' section."
             (push (zetta-hywiki-alias--add index word segs) patterns)))
         ;; Manual aliases from the page's `Aliases' section (always honoured).
         (dolist (alias (zetta-hywiki-alias--file-aliases word))
-          (push (zetta-hywiki-alias--add index word (split-string alias "[ \t]+" t))
+          (push (zetta-hywiki-alias--add index word (split-string alias "[ \t-]+" t))
                 patterns))))
     (setq patterns (delq nil patterns))
     ;; Longer phrases first so a short alias cannot pre-empt a longer one.

--- a/modules/app/hywiki-alias.el
+++ b/modules/app/hywiki-alias.el
@@ -27,6 +27,8 @@
 (declare-function hywiki-add-referent "hywiki")
 (declare-function hywiki-add-page "hywiki")
 (defvar hywiki-word-face)
+(defvar hywiki-directory)
+(defvar hywiki-file-suffix)
 (defvar zetta-hywiki-alias-mode)
 
 (defgroup zetta-hywiki-alias nil
@@ -70,19 +72,77 @@ Handles acronym runs, so \"HTMLParser\" -> (\"HTML\" \"Parser\")."
              "\\([[:lower:][:digit:]]\\)\\([[:upper:]]\\)" "\\1\0\\2" s)))
     (split-string s "\0" t)))
 
+(defun zetta-hywiki-alias--page-file (word)
+  "Return WORD's readable HyWiki page file, or nil."
+  (when (and (boundp 'hywiki-directory) hywiki-directory)
+    (let ((f (expand-file-name
+              (concat word (if (boundp 'hywiki-file-suffix) hywiki-file-suffix ".org"))
+              hywiki-directory)))
+      (and (file-readable-p f) f))))
+
+(defun zetta-hywiki-alias--hywiki-page-file-p (file)
+  "Return non-nil if FILE is a HyWiki page file directly under `hywiki-directory'."
+  (and file (boundp 'hywiki-directory) hywiki-directory
+       (let ((f (expand-file-name file))
+             (dir (file-name-as-directory (expand-file-name hywiki-directory)))
+             (suffix (if (boundp 'hywiki-file-suffix) hywiki-file-suffix ".org")))
+         (and (string-suffix-p suffix f)
+              (equal (file-name-directory f) dir)))))
+
+(defun zetta-hywiki-alias--file-aliases (word)
+  "Return the manual alias strings declared in WORD's page `Aliases' section.
+Reads WORD's page file and collects each entry beneath a heading whose title
+is `Aliases' (any level, case-insensitive), up to the next heading.  Leading
+list bullets are stripped; blank lines and Org keyword/comment lines (`#...')
+are ignored."
+  (let ((file (zetta-hywiki-alias--page-file word)))
+    (when file
+      (with-temp-buffer
+        (insert-file-contents file)
+        (goto-char (point-min))
+        (let (aliases)
+          (when (re-search-forward "^\\*+[ \t]+[Aa]liases[ \t]*$" nil t)
+            (forward-line 1)
+            (while (and (not (eobp)) (not (looking-at-p "^\\*+[ \t]")))
+              (let ((line (string-trim (buffer-substring-no-properties
+                                        (line-beginning-position)
+                                        (line-end-position)))))
+                (setq line (replace-regexp-in-string
+                            "\\`\\(?:[-+*]\\|[0-9]+[.)]\\)[ \t]+" "" line))
+                (when (and (not (string-empty-p line))
+                           (not (string-prefix-p "#" line)))
+                  (push line aliases)))
+              (forward-line 1)))
+          (nreverse aliases))))))
+
+(defun zetta-hywiki-alias--add (index canon tokens)
+  "Map an alias built from TOKENS to CANON in INDEX and return its regexp.
+TOKENS is the ordered list of word pieces; in text they may be joined, or
+separated by a single space/tab or hyphen.  Returns nil for empty TOKENS."
+  (when tokens
+    (puthash (downcase (apply #'concat tokens)) canon index)
+    (mapconcat #'regexp-quote tokens "[ \t-]?")))
+
 (defun zetta-hywiki-alias--rebuild ()
-  "Rebuild the alias index and matching regexp from existing HyWikiWords."
+  "Rebuild the alias index and matching regexp from existing HyWikiWords.
+Includes both aliases derived from each WikiWord's CamelCase segments and any
+manual aliases listed in a page's `Aliases' section."
   (let ((index (make-hash-table :test 'equal))
         (patterns nil))
     (dolist (word (and (fboundp 'hywiki-get-wikiword-list)
                        (hywiki-get-wikiword-list)))
       (when (stringp word)
+        ;; Derived aliases: case/space/hyphen variants of the CamelCase segments.
         (let ((segs (zetta-hywiki-alias--segments word)))
           (when (and (>= (length segs) zetta-hywiki-alias-min-segments)
                      (>= (length word) zetta-hywiki-alias-min-length)
                      (not (member word zetta-hywiki-alias-deny-list)))
-            (puthash (downcase (apply #'concat segs)) word index)
-            (push (mapconcat #'regexp-quote segs "[ \t]?") patterns)))))
+            (push (zetta-hywiki-alias--add index word segs) patterns)))
+        ;; Manual aliases from the page's `Aliases' section (always honoured).
+        (dolist (alias (zetta-hywiki-alias--file-aliases word))
+          (push (zetta-hywiki-alias--add index word (split-string alias "[ \t]+" t))
+                patterns))))
+    (setq patterns (delq nil patterns))
     ;; Longer phrases first so a short alias cannot pre-empt a longer one.
     (setq patterns (sort patterns (lambda (a b) (> (length a) (length b)))))
     (setq zetta-hywiki-alias--index index
@@ -123,6 +183,16 @@ it reads as both.  Recognises `shr'/eww links and `button' buttons."
    ((and (get-text-property pos 'button) (facep 'button))
     (face-attribute 'button :foreground nil t))))
 
+(defun zetta-hywiki-alias--hyphen-bounded-p (mb me)
+  "Return non-nil if [MB, ME) is joined by a hyphen to another word.
+This skips an alias that is only part of a larger hyphenated token -- e.g.
+`emacs' inside `emacs-foobar' -- while still allowing a hyphen that lies
+between the WikiWord's own segments, since that hyphen is consumed inside the
+match rather than sitting at its edge."
+  (cl-flet ((wordish (c) (and c (eq ?w (char-syntax c)))))
+    (or (and (eq (char-after me) ?-) (wordish (char-after (1+ me))))
+        (and (eq (char-before mb) ?-) (wordish (char-before (1- mb)))))))
+
 (defun zetta-hywiki-alias--highlight-region (start end)
   "Highlight derived HyWikiWord aliases between START and END."
   (zetta-hywiki-alias--ensure)
@@ -135,22 +205,32 @@ it reads as both.  Recognises `shr'/eww links and `button' buttons."
           (let* ((mb (match-beginning 0))
                  (me (match-end 0))
                  (text (match-string-no-properties 0))
-                 (key (downcase (replace-regexp-in-string "[ \t]+" "" text)))
+                 (key (downcase (replace-regexp-in-string "[ \t-]+" "" text)))
                  (canon (gethash key zetta-hywiki-alias--index))
-                 (link-color (zetta-hywiki-alias--link-color-at mb)))
+                 (link-color (zetta-hywiki-alias--link-color-at mb))
+                 (hy-ov (zetta-hywiki-alias--hywiki-face-at mb))
+                 ;; Does a HyWiki overlay already span our whole match?  If so it
+                 ;; owns the exact WikiWord and we defer.  If it covers only a
+                 ;; sub-part -- e.g. `Emacs' inside a longer `Emacs Completion'
+                 ;; whose joined form is the page `EmacsCompletion' -- we take
+                 ;; over so the longest (composite) WikiWord wins as one unit.
+                 (hy-covers-all (and hy-ov (>= (overlay-end hy-ov) me))))
             (when (and canon
-                       ;; Skip only where HyWiki has already highlighted this
-                       ;; spot (its overlay's face IS `hywiki-word-face', unlike
-                       ;; our inheriting one) -- UNLESS this is a link, where we
-                       ;; layer on top to add the link cue.  The exact WikiWord
-                       ;; form is normally left to HyWiki, but in buffers it does
-                       ;; not manage -- e.g. eww, which never gets HyWiki's
-                       ;; buffer-local post-command highlighter -- highlight it
-                       ;; too, so the real word is not left dark while its
-                       ;; aliases light up.  If HyWiki later claims the spot, the
-                       ;; next re-scan drops our now-redundant overlay.
-                       (or link-color
-                           (not (zetta-hywiki-alias--hywiki-face-at mb))))
+                       ;; Not merely part of a larger hyphenated token: catch
+                       ;; `emacs-completion' (EmacsCompletion) but not `emacs'
+                       ;; inside `emacs-foobar'.
+                       (not (zetta-hywiki-alias--hyphen-bounded-p mb me))
+                       ;; Defer only to a HyWiki overlay that already covers the
+                       ;; whole match; on a link we still layer on for the cue.
+                       ;; Elsewhere -- HyWiki idle (eww), a spot it skipped, or a
+                       ;; composite it split -- we highlight the match ourselves.
+                       (or link-color (not hy-covers-all)))
+              ;; Composite override: drop any HyWiki sub-part overlays inside our
+              ;; span so the composite shows and activates as a single WikiWord.
+              (unless hy-covers-all
+                (dolist (o (overlays-in mb me))
+                  (when (eq (overlay-get o 'face) hywiki-word-face)
+                    (delete-overlay o))))
               (let ((ov (make-overlay mb me)))
                 (overlay-put ov 'zetta-hywiki-alias canon)
                 (overlay-put ov 'zetta-hywiki-alias-p t)
@@ -235,11 +315,38 @@ When point is on an alias overlay, return its canonical WikiWord -- as a
           canon)
       (funcall orig range-flag hash-sign-only-flag))))
 
+(defun zetta-hywiki-alias--refresh-on-save ()
+  "Rebuild aliases and re-highlight after saving a HyWiki page file.
+On `after-save-hook' so edits to a page's `Aliases' section (or a new page
+saved to disk) take effect at once, without a manual refresh."
+  (when (and (bound-and-true-p zetta-hywiki-alias-mode)
+             (zetta-hywiki-alias--hywiki-page-file-p buffer-file-name))
+    (zetta-hywiki-alias--invalidate)))
+
+(defun zetta-hywiki-alias--rehighlight-hywiki ()
+  "Re-run HyWiki's own WikiWord highlighting in every visible window.
+Called on disable so toggling the mode off is a clean A/B against HyWiki's
+native behaviour -- restoring its view even where we had replaced its overlays
+\(e.g. composites in eww, which HyWiki never re-scans on its own)."
+  (when (fboundp 'hywiki-maybe-highlight-references)
+    (walk-windows
+     (lambda (win)
+       (with-current-buffer (window-buffer win)
+         (when (and (fboundp 'hywiki-active-in-current-buffer-p)
+                    (hywiki-active-in-current-buffer-p))
+           (ignore-errors (hywiki-maybe-highlight-references)))))
+     nil t)))
+
 ;;;###autoload
 (define-minor-mode zetta-hywiki-alias-mode
-  "Global mode: highlight and activate case/space variants of HyWikiWords.
-Aliases are derived from your existing HyWiki pages; see hywiki-alias.README.md
-for what this does and (deliberately) does not cover."
+  "Global mode: highlight and activate case/space/hyphen variants of HyWikiWords.
+Aliases are derived from your existing HyWiki pages, plus any listed in a page's
+`Aliases' section; see hywiki-alias.README.md for details.
+
+This is the toggle between this module and HyWiki's native behaviour: turn it on
+\(\\[zetta-hywiki-alias-mode]) for aliasing and composite handling, or off to
+fall back to plain HyWiki -- disabling restores HyWiki's own highlighting in the
+visible buffers."
   :global t
   :group 'zetta-hywiki-alias
   (if zetta-hywiki-alias-mode
@@ -253,15 +360,20 @@ for what this does and (deliberately) does not cover."
         (advice-add 'hywiki-add-referent :after #'zetta-hywiki-alias--invalidate)
         (advice-add 'hywiki-add-page :after #'zetta-hywiki-alias--invalidate)
         (add-hook 'post-command-hook #'zetta-hywiki-alias--post-command)
+        (add-hook 'after-save-hook #'zetta-hywiki-alias--refresh-on-save)
         (zetta-hywiki-alias--refresh-windows))
     (remove-hook 'post-command-hook #'zetta-hywiki-alias--post-command)
+    (remove-hook 'after-save-hook #'zetta-hywiki-alias--refresh-on-save)
     (advice-remove 'hywiki-word-at #'zetta-hywiki-alias--word-at-advice)
     (advice-remove 'hywiki-add-referent #'zetta-hywiki-alias--invalidate)
     (advice-remove 'hywiki-add-page #'zetta-hywiki-alias--invalidate)
     (dolist (buf (buffer-list))
       (with-current-buffer buf
         (remove-overlays (point-min) (point-max) 'zetta-hywiki-alias-p t)))
-    (zetta-hywiki-alias--invalidate)))
+    (zetta-hywiki-alias--invalidate)
+    ;; Restore HyWiki's native highlighting in visible buffers so toggling off
+    ;; is a clean A/B against HyWiki's own behaviour.
+    (zetta-hywiki-alias--rehighlight-hywiki)))
 
 ;; Enable automatically once HyWiki is available.  This file loads at startup,
 ;; before Hyperbole's deferred load, so the mode turns on as soon as HyWiki


### PR DESCRIPTION
## Summary

Bundles the HyWiki alias-highlighting improvements built up over the last few
sessions, plus a page-creation safeguard in the Hyperbole config.

### hywiki-alias

- **Hyphenation** — hyphenated WikiWord forms highlight (`EmacsCompletion` →
  `emacs-completion`); a match that is only part of a larger hyphenated token
  (`emacs-foobar`) is left alone.
- **Manual aliases** — list extra aliases under an `Aliases` section in a page
  file. Honoured regardless of the derived-alias filters, and rebuilt on save
  via `after-save-hook`.
- **Composite WikiWords** — the longest match wins: when a composite spans
  HyWiki's sub-part overlays it removes them so the whole phrase highlights and
  activates as one unit (`Emacs Completion` → `EmacsCompletion`).
- **Toggle A/B** — disabling `zetta-hywiki-alias-mode` now restores HyWiki's
  native highlighting in the visible windows, so it is a clean A/B against
  plain HyWiki.
- **README** — rewritten to document all of the above.

### hyperbole

- **Page-file safeguard** — `zetta-hywiki-ensure-page-file` (advised onto
  `hywiki-display-page`) guarantees that following any WikiWord lands in a real,
  `#+title:`-seeded page file, even when HyWiki's referent hash and the on-disk
  pages have drifted apart. Fixes WikiWords that registered but never got a file
  (empty buffer, "no changes need to be saved", gone after a restart).
- Also carries in-progress Action-Key binding changes (default `M-RET` Action
  Key; evil-collection `M-<return>` in outline buffers).

## Testing

- `hywiki-alias.el` and `hyperbole.el` byte-compile clean.
- Verified live in a running Emacs: manual aliases, save-hook rebuild,
  hyphenation, composite precedence (against three real pages), the toggle's
  native-view restore, and page-file creation for both the normal-create and
  drift (registered-but-missing-file) paths.
