### PR TITLE
fix: purge eln-cache and stale .elc before install phase 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,14 @@ git clone https://github.com/chiply/.zetta.d ~/.zetta.d && cd ~/.zetta.d && bin/
 
 The install command will:
 1. Create `~/.zetta.el` (your config) and `~/.private.el` (API keys)
-2. Install and byte-compile all packages via Elpaca
-3. Native-compile everything (a few minutes)
+2. Purge stale compiled artifacts (`eln-cache/`, module/bootstrap `.elc`) —
+   Emacs prefers a matching native-compiled cache entry over the source on
+   disk, so a stale entry can silently shadow fixed code and crash the
+   installer. Reinstalling over an existing checkout is safe because of
+   this step; if you ever roll back package state by restoring an
+   `elpaca.pre-*.bak` snapshot, purge `eln-cache/` the same way.
+3. Install and byte-compile all packages via Elpaca
+4. Native-compile everything (a few minutes)
 
 ### With chemacs2
 

--- a/bin/zetta
+++ b/bin/zetta
@@ -53,6 +53,21 @@ cmd_install() {
         cp "$ZETTA_DIR/templates/zetta.example.el" ~/.zetta.el
     fi
 
+    # Purge stale compiled artifacts BEFORE the install Emacs starts.  The
+    # phase-1 Emacs loads the bootstrap from whatever compiled form exists,
+    # and Emacs transparently prefers a matching eln-cache entry over the
+    # .elc/.el on disk — so a .eln native-compiled from since-corrected
+    # bytecode silently shadows the fix (measured 2026-07-23: a stale
+    # bootstrap-compile-angel.eln from the broken-bootstrap window crashed
+    # phase 1 with void-variable even though the on-disk .elc was correct).
+    # CI never sees this class of failure: fresh checkouts have no
+    # eln-cache and no .elc files.  Both are pure caches — the byte-compile
+    # and native-compile steps below regenerate them.  The same applies
+    # when rolling back to an elpaca.pre-*.bak snapshot: purge eln-cache.
+    _info "Purging stale compiled artifacts (eln-cache, module/bootstrap .elc)..."
+    rm -rf "$ZETTA_DIR/eln-cache"
+    find "$ZETTA_DIR/modules" "$ZETTA_DIR/source" -name '*.elc' -delete 2>/dev/null || true
+
     _info "Starting Emacs to install and build packages..."
     "$EMACS" --init-directory="$ZETTA_DIR" --batch \
         -l "$ZETTA_DIR/init.el" \


### PR DESCRIPTION
## Summary

`bin/zetta install`'s phase-1 Emacs loads the bootstrap from whatever compiled form exists — and Emacs transparently prefers a matching `eln-cache` entry over the `.elc`/`.el` on disk. A `.eln` native-compiled from since-corrected bytecode silently shadows the fix.

**Measured 2026-07-23**: the local v0.1.38 cold install died in phase 1 with `(void-variable compile-angel)` after 6 builds. The on-disk `bootstrap-compile-angel.elc` was correct (proper `elpaca--expand-declaration` expansion, loaded cleanly in isolation), but the installer executed a stale `.eln` JIT-compiled during the broken-bootstrap window (v0.1.37 era, bytecode compiled without the elpaca macro — `(elpaca compile-angel)` as a function call with a variable argument). Purging `eln-cache` + `.elc`s made the identical install pass: exit 0, 337 builds.

**CI can never catch this class**: fresh checkouts have no eln-cache and no .elc files. It only bites machines reinstalling over existing state — exactly the local cold-install path.

## Changes
- `bin/zetta` install: purge `eln-cache/` and module/bootstrap `.elc`s before phase 1 (both are pure derived state; the later byte-compile and native-compile steps regenerate them)
- README: document the purge step and note that rolling back to an `elpaca.pre-*.bak` snapshot needs the same eln-cache purge

## Test plan
- [x] The exact failure scenario, manually: stale eln-cache present → install crashed; after purge (same commands this patch adds) → exit 0, 337 builds, clean daemon startup
- [ ] CI (exercises the fresh-checkout path — regression check only)