### PR TITLE
fix: require elpaca in bootstrap-elpaca — compiled bootstrap crashed startup

### DIFF
--- a/source/bootstrap/bootstrap-elpaca.el
+++ b/source/bootstrap/bootstrap-elpaca.el
@@ -54,6 +54,17 @@
     (require 'elpaca)
     (elpaca-generate-autoloads "elpaca" repo)
     (let ((load-source-file-function nil)) (load "./elpaca-autoloads"))))
+;; Load elpaca NOW, not lazily via the `elpaca' macro's autoload.  When
+;; this file is byte-compiled (`zetta install'/`zetta sync' compile the
+;; bootstrap), the macro calls below are already expanded into direct
+;; calls to elpaca internals (`elpaca--expand-declaration'), so loading
+;; the .elc crashes void-function before any autoload can fire.  That
+;; broke every interactive startup after the 2026-07-23 cold install,
+;; while CI and the installer never noticed -- both always load the
+;; bootstrap from source (install deletes .elc first; compile-angel
+;; excludes the bootstrap dir).  `require' is idempotent, and elpaca
+;; would be resident moments later anyway.
+(require 'elpaca)
 (add-hook 'elpaca-after-init-hook #'elpaca-process-queues)
 (elpaca `(,@elpaca-order))
 


### PR DESCRIPTION
First interactive startup after the v0.1.36 cold install crashed with `void-function elpaca--expand-declaration`: the `elpaca` macro compiles into direct calls to that internal, and the byte-compiled `bootstrap-elpaca.elc` (produced by `zetta install`/`sync`) contains those calls with no `(require 'elpaca)` — the macro-autoload that saves the source path never fires for a compiled one.

CI and the installer never execute the compiled-bootstrap path (install deletes `.elc` first; compile-angel excludes the bootstrap dir), which is why every batch validation stayed green while real startup broke — a coverage gap worth closing separately (make CI start Emacs once with a compiled bootstrap).

Fix: explicit `(require 'elpaca)` before the first macro call. Verified structurally: in the recompiled `.elc` the require precedes the first internal call.

Local workaround already applied on the affected machine: bootstrap `.elc` deleted so startup loads source; the next `zetta sync` after this merges recompiles them correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)