### PR TITLE
ci: weekly cold-install rehearsal; save caches only from successful jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,17 @@ on:
   # release.yml; that workflow is unaffected.
   pull_request:
     branches: [main]
+  # Weekly cold-install rehearsal.  Warm-cache PR runs only prove the
+  # config loads against already-built packages; the install path itself
+  # went untested for ten weeks (2026-05-07 -> 2026-07-22) while broken
+  # for every fresh user, because caches kept every run warm.  Scheduled
+  # and manually-dispatched runs skip the cache restore below and build
+  # everything from nothing -- bootstrap, lockfile pins, every recipe --
+  # exactly what a new clone experiences.  GitHub emails the repo owner
+  # when a scheduled run fails.
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -52,16 +63,19 @@ jobs:
         with:
           version: ${{ matrix.emacs-version }}
 
-      - name: Cache elpaca directory
+      - name: Restore elpaca cache
+        # Restore-only (paired with the explicit save at the end of the
+        # job): actions/cache's implicit post-step saves even from failed
+        # jobs, and a cache captured mid-wedge poisons every later restore
+        # (measured repeatedly during the cold-install repair, runs
+        # 29951544889+).  Scheduled and manually-dispatched runs skip the
+        # restore on purpose -- they are the cold fresh-install rehearsal.
+        # v2 epoch: orphans the v1 caches saved mid-wedge.
+        if: github.event_name == 'pull_request'
         id: cache-elpaca
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: elpaca
-          # v2 epoch: v1 caches for 30.2 were saved mid-wedge during the
-          # cold-install repair (run 29951544889 and after) and restoring
-          # that half-built state kept poisoning subsequent runs.  Bumping
-          # the epoch orphans every v1 cache so each version rebuilds from
-          # a verified-clean cold state once, then stays warm.
           key: elpaca-v2-${{ matrix.emacs-version }}-${{ hashFiles('early-init.el', 'init.el', 'source/**', 'modules/**', 'elpaca-lock.el') }}
           restore-keys: |
             elpaca-v2-${{ matrix.emacs-version }}-
@@ -80,3 +94,16 @@ jobs:
       - name: Run CI test
         shell: bash
         run: bin/zetta ci-test
+
+      - name: Save elpaca cache
+        # Only a fully successful job may write the cache, so a restored
+        # cache always means a known-good build state.  Cold (scheduled/
+        # dispatched) successes also save, refreshing the cache weekly
+        # from a verified-clean fresh install.  Skipped on exact cache
+        # hits (nothing new to save); if the key already exists from a
+        # concurrent job, the save is a no-op warning.
+        if: success() && steps.cache-elpaca.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: elpaca
+          key: elpaca-v2-${{ matrix.emacs-version }}-${{ hashFiles('early-init.el', 'init.el', 'source/**', 'modules/**', 'elpaca-lock.el') }}


### PR DESCRIPTION
Follow-up to #109 — the two structural guards against the silent-success failure mode (warm caches shrinking CI coverage to \"config loads\" while fresh installs stayed broken for ten weeks):

1. **Weekly cold-install rehearsal**: `schedule` (Mon 06:00 UTC) and `workflow_dispatch` runs skip the cache restore entirely and build from nothing — the exact fresh-clone experience, validating the bootstrap, every lockfile pin, and every recipe. Failing scheduled runs email the repo owner. Dispatch it on demand whenever a reader reports install trouble.
2. **Save-on-success caches**: `actions/cache` split into `restore` + explicit `save` gated on `success()`, so a restored cache always means a known-good state (mid-wedge saves poisoned several rounds during the #109 investigation). Green cold rehearsals also save, refreshing the caches weekly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)