### PR TITLE
fix: HyWiki navigation/completion + Corfu icon-row clipping at high text scale

### DIFF
--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -86,9 +86,20 @@ Advised onto `hywiki-display-page' as `:before'.  Writes the page file with an
 Org `#+title:' line when it is missing, or when it exists but is empty and not
 already open in a buffer -- so following a WikiWord always lands in a real,
 non-empty page, even if HyWiki's referent hash and the on-disk pages have
-drifted apart.  Files with content, or already open in a buffer, are untouched."
-  (let ((file (ignore-errors (hywiki-get-page-file (or file-name wikiword)))))
+drifted apart.  Any #section:Lnum:Cnum suffix is stripped first so we seed the
+real page rather than a `WikiWord#Section' stub.  Files with content, or already
+open in a buffer, are untouched."
+  ;; Resolve (and seed) the *page* file: strip any #section:Lnum:Cnum suffix
+  ;; first, because `hywiki-get-page-file' otherwise appends it to the file name
+  ;; (e.g. `HyWikiWord.org#Description') and we would create that stub instead of
+  ;; the real page -- so following `WikiWord#Section' opens an empty buffer
+  ;; rather than the section.  As a final guard, never seed a name still carrying
+  ;; a `#'.
+  (let* ((reference (or file-name wikiword))
+         (page (and reference (hywiki-word-strip-suffix reference)))
+         (file (and page (ignore-errors (hywiki-get-page-file page)))))
     (when (and (stringp file)
+               (not (string-search "#" (file-name-nondirectory file)))
                (file-writable-p file)
                (not (get-file-buffer file))
                (or (not (file-exists-p file))

--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -130,6 +130,24 @@ Run ORIG only when the referent hash is non-empty."
                (zerop (hash-table-count hywiki--referent-hasht)))
     (apply orig args)))
 
+;; HyWiki completion offers a bogus `zsh#no matches found...' candidate.
+;; `hywiki-completion-at-point' lists page candidates by globbing `./PREFIX*.org'
+;; through `shell-command-to-string', and discards the glob's no-match error --
+;; but only in its POSIX form (`grep: ...: No such file or directory').  When
+;; `shell-file-name' is zsh, an unmatched glob aborts with `zsh: no matches
+;; found: ...' *before* grep runs, so that text slips past HyWiki's filter and
+;; shows up as a completion candidate.  Run the command under a POSIX shell so
+;; the no-match degrades to the error HyWiki already handles.
+(defun zetta-hywiki-completion-posix-shell (orig &rest args)
+  "Run `hywiki-completion-at-point' under a POSIX shell.
+Around advice: bind `shell-file-name'/`shell-command-switch' to a POSIX `sh'
+so HyWiki's page-name glob yields the `No such file or directory' no-match
+error it filters, instead of zsh's unfiltered `no matches found' -- which would
+otherwise appear as a bogus `zsh#...' completion candidate."
+  (let ((shell-file-name (or (executable-find "sh") "/bin/sh"))
+        (shell-command-switch "-c"))
+    (apply orig args)))
+
 (use-package hyperbole
   :defer 1
   :init
@@ -155,6 +173,11 @@ Run ORIG only when the referent hash is non-empty."
   ;; (see `zetta-hywiki-skip-empty-rehighlight').
   (advice-add 'hywiki-maybe-highlight-wikiwords-in-frame :around
               #'zetta-hywiki-skip-empty-rehighlight)
+
+  ;; Keep zsh's `no matches found' glob error out of HyWiki completion
+  ;; candidates (see `zetta-hywiki-completion-posix-shell').
+  (advice-add 'hywiki-completion-at-point :around
+              #'zetta-hywiki-completion-posix-shell)
 
   ;;;; --- Relocate the minibuffer menu: {C-h h} -> {C-h H} ---
   ;;;; Hyperbole binds `hyperbole' to {C-h h} globally; undo that and rebind.

--- a/modules/completion/corfu.el
+++ b/modules/completion/corfu.el
@@ -77,9 +77,36 @@
    "C-S-j" 'corfu-popupinfo-scroll-up
    "C-S-k" 'corfu-popupinfo-scroll-down))
 
+(defcustom zetta-corfu-icon-height 0.8
+  "Relative height for `nerd-icons-corfu' completion icons.
+Nerd-icons glyphs rasterize about 1.2x taller than the completion text.
+Corfu sizes every candidate row by `default-line-height', so the taller
+icon rows overflow and the lower rows are clipped -- barely noticeable at
+the normal size, badly at large text scales.  Capping each icon to this
+fraction of the text height keeps every row at the line height, so no
+candidate is vertically truncated.  Set to nil to disable the cap."
+  :type '(choice (const :tag "No cap" nil) number)
+  :group 'corfu)
+
 (use-package nerd-icons-corfu
   :after corfu
   :config
+  (defun zetta-corfu-cap-icon-height (icon)
+    "Cap ICON to `zetta-corfu-icon-height' of the completion text height.
+`:filter-return' advice for `nerd-icons-corfu--get-by-kind'.  Returns a copy
+of the icon glyph scaled down so Corfu -- which budgets each row at
+`default-line-height' -- never clips the lower rows (worst at large text
+scales).  Copies the string first so the shared nerd-icons glyph cache is
+left untouched; a nil `zetta-corfu-icon-height' leaves the icon unchanged."
+    (if (and (stringp icon) (> (length icon) 0) (numberp zetta-corfu-icon-height))
+        (let ((s (copy-sequence icon)))
+          (add-face-text-property 0 (length s)
+                                  (list :height zetta-corfu-icon-height) nil s)
+          s)
+      icon))
+  (advice-add 'nerd-icons-corfu--get-by-kind :filter-return
+              #'zetta-corfu-cap-icon-height)
+
   (add-to-list 'corfu-margin-formatters #'nerd-icons-corfu-formatter))
 
 


### PR DESCRIPTION
Three small HyWiki/completion fixes on one branch.

## 1. `fix(hywiki)`: strip `#section` before seeding a WikiWord page file

Following `WikiWord#Section` (e.g. `HyWikiWord#Description`) opened an empty
buffer named `HyWikiWord.org#Description` instead of jumping to the section.

`zetta-hywiki-ensure-page-file` (`:before` on `hywiki-display-page`) resolved the
page file with `hywiki-get-page-file (or file-name wikiword)`, and
`hywiki-get-page-file` **appends** a `#section` to the file name rather than
stripping it:

| call | result |
| --- | --- |
| `(hywiki-get-page-file "HyWikiWord#Description")` | `HyWikiWord.org#Description` |
| `(hywiki-get-page-file (hywiki-word-strip-suffix "HyWikiWord#Description"))` | `HyWikiWord.org` |

The advice then wrote and opened that stub. Fires on the native path too — no
`hywiki-alias-mode` needed. Fix: strip the suffix with `hywiki-word-strip-suffix`
first, and never seed a basename containing `#`. Verified: following
`HyWikiWord#Description` lands on the `* Description` heading, no stub created.

## 2. `fix(hywiki)`: keep zsh's glob error out of completion candidates

Typing a WikiWord prefix sometimes offered a bogus candidate like
`zsh#no matches found: ./Heli*.org [HyWiki]`.

`hywiki-completion-at-point` lists pages by globbing `./PREFIX*.org` through
`shell-command-to-string` and discards the glob's no-match error — but only its
POSIX form (`grep: …: No such file or directory`). With `shell-file-name` = zsh,
an unmatched glob aborts with `zsh: no matches found: …` before grep runs, so
that text slips past the filter and becomes a candidate. Fix: `:around` advice
binds a POSIX `sh` for the completion, so the no-match degrades to the handled
error. Verified: a non-matching prefix now yields no candidate.

## 3. `fix(corfu)`: cap nerd-icons height so rows aren't clipped at high text scale

At large text scales, completion rows were vertically truncated. Nerd-icons
glyphs rasterize ~1.2× taller than the text, and Corfu sizes each row by
`default-line-height`, so icon rows overflow and the lower rows clip:

| text scale | `default-line-height` | icon row | overflow/row |
| --- | --- | --- | --- |
| 1× | 29px | 35px | +6px |
| 5× | 141px | 172px | +31px |

Fix: add `zetta-corfu-icon-height` (default `0.8`) + `:filter-return` advice on
`nerd-icons-corfu--get-by-kind` capping each icon to that fraction of the text
height (copying the glyph so the nerd-icons cache is untouched). Verified fitting
from 1× to 10× scale across icon kinds.
