### PR TITLE
feat!: upgrade elpaca pin 1508298 -> 7484867 (2026-07-21 master)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,19 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    # A fully cold elpaca build measures ~25 minutes, and when the sync
-    # step crashes early (tolerated by design) ci-test must do all of it
-    # inside its own elpaca window (2400s in bin/zetta).  Leave room for
-    # that plus the watchdog's stall window rather than letting the job
-    # timeout preempt the diagnostic dump.
-    timeout-minutes: 60
+    # A fully cold elpaca build measured ~25 minutes at the old
+    # 1508298 pin; the 7484867 elpaca's event system costs ~2x main-
+    # process CPU on these 4-vCPU runners and a cold sync now measures
+    # ~65 minutes (runs 30064121523 unthrottled and 30068189855
+    # throttled both blew a 60-minute ceiling while progressing
+    # normally).  Cold builds only happen on schedule/dispatch and
+    # epoch-cold first PR runs -- warm-cache runs are minutes -- so pay
+    # for them with ceiling instead of masking true wedges: the
+    # in-process watchdog still kills a frozen queue at 20 minutes.
+    # When the sync step crashes early (tolerated by design) ci-test
+    # must do the whole cold build inside its own elpaca window (4800s
+    # in bin/zetta); leave room for that plus the stall dump.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,21 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     # A fully cold elpaca build measured ~25 minutes at the old
-    # 1508298 pin; the 7484867 elpaca's event system costs ~2x main-
-    # process CPU on these 4-vCPU runners and a cold sync now measures
-    # ~65 minutes (runs 30064121523 unthrottled and 30068189855
-    # throttled both blew a 60-minute ceiling while progressing
-    # normally).  Cold builds only happen on schedule/dispatch and
-    # epoch-cold first PR runs -- warm-cache runs are minutes -- so pay
-    # for them with ceiling instead of masking true wedges: the
-    # in-process watchdog still kills a frozen queue at 20 minutes.
-    # When the sync step crashes early (tolerated by design) ci-test
-    # must do the whole cold build inside its own elpaca window (4800s
-    # in bin/zetta); leave room for that plus the stall dump.
-    timeout-minutes: 90
+    # 1508298 pin; the 7484867 elpaca's event system costs 2-3x main-
+    # process CPU on these 4-vCPU runners and the cost compounds on the
+    # slow tail categories -- run 30071082660 was still syncing at
+    # 300/318 when a 90-minute ceiling cancelled it, progressing
+    # normally the whole way (runs 30064125083/30068189855 likewise at
+    # 60).  A green cold job needs ~105 minutes end to end.  Cold
+    # builds only happen on schedule/dispatch and epoch-cold first PR
+    # runs -- warm-cache runs are minutes -- so pay for them with
+    # ceiling instead of masking true wedges: the in-process watchdog
+    # still kills a frozen queue at 20 minutes.  Follow-up: profile
+    # batch elpaca on a 4-vCPU container and file upstream.  When the
+    # sync step crashes early (tolerated by design) ci-test must do the
+    # whole cold build inside its own elpaca window (4800s in
+    # bin/zetta); leave room for that plus the stall dump.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,15 +70,20 @@ jobs:
         # (measured repeatedly during the cold-install repair, runs
         # 29951544889+).  Scheduled and manually-dispatched runs skip the
         # restore on purpose -- they are the cold fresh-install rehearsal.
-        # v2 epoch: orphans the v1 caches saved mid-wedge.
+        # v2 epoch: orphaned the v1 caches saved mid-wedge.  v3 epoch:
+        # orphans every old-elpaca (pin 1508298) cache so the prefix
+        # restore-key can never feed a pre-upgrade store into a
+        # new-elpaca (pin 7484867, sources/ layout) run.  The bootstrap
+        # also self-verifies the elpaca clone against the pin, so the
+        # epoch bump is belt-and-braces rather than load-bearing.
         if: github.event_name == 'pull_request'
         id: cache-elpaca
         uses: actions/cache/restore@v4
         with:
           path: elpaca
-          key: elpaca-v2-${{ matrix.emacs-version }}-${{ hashFiles('early-init.el', 'init.el', 'source/**', 'modules/**', 'elpaca-lock.el') }}
+          key: elpaca-v3-${{ matrix.emacs-version }}-${{ hashFiles('early-init.el', 'init.el', 'source/**', 'modules/**', 'elpaca-lock.el') }}
           restore-keys: |
-            elpaca-v2-${{ matrix.emacs-version }}-
+            elpaca-v3-${{ matrix.emacs-version }}-
 
       - name: Create stub files
         run: |
@@ -106,4 +111,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: elpaca
-          key: elpaca-v2-${{ matrix.emacs-version }}-${{ hashFiles('early-init.el', 'init.el', 'source/**', 'modules/**', 'elpaca-lock.el') }}
+          key: elpaca-v3-${{ matrix.emacs-version }}-${{ hashFiles('early-init.el', 'init.el', 'source/**', 'modules/**', 'elpaca-lock.el') }}

--- a/bin/zetta
+++ b/bin/zetta
@@ -83,12 +83,12 @@ cmd_install() {
                            (let ((pending 0) (failed 0) (total 0) (done 0) (stuck nil))
                              (dolist (entry (elpaca--queued))
                                (cl-incf total)
-                               (pcase (elpaca--status (cdr entry))
+                               (pcase (elpaca<-status (cdr entry))
                                  ('failed (cl-incf failed))
                                  ((or 'finished 'blocked) (cl-incf done))
                                  (_ (cl-incf pending)
                                     (push (format \"%s [%s]\" (car entry)
-                                                  (elpaca--status (cdr entry)))
+                                                  (elpaca<-status (cdr entry)))
                                           stuck))))
                              (message \"install: %d/%d done, %d pending, %d failed (%.0fs)\"
                                       done total pending failed
@@ -421,19 +421,37 @@ cmd_test() {
 # detector exists, so the job eats the full job timeout with no package
 # named in the log.  Timers fire inside elpaca-wait's sit-for loop, so a
 # timer registered up front reports from within that hang: a status line
-# every minute, and after ~5 minutes with no order reaching a terminal
-# state, a dump of every stuck order with its last elpaca log line, then
-# exit 70 so the step fails fast and named instead of silently timing out.
+# every minute, and after a stretch with no order reaching a terminal
+# state, a dump of every stuck order with its most recent event text,
+# then exit 70 so the step fails fast and named instead of silently
+# timing out.
 ZETTA_CI_WATCHDOG="(progn
   (defvar zetta--wd-prev \"\")
   (defvar zetta--wd-stall 0)
+  ;; elpaca's per-order log slot is gone (2026 struct redesign); the
+  ;; global event log ('elpaca--event-log', newest first) is the batch
+  ;; introspection surface.  An event's human-readable text is :info
+  ;; (elpaca-note -- includes failure reasons) or :output (subprocess
+  ;; output); bare status-transition events carry neither, skip them.
+  (defun zetta--elpaca-events (id n)
+    \"Up to N most recent elpaca event texts for package ID, oldest first.\"
+    (let (texts)
+      (catch 'done
+        (dolist (ev (elpaca-event-log id))
+          (let* ((payload (elpaca-event<-payload ev))
+                 (text (or (plist-get payload :info)
+                           (plist-get payload :output))))
+            (when text
+              (push text texts)
+              (when (>= (length texts) n) (throw 'done nil))))))
+      texts))
   (run-with-timer 60 60
    (lambda ()
      (when (featurep 'elpaca)
        (let ((done 0) (total 0) (waiting nil))
          (dolist (entry (elpaca--queued))
            (setq total (1+ total))
-           (let ((s (elpaca--status (cdr entry))))
+           (let ((s (elpaca<-status (cdr entry))))
              ;; 'blocked is NOT terminal here: elpaca-wait keeps waiting
              ;; on blocked orders, so one blocked forever (dep of a failed
              ;; package, monorepo partner) spins the wait while an
@@ -462,27 +480,22 @@ ZETTA_CI_WATCHDOG="(progn
              (message \"WATCHDOG-STALL: waiting set frozen for %d minutes:\"
                       zetta--wd-stall)
              (dolist (entry (elpaca--queued))
-               (let* ((e (cdr entry)) (s (elpaca--status e)))
+               (let* ((e (cdr entry)) (s (elpaca<-status e)))
                  ;; Failed orders are terminal but they are USUALLY the
                  ;; reason others sit blocked -- without them the dump
                  ;; names victims and hides the culprit (measured: three
                  ;; elfeed dependents frozen [blocked], the failed elfeed
                  ;; order that caused it invisible).
-                 ;; elpaca pushes log entries, so the log is stored
-                 ;; NEWEST-FIRST: seq-take from the front for the failure
-                 ;; reason (taking from the tail dumps \"Package queued\" -- the
-                 ;; three oldest, least informative lines).
                  (cond
                   ((eq s 'failed)
-                   (dolist (info (reverse (seq-take (elpaca<-log e) 4)))
-                     (message \"  FAILED: %s | %s\" (car entry)
-                              (nth 2 info))))
+                   (dolist (msg (zetta--elpaca-events (car entry) 4))
+                     (message \"  FAILED: %s | %s\" (car entry) msg)))
                   ((eq s 'finished) nil)
                   (t
-                   (let ((info (car (elpaca<-log e))))
-                     (message \"  STUCK: %s [%s] blockers=%S %s\"
-                              (car entry) s (elpaca<-blockers e)
-                              (if info (nth 2 info) \"\"))))))))
+                   (message \"  STUCK: %s [%s] step=%s conditions=%S %s\"
+                            (car entry) s (elpaca<-current-step e)
+                            (elpaca<-conditions e)
+                            (or (car (last (zetta--elpaca-events (car entry) 1))) \"\")))))))
            (when (and waiting (>= zetta--wd-stall 20))
              (kill-emacs 70))))))))"
 
@@ -510,12 +523,12 @@ cmd_ci_sync() {
                            (let ((pending 0) (failed 0) (total 0) (done 0) (stuck nil))
                              (dolist (entry (elpaca--queued))
                                (cl-incf total)
-                               (pcase (elpaca--status (cdr entry))
+                               (pcase (elpaca<-status (cdr entry))
                                  ('failed (cl-incf failed))
                                  ((or 'finished 'blocked) (cl-incf done))
                                  (_ (cl-incf pending)
                                     (push (format \"%s [%s]\" (car entry)
-                                                  (elpaca--status (cdr entry)))
+                                                  (elpaca<-status (cdr entry)))
                                           stuck))))
                              (message \"sync: %d/%d done, %d pending, %d failed (%.0fs)\"
                                       done total pending failed
@@ -578,7 +591,7 @@ cmd_ci_test() {
                            (let ((pending 0) (failed 0) (total 0))
                              (dolist (entry (elpaca--queued))
                                (cl-incf total)
-                               (pcase (elpaca--status (cdr entry))
+                               (pcase (elpaca<-status (cdr entry))
                                  ('failed (cl-incf failed))
                                  ((or 'finished 'blocked) nil)
                                  (_ (cl-incf pending))))
@@ -588,23 +601,22 @@ cmd_ci_test() {
                            (when (> (- (float-time) start) timeout)
                              (message \"ELPACA-TIMEOUT after %ds\" timeout)
                              (dolist (entry (elpaca--queued))
-                               (unless (memq (elpaca--status (cdr entry)) '(finished blocked))
-                                 (message \"  %s [%s]\" (car entry) (elpaca--status (cdr entry)))))
+                               (unless (memq (elpaca<-status (cdr entry)) '(finished blocked))
+                                 (message \"  %s [%s]\" (car entry) (elpaca<-status (cdr entry)))))
                              (cancel-timer zetta--ci-timer)
                              (throw 'elpaca-timeout nil)))))
                   (catch 'elpaca-timeout
                     (unwind-protect (elpaca-wait) (cancel-timer zetta--ci-timer)))
                   (message \"elpaca-wait: finished in %.0fs\" (- (float-time) start)))" \
         --eval "(let ((failed-pkgs (cl-remove-if-not
-                                    (lambda (e) (eq (elpaca--status (cdr e)) 'failed))
+                                    (lambda (e) (eq (elpaca<-status (cdr e)) 'failed))
                                     (elpaca--queued))))
                   (when failed-pkgs
                     (message \"ELPACA-FAILED %d packages:\" (length failed-pkgs))
                     (dolist (e failed-pkgs)
                       (let* ((name (car e))
-                             (p (cdr e))
-                             (info (car (last (elpaca<-log p)))))
-                        (message \"  %s: %s\" name (if info (nth 2 info) \"unknown\"))))))" \
+                             (msg (car (zetta--elpaca-events name 1))))
+                        (message \"  %s: %s\" name (or msg \"unknown\"))))))" \
         --eval "(message \"ZETTA-OK packages=%d modules=%d\" (length (elpaca--queued)) (length user-files))" \
         --eval "(let* ((lock (expand-file-name \"elpaca-lock.el\" user-emacs-directory))
                        (locked (when (file-exists-p lock)

--- a/bin/zetta
+++ b/bin/zetta
@@ -584,7 +584,7 @@ cmd_ci_test() {
         -l "$ZETTA_DIR/init.el" \
         --eval "(defvar zetta--ci-timer nil)" \
         --eval "(let* ((start (float-time))
-                       (timeout 2400))
+                       (timeout 4800))
                   (setq zetta--ci-timer
                         (run-with-timer 10 10
                          (lambda ()

--- a/bin/zetta
+++ b/bin/zetta
@@ -584,7 +584,7 @@ cmd_ci_test() {
         -l "$ZETTA_DIR/init.el" \
         --eval "(defvar zetta--ci-timer nil)" \
         --eval "(let* ((start (float-time))
-                       (timeout 4800))
+                       (timeout 6600))
                   (setq zetta--ci-timer
                         (run-with-timer 10 10
                          (lambda ()

--- a/elpaca-lock.el
+++ b/elpaca-lock.el
@@ -586,8 +586,10 @@
          (:package "compat" :repo
                    ("https://github.com/emacs-compat/compat"
                     . "compat")
-                   :files ("*" (:exclude ".git")) :source "GNU ELPA"
-                   :protocol https :inherit t :depth treeless :ref
+                   :tar "31.0.0.2" :host gnu :files
+                   ("*" (:exclude ".git")) :source "GNU ELPA" :id
+                   compat :type git :protocol https :inherit t :depth
+                   treeless :ref
                    "1f3d7596173cf2851d3c4181b15d6c3573a38252"))
  (compile-angel :source "elpaca-menu-lock-file" :recipe
                 (:package "compile-angel" :fetcher github :repo
@@ -905,8 +907,7 @@
                         "31a8c67405afa99d0e25e7c86a4ee7ef84a808fe"))
  (detached :source "elpaca-menu-lock-file" :recipe
            (:package "detached" :fetcher sourcehut :repo
-                     "niklaseklund/detached.el" :old-names (dtache)
-                     :files
+                     "chiply/detached.el" :old-names (dtache) :files
                      ("*.el" "*.el.in" "dir" "*.info" "*.texi"
                       "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
                       "doc/*.texinfo" "lisp/*.el" "docs/dir"
@@ -917,7 +918,8 @@
                      :source "elpaca-menu-lock-file" :id detached
                      :type git :protocol https :inherit t :depth
                      treeless :ref
-                     "6b64d4d8064cee781e071e825857b442ea96c3d9"))
+                     "6b64d4d8064cee781e071e825857b442ea96c3d9" :host
+                     github))
  (devdocs :source "elpaca-menu-lock-file" :recipe
           (:package "devdocs" :fetcher github :repo
                     "astoff/devdocs.el" :files
@@ -1056,8 +1058,9 @@
                                     "tests.el" "*-test.el"
                                     "*-tests.el" "LICENSE" "README*"
                                     "*-pkg.el"))
-                         :source "MELPA" :protocol https :inherit t
-                         :depth treeless :ref
+                         :source "MELPA" :id editorconfig :type git
+                         :protocol https :inherit t :depth treeless
+                         :ref
                          "b18fcf7fdea1ce84b7fdc60360ad8016b5c00d79"))
  (ef-themes :source "elpaca-menu-lock-file" :recipe
             (:package "ef-themes" :repo
@@ -1149,11 +1152,12 @@
                        "541a064c3ce27867872cf708354a65d83baf2a6d"))
  (elpaca :source
    "elpaca-menu-lock-file" :recipe
-   (:source nil :protocol https :inherit ignore :depth nil :repo
+   (:source nil :package "elpaca" :id elpaca :repo
             "https://github.com/progfolio/elpaca.git" :ref
-            "1508298c1ed19c81fa4ebc5d22d945322e9e4c52" :files
+            "74848674bfca8590e9286309d11e9645c8425400" :depth nil
+            :inherit ignore :files
             (:defaults "elpaca-test.el" (:exclude "extensions"))
-            :build (:not elpaca--activate-package) :package "elpaca"))
+            :build (:not elpaca-activate) :type git :protocol https))
  (elysium :source "elpaca-menu-lock-file" :recipe
           (:package "elysium" :fetcher github :repo
                     "lanceberge/elysium" :files
@@ -1908,7 +1912,8 @@
                       :source "elpaca-menu-lock-file" :id hyperbole
                       :type git :protocol https :inherit t :depth
                       treeless :ref
-                      "f076ff8c5997e9e9401d02da5034c1c10ba070f4"))
+                      "f076ff8c5997e9e9401d02da5034c1c10ba070f4" :host
+                      github :repo "rswgnu/hyperbole"))
  (iedit :source "elpaca-menu-lock-file" :recipe
         (:package "iedit" :repo "victorhge/iedit" :fetcher github
                   :files
@@ -2954,9 +2959,10 @@
  (peg :source "elpaca-menu-lock-file" :recipe
       (:package "peg" :repo
                 ("https://github.com/emacsmirror/gnu_elpa" . "peg")
-                :branch "externals/peg" :files
+                :tar "1.0.2" :host gnu :branch "externals/peg" :files
                 ("*" (:exclude ".git" "COPYING")) :source "GNU ELPA"
-                :protocol https :inherit t :depth treeless :ref
+                :id peg :type git :protocol https :inherit t :depth
+                treeless :ref
                 "2bccc414a94f067eb571fe614270494750a5de0e"))
  (persist :source "elpaca-menu-lock-file" :recipe
           (:package "persist" :repo
@@ -3674,12 +3680,13 @@
                 (:package "track-changes" :repo
                           ("https://github.com/emacs-mirror/emacs"
                            . "track-changes")
-                          :branch "master" :files
+                          :tar "1.5" :host gnu :branch "master" :files
                           ("lisp/emacs-lisp/track-changes.el"
                            (:exclude ".git"))
-                          :source "GNU ELPA" :protocol https :inherit
-                          t :depth treeless :ref
-                          "389be0b24781bdf81679beb39042ff2bd9a1c275"))
+                          :source "GNU ELPA" :id track-changes :type
+                          git :protocol https :inherit t :depth
+                          treeless :ref
+                          "21c979ee6088da645636f8751ad873c38dad830f"))
  (trailing-newline-indicator :source "elpaca-menu-lock-file" :recipe
                              (:package "trailing-newline-indicator"
                                        :fetcher github :repo
@@ -4053,9 +4060,9 @@
                   (:exclude ".dir-locals.el" "test.el" "tests.el"
                             "*-test.el" "*-tests.el" "LICENSE"
                             "README*" "*-pkg.el"))
-                 :source "elpaca-menu-lock-file" :id yaml :host github
-                 :type git :protocol https :inherit t :depth treeless
-                 :ref "f2369fb4985ed054be47ae111760ff2075dff72a"))
+                 :source "MELPA" :id yaml :host github :type git
+                 :protocol https :inherit t :depth treeless :ref
+                 "5546f36bde24a9a8c1934e0f6ce205cd41d72537"))
  (yaml-mode :source "elpaca-menu-lock-file" :recipe
             (:package "yaml-mode" :repo "yoshiki/yaml-mode" :fetcher
                       github :files

--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -148,7 +148,13 @@ otherwise appear as a bogus `zsh#...' completion candidate."
         (shell-command-switch "-c"))
     (apply orig args)))
 
+;; Official GitHub mirror -- git.savannah.gnu.org is slow and
+;; intermittently times out on CI runners (cold-run clone flake, PR
+;; #114's 29.4 job, 2026-07-23).  A true mirror shares commit SHAs, so
+;; the lockfile pin holds; verified the pinned f076ff8 present on the
+;; mirror 2026-07-23.
 (use-package hyperbole
+  :ensure (hyperbole :host github :repo "rswgnu/hyperbole")
   :defer 1
   :init
   ;; Keep Hyperbole's default key initialization; we relocate two keys below.

--- a/modules/tools/detached.el
+++ b/modules/tools/detached.el
@@ -1,6 +1,13 @@
 ;;; detached.el --- Configure detached -*- lexical-binding: t; -*-
 
+;; chiply/detached.el is a push-mirror of git.sr.ht/~niklaseklund/detached.el:
+;; sr.ht throttles GitHub Actions runners, which made the upstream clone
+;; the last chronic cold-run flake (detached "[cloning]" hang failed the
+;; v0.1.36 release snapshot job, 2026-07-23).  Commit SHAs are identical
+;; to upstream, so the lockfile pin holds.  Re-sync the mirror
+;; (git push --mirror) only when deliberately bumping the pin.
 (use-package detached
+  :ensure (detached :host github :repo "chiply/detached.el")
   :config
   ;; this avoids a cryptic error.  For whatever reason I'm able to
   ;; proceed with using detached despite ignoring the error in

--- a/source/bootstrap/bootstrap-elpaca.el
+++ b/source/bootstrap/bootstrap-elpaca.el
@@ -206,6 +206,34 @@
 (advice-add 'elpaca--queue :around #'zetta--elpaca-queue-return-struct)
 (advice-add 'elpaca--enqueue :around #'zetta--elpaca-queue-return-struct)
 
+;; Fix elpaca mono-repo deadlock (verified present at pin 7484867).
+;; `elpaca-source' blocks a shared-source-dir partner on the
+;; (source-dir-exists . DIR) condition while the dir's OWNER still has
+;; `elpaca-git--checkout-ref' pending -- or when ANY earlier waiter is
+;; already in the condition table -- but the only `elpaca-resolve'
+;; calls for that condition live in the CLONE path (elpaca-git.el:
+;; clone sentinel + dir-exists branch).  A partner that blocks after
+;; the owner's clone already resolved (fast clone; partner enqueued
+;; during or after the owner's checkout) therefore waits forever, and
+;; the owner then waits on the partner as a dependency: deadlock
+;; (measured cold 2026-07-23: swiper [blocked (finished . ivy)] while
+;; ivy and counsel sat [blocked (source-dir-exists . sources/swiper/)]
+;; -- the abo-abo mono-repo; watchdog killed the run at 20 frozen
+;; minutes.  The same race produced the earlier "counsel failed"
+;; sentinel crash.  The slow-clone interleaving works -- waiters arrive
+;; while the clone is still in flight and its sentinel releases them --
+;; which is why consult-gh's partners survive).  Resolve the condition
+;; whenever an order COMPLETES its checkout-ref step: the checkout
+;; sentinel funnels into `elpaca-continue' with `current-step' still
+;; `elpaca-git--checkout-ref', and resolving with no waiters is a
+;; no-op, so this closes the window for every shared-repo group
+;; generically.  Report upstream; drop once the pin reaches a fix.
+(defun zetta--elpaca-resolve-source-dir-after-checkout (e &rest _)
+  "Release (source-dir-exists . DIR) waiters when E completes checkout-ref."
+  (when (eq (elpaca<-current-step e) 'elpaca-git--checkout-ref)
+    (elpaca-resolve 'source-dir-exists (elpaca<-source-dir e))))
+(advice-add 'elpaca-continue :before #'zetta--elpaca-resolve-source-dir-after-checkout)
+
 ;; In batch mode (`zetta install'/CI), `after-init-time' is already set
 ;; before init.el loads, so every declaration runs `elpaca--unprocess',
 ;; which resets `builtp' -- and the throttle only exempts built packages,

--- a/source/bootstrap/bootstrap-elpaca.el
+++ b/source/bootstrap/bootstrap-elpaca.el
@@ -2,21 +2,26 @@
 
 ;; MUST match the version the pinned elpaca expects (its doc/installer.el;
 ;; elpaca.el lwarns "installer version does not match" otherwise).  The
-;; pinned 1508298 declares 0.11; current master declares 0.12 — bump this
-;; together with the :ref below, never independently.
-(defvar elpaca-installer-version 0.11)
+;; pinned 7484867 declares 0.12 -- bump this together with the :ref below,
+;; never independently.
+(defvar elpaca-installer-version 0.12)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
 (defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
-;; The bootstrap clone MUST land in elpaca-repos-directory/elpaca -- the
-;; location elpaca itself reads (elpaca.el `elpaca-repos-directory'): the
+;; The bootstrap clone MUST land in elpaca-sources-directory/elpaca -- the
+;; location elpaca itself reads (elpaca.el `elpaca-sources-directory'): the
 ;; self-order reuses a repo found there, and every package build's
-;; autoload subprocess loads repos/elpaca/elpaca.el.  The previous
-;; config-invented "sources/" directory was invisible to elpaca, so the
-;; self-order re-cloned the repo asynchronously and every early cold
-;; build raced that clone (measured 2026-07-22: compile-angel's autoload
-;; step died file-missing on repos/elpaca/elpaca.el, and
-;; elpaca-use-package sat "waiting on monorepo" forever).
-(defvar elpaca-repos-directory (expand-file-name "repos/" elpaca-directory))
+;; autoload subprocess loads sources/elpaca/elpaca.el.  This variable was
+;; `elpaca-repos-directory' (dir "repos/") before upstream's 2026 struct
+;; redesign; the name here must be the one THE PINNED elpaca.el reads.
+;; Getting this wrong is invisible on warm machines and breaks every cold
+;; install: a config-invented "sources/" against the old repos-reading
+;; elpaca made the self-order re-clone asynchronously and every early
+;; cold build raced that clone (measured 2026-07-22: compile-angel's
+;; autoload step died file-missing on the elpaca clone, and
+;; elpaca-use-package sat "waiting on monorepo" forever).  When flipping
+;; the pin across the rename in EITHER direction, re-check this name
+;; against the pinned elpaca.el first.
+(defvar elpaca-sources-directory (expand-file-name "sources/" elpaca-directory))
 ;; elpaca is the one package the lockfile cannot pin -- this installer
 ;; clones it before any lockfile is read -- so it MUST be pinned here.
 ;; With :ref nil every fresh install got that day's master, whose internal
@@ -25,15 +30,46 @@
 ;; tools-category elpaca-wait on CI and on a reader's machine alike, while
 ;; warm checkouts kept working from their old builds).  Bump this SHA
 ;; deliberately, together with `zetta freeze', never implicitly.
+;; Pinned: master 7484867 (2026-07-21, "elpaca-menu--build: add autoload
+;; cookie"); upgraded from 1508298 (2026-01-01) on 2026-07-23.
 (defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
-                              :ref "1508298c1ed19c81fa4ebc5d22d945322e9e4c52"
+                              :ref "74848674bfca8590e9286309d11e9645c8425400"
                               :depth nil :inherit ignore
                               :files (:defaults "elpaca-test.el" (:exclude "extensions"))
-                              :build (:not elpaca--activate-package)))
-(let* ((repo  (expand-file-name "elpaca/" elpaca-repos-directory))
+                              :build (:not elpaca-activate)))
+(let* ((repo  (expand-file-name "elpaca/" elpaca-sources-directory))
        (build (expand-file-name "elpaca/" elpaca-builds-directory))
        (order (cdr elpaca-order))
        (default-directory repo))
+  ;; Pin self-enforcement: the clone branch below only runs when the repo
+  ;; is ABSENT, so a bumped :ref would be silently ignored wherever a
+  ;; clone already exists -- warm CI caches (restore-keys prefix-restores
+  ;; an older cache into the run) and every local machine alike would
+  ;; keep running the old elpaca after a pin flip.  Verify the existing
+  ;; checkout against the pin; on mismatch fetch + checkout + recompile,
+  ;; drop the stale generated autoloads, and invalidate the stale build
+  ;; dir so the re-pinned source is what actually loads.  If convergence
+  ;; fails, delete the clone and fall through to a fresh clone below.
+  (let ((ref (plist-get order :ref)))
+    (when (and ref (file-exists-p (expand-file-name ".git" repo)))
+      (let ((head (with-temp-buffer
+                    (when (zerop (call-process "git" nil t nil "rev-parse" "HEAD"))
+                      (car (split-string (buffer-string)))))))
+        (unless (equal head ref)
+          (message "elpaca: clone at %s is %s, pin is %s; converging"
+                   repo (or head "unreadable") ref)
+          (if (with-temp-buffer
+                (and (zerop (call-process "git" nil t nil "fetch" "origin"))
+                     (zerop (call-process "git" nil t nil "checkout" ref))
+                     (zerop (call-process (concat invocation-directory invocation-name)
+                                          nil t nil "-Q" "-L" "." "--batch" "--eval"
+                                          "(byte-recompile-directory \".\" 0 'force)"))))
+              (dolist (stale '("elpaca-autoloads.el" "elpaca-autoloads.elc"))
+                (when (file-exists-p (expand-file-name stale repo))
+                  (delete-file (expand-file-name stale repo))))
+            (warn "elpaca: pin convergence failed; re-cloning at the pin")
+            (delete-directory repo 'recursive))
+          (when (file-exists-p build) (delete-directory build 'recursive))))))
   (add-to-list 'load-path (if (file-exists-p build) build repo))
   (unless (file-exists-p repo)
     (make-directory repo t)
@@ -67,24 +103,34 @@
 ;; while CI and the installer never noticed -- both always load the
 ;; bootstrap from source (install deletes .elc first; compile-angel
 ;; excludes the bootstrap dir).  `require' is idempotent, and elpaca
-;; would be resident moments later anyway.
+;; would be resident moments later anyway.  (Upstream's installer now
+;; ships a `no-byte-compile: t' file-local instead; we compile the
+;; bootstrap deliberately, so the eager require stays.)
 (require 'elpaca)
-(add-hook 'elpaca-after-init-hook #'elpaca-process-queues)
+;; Matches the upstream installer.  (Until the 2026-07 pin bump this
+;; added to `elpaca-after-init-hook' -- an undocumented deviation; both
+;; the old and new upstream installers use `after-init-hook'.)
+(add-hook 'after-init-hook #'elpaca-process-queues)
 (elpaca `(,@elpaca-order))
 
 ;; Install use-package support -- activated directly from the bootstrap
-;; clone, NOT as an `(elpaca elpaca-use-package ...)' order.  That order is
-;; a monorepo partner of the `elpaca' order itself, and with a pinned :ref
-;; its dependency scan reads repos/elpaca/extensions/elpaca-use-package.el
-;; before the pinned checkout materialises it (measured cold, 2026-07-22:
-;; the order fails file-missing, elpaca-wait returns, use-package silently
-;; falls back to package.el -- which cannot parse elpaca recipes, so
-;; `general' never installs and the first `general-define-key' crashes
-;; init).  The installer has already cloned AND byte-compiled the extension
-;; at the pinned ref; requiring it from there is the same file with no
-;; network and no monorepo coordination.
+;; clone, NOT as an `(elpaca elpaca-use-package ...)' order.  The
+;; installer has already cloned AND byte-compiled the extension at the
+;; pinned ref; requiring it from there is the same file with no network
+;; and no queue coordination, so it is categorically race-free.  History:
+;; under the old 1508298 pin the order was a mono-repo partner of the
+;; `elpaca' order itself, and its dependency scan read
+;; extensions/elpaca-use-package.el before the pinned checkout
+;; materialised it (measured cold, 2026-07-22: the order failed
+;; file-missing, elpaca-wait returned, use-package silently fell back to
+;; package.el -- which cannot parse elpaca recipes, so `general' never
+;; installed and the first `general-define-key' crashed init).  Upstream
+;; has since fixed the mono-repo deadlock and ships a first-class
+;; extensions menu (`elpaca-menu-extensions'), so the standard order is a
+;; candidate cleanup -- flip it in its own change, cold-verified, not as
+;; part of a pin bump.
 (add-to-list 'load-path (expand-file-name "elpaca/extensions"
-                                          elpaca-repos-directory))
+                                          elpaca-sources-directory))
 (require 'elpaca-use-package)
 (elpaca-use-package-mode)
 
@@ -109,10 +155,12 @@
 ;; every Emacs, so one freeze covers all supported versions.
 ;; ...and they must ALSO leave `elpaca-ignored-dependencies', which
 ;; defaults to the RUNNING Emacs's builtin list -- on Emacs 31 that
-;; includes peg and editorconfig, and this elpaca version silently drops
-;; even explicit orders for ignored ids (measured: (elpaca peg) produced
-;; no order at all, so `zetta freeze' could never pin them).  Upstream
-;; made the same move for compat (elpaca c1833ca).
+;; includes peg and editorconfig, and the old pinned elpaca silently
+;; dropped even explicit orders for ignored ids (measured: (elpaca peg)
+;; produced no order at all, so `zetta freeze' could never pin them).
+;; Newer elpacas auto-un-ignore explicitly ordered ids, but the
+;; set-difference is kept: it is harmless and preserves pin-rollback
+;; safety.
 (setq elpaca-ignored-dependencies
       (cl-set-difference elpaca-ignored-dependencies '(peg editorconfig)))
 (elpaca peg)
@@ -129,19 +177,20 @@
 (elpaca (yaml :host github :repo "zkry/yaml.el"))
 (elpaca-wait)
 
-;; Fix elpaca bug: when a package is re-declared after being queued as a
-;; transitive dependency, the queue function's duplicate branch returns the
-;; value of `warn' instead of the existing elpaca struct (its own docstring
-;; says "Return E.").  In a frameless daemon `warn' returns the rendered
+;; Fix elpaca bug (verified still present at pin 7484867, elpaca.el
+;; `elpaca--enqueue'): when a package is re-declared after being queued
+;; as a transitive dependency, the duplicate branch returns the value of
+;; `warn' instead of the existing elpaca struct (its own docstring says
+;; "Return E.").  In a frameless daemon `warn' returns the rendered
 ;; warning string, which then crashes queue processing after init with
 ;; (wrong-type-argument listp ...) -- aborting daemon startup before the
-;; server starts (measured 2026-07-23: ace-window re-declared after treemacs
-;; queued it; `--fg-daemon' exited after every module had loaded).  The
-;; function is `elpaca--queue' at the pinned ref and was renamed to
-;; `elpaca--enqueue' on later masters, so advise BOTH names -- advice on an
-;; undefined symbol is inert until the function is defined, which lets the
-;; fix survive a pin bump in either direction.  Drop this once the pin
-;; reaches an upstream where the duplicate branch returns the struct.
+;; server starts (measured 2026-07-23 at the old 1508298 pin: ace-window
+;; re-declared after treemacs queued it; `--fg-daemon' exited after every
+;; module had loaded).  The function is `elpaca--queue' at 1508298 and
+;; `elpaca--enqueue' from 49db2a6 on, so advise BOTH names -- advice on
+;; an undefined symbol is inert until the function is defined, which lets
+;; the fix survive a pin flip in either direction.  Drop this once the
+;; pin reaches an upstream where the duplicate branch returns the struct.
 (defun zetta--elpaca-queue-return-struct (fn order &optional queue)
   "Return existing elpaca struct for duplicate packages instead of warn string."
   (if-let* ((id (elpaca--first (or order (signal 'wrong-type-argument
@@ -157,16 +206,15 @@
 (advice-add 'elpaca--queue :around #'zetta--elpaca-queue-return-struct)
 (advice-add 'elpaca--enqueue :around #'zetta--elpaca-queue-return-struct)
 
-;; Configure use-package to use Elpaca by default
-(setq elpaca-use-package-by-default t)
-;; In batch mode (e.g. `zetta install`), after-init-time is already set before
-;; init.el loads, which causes elpaca--unprocess to reset builtp on all packages.
-;; With builtp=nil, queue throttling applies.  The unthrottle code path in
-;; elpaca--finalize can trigger synchronous dependency processing that grows the
-;; queue, but elpaca--finalize's stale snapshot of the queue length causes a
-;; premature finalize-queue call before all packages are activated, resulting in
-;; "Cannot load" errors for tail-end packages.  Disabling the queue limit in
-;; batch mode avoids the throttle code path entirely.
+;; In batch mode (`zetta install'/CI), `after-init-time' is already set
+;; before init.el loads, so every declaration runs `elpaca--unprocess',
+;; which resets `builtp' -- and the throttle only exempts built packages,
+;; so with a limit set EVERYTHING would throttle.  Batch therefore runs
+;; unthrottled (nil).  Interactively the limit caps concurrent active
+;; builds at 8.  (The old rationale here -- a stale queue-length snapshot
+;; in `elpaca--finalize' finalizing the queue prematurely -- no longer
+;; describes upstream: queue completion is subscriber-driven and always
+;; re-checks the whole queue since the pub-sub redesign.)
 (setq elpaca-queue-limit (unless noninteractive 8))
 
 ;; Enable lockfile for reproducible builds.

--- a/source/bootstrap/bootstrap-elpaca.el
+++ b/source/bootstrap/bootstrap-elpaca.el
@@ -234,16 +234,22 @@
     (elpaca-resolve 'source-dir-exists (elpaca<-source-dir e))))
 (advice-add 'elpaca-continue :before #'zetta--elpaca-resolve-source-dir-after-checkout)
 
-;; In batch mode (`zetta install'/CI), `after-init-time' is already set
-;; before init.el loads, so every declaration runs `elpaca--unprocess',
-;; which resets `builtp' -- and the throttle only exempts built packages,
-;; so with a limit set EVERYTHING would throttle.  Batch therefore runs
-;; unthrottled (nil).  Interactively the limit caps concurrent active
-;; builds at 8.  (The old rationale here -- a stale queue-length snapshot
-;; in `elpaca--finalize' finalizing the queue prematurely -- no longer
-;; describes upstream: queue completion is subscriber-driven and always
-;; re-checks the whole queue since the pub-sub redesign.)
-(setq elpaca-queue-limit (unless noninteractive 8))
+;; Cap concurrent active builds EVERYWHERE, batch included.  History:
+;; at the old 1508298 pin batch had to run unthrottled -- a stale
+;; queue-length snapshot in `elpaca--finalize' finalized queues
+;; prematurely under throttling -- but that bug is structurally gone
+;; (queue completion is subscriber-driven and always re-checks the
+;; whole queue since the pub-sub redesign), and unthrottled batch now
+;; actively breaks CI: a category-boundary `elpaca-wait' with ~60
+;; concurrent pty build subprocesses drowns the 4-vCPU runner in
+;; process-filter/event churn, `accept-process-output' starves timers
+;; (the CI watchdog fell silent for 28 minutes while builds crawled),
+;; and every job blew the 60-minute ceiling (measured: run
+;; 30064121523, all three Emacs versions, 2026-07-24; the previous
+;; unthrottled elpaca finished the same cold build in ~27 minutes --
+;; the event system's per-chunk overhead is what tipped it over).
+;; Throttling bounds the churn and lets timers breathe.
+(setq elpaca-queue-limit 8)
 
 ;; Enable lockfile for reproducible builds.
 ;; The lockfile pins all packages to exact commits.


### PR DESCRIPTION
Upgrades the elpaca pin from `1508298` (2026-01-01) to master tip `7484867` (2026-07-21) — 83 upstream commits spanning the order-struct redesign (single `status` slot, pub-sub event system, `log`/`blockers` slots removed), the `repos/` → `sources/` rename, and the `elpaca--status` removal. Full plan + execution record: `~/upgrade-elpaca.org`.

## What changed

- **bootstrap-elpaca.el**: installer 0.11→0.12; `elpaca-sources-directory` (`sources/` on disk, upstream-identical skeleton); `:build (:not elpaca-activate)` (old symbol removed upstream — `:not` on it silently no-ops and elpaca self-activates twice); queues processed on `after-init-hook` (upstream parity); dropped `elpaca-use-package-by-default` (deleted upstream). **New: pin self-enforcement** — an existing clone is verified against `:ref` on every start and converged on mismatch (fetch + checkout + recompile + stale build/autoloads invalidation), so pin bumps take effect on warm caches and local machines, not just truly-cold installs.
- **bin/zetta**: all 11 `elpaca--status` probes → `elpaca<-status`; per-order `log` → global event log via a `zetta--elpaca-events` helper (`elpaca-event-log` payload `:info`/`:output`); `blockers` → `conditions` + `current-step` in watchdog stall dumps; ci-test failure reports now surface the newest event text (old code took the oldest, least-informative line).
- **New workaround — upstream mono-repo deadlock (report upstream)**: `elpaca-source` blocks shared-source-dir partners on `(source-dir-exists . DIR)`, but only the *clone* path ever resolves it — after a fast clone, partners arriving during/after the owner's `checkout-ref` wait forever while the owner waits on them as dependencies. Measured cold: swiper `[blocked (finished . ivy)]` with ivy+counsel `[blocked (source-dir-exists …)]`. Fixed by `zetta--elpaca-resolve-source-dir-after-checkout`, a guarded `:before` advice on `elpaca-continue` that resolves the condition when an order completes checkout-ref (no-op without waiters). Regression-probed 3/3 from scratch on the exact path that wedged.
- **Kept, each verified still required against 7484867 source**: duplicate-enqueue advice (duplicate branch still returns `warn`'s value), `elpaca-queue-limit` batch workaround (batch `elpaca--unprocess` resets `builtp`), explicit compat/track-changes/peg/editorconfig/yaml orders, direct `elpaca-use-package` require. The calfw two-order revert and the elpaca-use-package menu order are deliberate follow-ups.
- **ci.yml**: cache epoch `v2` → `v3` (no old-elpaca cache can prefix-restore into a new-elpaca run; belt-and-braces now that the bootstrap self-verifies the pin).
- **Flake fixes**: hyperbole → official mirror `rswgnu/hyperbole` (savannah timeouts); detached → push-mirror `chiply/detached.el` (sr.ht throttles Actions runners). Both pinned SHAs verified present on the mirrors before repointing.
- **elpaca-lock.el**: regenerated from the validated cold build. track-changes 1.4→1.5 and yaml (zkry tip) moved — bootstrap-declared orders resolve from live menus (`elpaca-lock-file` is set after their `elpaca-wait`; pre-existing, documented as a follow-up). swagg + mu4e-* + org-mime preserved verbatim (scratch-HOME freeze can't queue them; first real-machine freeze re-validates).

## Local validation (all green before this PR was opened)

- Pristine cold install (fresh checkout, scratch `$HOME`): `ci-sync` + `ci-test` → `ZETTA-OK packages=332 modules=280`, zero failed orders, no LOCK-MISSING — which also proves every lock `:ref` is fetchable from nothing, including both mirrors.
- Daemon startup test: responsive, 333 queued / 280 modules, no error warnings.
- Pin-convergence test: a clone forced to the old SHA converged automatically.
- Mono-repo deadlock regression probe: 3/3 clean from-scratch finishes.

## Migration note

Existing installs converge automatically on next start after pulling (elpaca re-clones into `sources/` and everything rebuilds); a full `bin/zetta install` is the recommended path. Rollback = revert this PR + bump the cache epoch to v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVwQJcUBQYdtq5w1s23dh5

---

## Update: CI throughput findings (post-open)

The first two CI runs were cancelled at the 60-minute job ceiling **while progressing normally** — not wedged (the mono-repo fix was visibly working; the runs sat at 249/265 resp. 289/300 sync when cancelled). Root cause: the new elpaca's pub-sub event system costs ~2× main-process CPU per package on 4-vCPU runners — a cold sync now measures ~65 min vs ~25 at the old pin (many-core local machines absorb it; local cold passes run ~29 min including home-bandwidth clones). Two follow-up commits:

- `elpaca-queue-limit` is now 8 in batch too (old unthrottled-batch workaround guarded a premature-finalize bug that is structurally gone upstream). Unthrottled, 60 concurrent pty builds starved timers so hard the CI watchdog fell silent for 28 minutes; throttling restored watchdog liveness.
- `timeout-minutes` 60 → 90 + ci-test's fallback elpaca window 2400s → 4800s. Only cold runs (schedule/dispatch/epoch-cold) pay the ceiling; warm-cache runs are minutes; true wedges are still killed by the in-process frozen-set watchdog at 20 minutes.

Upstream issue candidates (numbers in `~/upgrade-elpaca.org`): the mono-repo `source-dir-exists` deadlock, and batch event-system throughput.
