### PR TITLE
feat: typst live-preview module; hyperbole keys; mode-line git-info cache

### DIFF
--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -156,13 +156,21 @@ otherwise appear as a bogus `zsh#...' completion candidate."
   :config
   (hyperbole-mode 1)
 
+  ;;(setq hsys-org-enable-smart-keys t)
+
   ;; --- HyWiki: highlight/buttonize WikiWords (pages live in ~/hywiki/) ---
   ;; `hyperbole-mode' alone does NOT highlight WikiWords; the global
   ;; `hywiki-mode' does.  `hywiki-directory' defaults to ~/hywiki/, which is
   ;; where the generated chiply.dev WikiWord pages live.  Follow a WikiWord
   ;; with the Action Key {s-H} (relocated from {M-RET} below).
-  (require 'hywiki)
+  ;;(require 'hywiki)
   (hywiki-mode 1)
+
+  (add-to-list 'brushup-styles
+               '(set-face-attribute 'hywiki--word-face nil
+                                   :foreground "goldenrod3"
+                                   ))
+
 
   ;; Make sure following a WikiWord always lands in a real page file on disk,
   ;; titled with the WikiWord, even if HyWiki's referent hash and the pages on
@@ -203,19 +211,19 @@ otherwise appear as a bogus `zsh#...' completion candidate."
                 hywiki--buttonize-character-regexp)
         hywiki--any-wikiword-regexp-list nil)
 
-  ;;;; --- Relocate the minibuffer menu: {C-h h} -> {C-h H} ---
-  ;;;; Hyperbole binds `hyperbole' to {C-h h} globally; undo that and rebind.
-  ;;(when (eq (lookup-key (current-global-map) (kbd "C-h h")) 'hyperbole)
-    ;;(global-set-key (kbd "C-h h") #'view-hello-file))
-  ;;(global-set-key (kbd "C-h H") #'hyperbole)
-;;
-  ;;;; --- Relocate the keyboard Action/Assist Key: {M-RET} -> {s-H} ---
-  ;;;; Free the default M-RET variants from `hyperbole-mode-map' (so org-mode's
-  ;;;; M-RET is no longer shadowed), then bind the Action Key on s-H via the
-  ;;;; supported `hkey-set-key' helper.  Assist Key = {C-u s-H}.
-  ;;(dolist (k '("M-RET" "M-<return>" "ESC RET" "ESC <return>"))
-    ;;(define-key hyperbole-mode-map (kbd k) nil))
-  ;;(hkey-set-key (kbd "s-H") #'hkey-either)
+  ;; --- Relocate the minibuffer menu: {C-h h} -> {C-h H} ---
+  ;; Hyperbole binds `hyperbole' to {C-h h} globally; undo that and rebind.
+  (when (eq (lookup-key (current-global-map) (kbd "C-h h")) 'hyperbole)
+    (global-set-key (kbd "C-h h") #'view-hello-file))
+  (global-set-key (kbd "C-h H") #'hyperbole)
+
+  ;; --- Relocate the keyboard Action/Assist Key: {M-RET} -> {s-H} ---
+  ;; Free the default M-RET variants from `hyperbole-mode-map' (so org-mode's
+  ;; M-RET is no longer shadowed), then bind the Action Key on s-H via the
+  ;; supported `hkey-set-key' helper.  Assist Key = {C-u s-H}.
+  (dolist (k '("M-RET" "M-<return>" "ESC RET" "ESC <return>"))
+    (define-key hyperbole-mode-map (kbd k) nil))
+  (hkey-set-key (kbd "s-H") #'hkey-either)
 
   ;; --- Give Hyperbole the physical M-<return> in outline buffers ---
   ;; evil-collection's outline module binds the physical key M-<return> to
@@ -232,7 +240,7 @@ otherwise appear as a bogus `zsh#...' completion candidate."
       (kbd "M-<return>") 'hkey-either))
 
   ;; --- HyRolo: search the Logseq pages as the rolo source ---
-  (setq hyrolo-file-list '("~/logseq/pages/"))
+  (setq hyrolo-file-list '("~/.rolo.org" "~/logseq/pages/"))
   ;; Make the consult-driven grep commands resolve their matched files
   ;; correctly (see `zetta-hyrolo-fix-consult-handoff' above).
   (advice-add 'hyrolo-grep-input :filter-return

--- a/modules/completion/embark.el
+++ b/modules/completion/embark.el
@@ -11,6 +11,7 @@
 (use-package embark
   :ensure (:wait t)
   :defer t
+  :after (hyperbole)
   :config
   ;; Don't quit on `embark-act' so it can be repeated.
   (defun embark-act-noquit ()
@@ -124,8 +125,8 @@ completing-read prompter."
   ;; falls back to `embark-general-map'.
   (with-eval-after-load 'embark-org
     (dolist (type '(drawer property-drawer quote-block example-block
-                    comment-block verse-block keyword planning
-                    latex-environment latex-fragment))
+                           comment-block verse-block keyword planning
+                           latex-environment latex-fragment))
       (cl-pushnew type embark-org--types)))
 
   ;; Act on the last echo-area message (from oantolin's config): jump to

--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -64,21 +64,45 @@
 (defun zetta-line-narrowed-icon ()
   (when (buffer-narrowed-p) "N"))
 
+;; Repo/branch render inside mode-line :eval forms (treemacs,
+;; telephone-line), so they run on every redisplay of those windows and
+;; must never fork a shell there: two `git rev-parse' subprocesses per
+;; window per redisplay block the main loop long enough to starve timers
+;; (async consult/irs results stall until a keypress).  Cache per
+;; directory instead; a branch switch shows up within `zetta-git-info-ttl'.
+(defvar zetta-git-info-ttl 10
+  "Seconds a cached repo/branch answer stays fresh.")
+(defvar zetta--git-info-cache (make-hash-table :test 'equal)
+  "Maps `default-directory' to (TIME REPO-NAME BRANCH-NAME).")
+
+(defun zetta--git-info ()
+  "Return (REPO-NAME BRANCH-NAME) for `default-directory', cached briefly.
+REPO-NAME is a one-element list, as `zetta-get-repo-name' has always
+returned; BRANCH-NAME is a string."
+  (let ((hit (gethash default-directory zetta--git-info-cache))
+        (now (float-time)))
+    (if (and hit (< (- now (car hit)) zetta-git-info-ttl))
+        (cdr hit)
+      (cdr (puthash
+            default-directory
+            (list now
+                  (last (split-string
+                         (nth 0 (split-string
+                                 (shell-command-to-string
+                                  "git rev-parse --show-toplevel")
+                                 "\n"))
+                         "/"))
+                  (nth 0 (split-string
+                          (shell-command-to-string
+                           "git rev-parse --abbrev-ref HEAD")
+                          "\n")))
+            zetta--git-info-cache)))))
+
 (defun zetta-get-repo-name ()
-  (last (split-string
-         (nth 0 (split-string
-                 (shell-command-to-string
-                  "git rev-parse --show-toplevel")
-                 "\n"))
-         "/"
-         ))
-  )
+  (nth 0 (zetta--git-info)))
 
 (defun zetta-get-branch-name ()
-  (nth 0 (split-string
-          (shell-command-to-string
-           "git rev-parse --abbrev-ref HEAD")
-          "\n")))
+  (nth 1 (zetta--git-info)))
 
 (defun zetta-line-col ()
   (let ((col-length (length (int-to-string (current-column)))))
@@ -798,12 +822,28 @@ below `zetta-tab-bar-battery-low'); above it the indicator is green."
   "Colours for low / medium / full battery levels (muted earth tones)."
   :type '(alist :key-type symbol :value-type color) :group 'zetta)
 
+(defvar zetta-tab-bar--battery-cache nil
+  "(TIME . DATA) of the last battery status read; DATA is the alist.")
+
+(defun zetta-tab-bar--battery-note (data)
+  "Record DATA from `battery-update-functions' so renders never poll."
+  (setq zetta-tab-bar--battery-cache (cons (float-time) data)))
+(add-hook 'battery-update-functions #'zetta-tab-bar--battery-note)
+
 (defun zetta-tab-bar--battery-data ()
-  "Return (PCT . PLUGGED) from `battery-status-function', or nil.
-PCT is the integer charge percentage; PLUGGED is non-nil when on AC power."
+  "Return (PCT . PLUGGED) from the cached battery status, or nil.
+PCT is the integer charge percentage; PLUGGED is non-nil when on AC power.
+`battery-status-function' shells out (pmset on macOS) and this renders
+inside redisplay, so the status is polled here at most once a minute;
+`display-battery-mode' normally refreshes the cache off-redisplay via
+`battery-update-functions' before that ever expires."
   (when (and (boundp 'battery-status-function) (functionp battery-status-function))
-    (let ((data (ignore-errors (funcall battery-status-function))))
-      (when data
+    (let ((now (float-time)))
+      (when (or (null zetta-tab-bar--battery-cache)
+                (> (- now (car zetta-tab-bar--battery-cache)) 60))
+        (setq zetta-tab-bar--battery-cache
+              (cons now (ignore-errors (funcall battery-status-function)))))
+      (when-let* ((data (cdr zetta-tab-bar--battery-cache)))
         (cons (string-to-number (or (cdr (assq ?p data)) "0"))
               (and (member (cdr (assq ?L data)) '("AC" "on-line" "on")) t))))))
 

--- a/modules/lang/typst-ts-mode.el
+++ b/modules/lang/typst-ts-mode.el
@@ -1,0 +1,55 @@
+;;; typst-ts-mode.el --- Configure typst-ts-mode -*- lexical-binding: t; -*-
+
+;; Tree-sitter major mode for Typst (.typ) markup with a fully in-Emacs live
+;; preview workflow: `typst-ts-watch-start' hot-compiles on every save and the
+;; output PDF is shown in a side window via pdf-tools with auto-revert, so the
+;; preview updates ~instantly as you edit.
+;;
+;; Requires the `typst' CLI (brew install typst).  The typst tree-sitter grammar
+;; is auto-installed on first visit because `treesit-auto-install-grammar' is t
+;; (set in modules/lang/treesit.el, Emacs 31); we register its source below.
+
+(defun zetta-typst-preview-in-emacs (pdf)
+  "Open PDF in a right-hand side window and keep it live via auto-revert.
+Used as `typst-ts-preview-function' so the package's compile/watch
+pipeline renders straight into a pdf-tools buffer that reloads itself
+whenever `typst watch' rewrites the file."
+  (let ((win (display-buffer
+              (find-file-noselect pdf)
+              '(display-buffer-in-side-window
+                (side . right) (window-width . 0.5)))))
+    (when win
+      (with-selected-window win
+        (when (derived-mode-p 'pdf-view-mode)
+          (auto-revert-mode 1))))))
+
+(defun zetta-typst-live ()
+  "Start hot-compile watch and open the live PDF preview side-by-side.
+This is the one-shot \"start editing\" command: it begins `typst watch'
+and renders the first compile into the live preview window."
+  (interactive)
+  (typst-ts-watch-start)
+  (typst-ts-compile-and-preview))
+
+(use-package typst-ts-mode
+  :if (executable-find "typst")
+  :mode ("\\.typ\\'" . typst-ts-mode)
+  :init
+  ;; Register the grammar source so Emacs 31 auto-installs it on first visit
+  ;; (`treesit-auto-install-grammar' is t — see modules/lang/treesit.el).
+  (require 'treesit)
+  (add-to-list 'treesit-language-source-alist
+               '(typst "https://github.com/Ziqi-Yang/tree-sitter-typst"))
+  :config
+  ;; Render previews inside Emacs (pdf-tools + auto-revert) instead of the
+  ;; default `browse-url' (which would shell out to Preview.app).
+  (setq typst-ts-preview-function #'zetta-typst-preview-in-emacs)
+  :general
+  (:keymaps 'typst-ts-mode-map
+   "C-c C-c" 'typst-ts-compile
+   "C-c C-p" 'typst-ts-preview
+   "C-c C-w" 'typst-ts-watch-start
+   "C-c C-k" 'typst-ts-watch-stop
+   "C-c C-l" 'zetta-typst-live))
+
+;;; typst-ts-mode.el ends here


### PR DESCRIPTION
Ships the straggling local work now that CI is healthy on the pinned elpaca: a new Typst tree-sitter module with in-Emacs live PDF preview, hyperbole key relocations + hywiki styling, embark ordered after hyperbole, and the mode-line git-info cache that stops redisplay-time git subprocesses from starving async timers.

Staged diff carried onto a fresh main-based branch via 3-way apply — the pre-#109 embark.el base would otherwise have reverted the repeatable guard; verified the guard and the new `:after (hyperbole)` coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)