### PR TITLE
feat: treeless clones for lock-pinned recipes

### DIFF
--- a/source/bootstrap/bootstrap-elpaca.el
+++ b/source/bootstrap/bootstrap-elpaca.el
@@ -234,6 +234,45 @@
     (elpaca-resolve 'source-dir-exists (elpaca<-source-dir e))))
 (advice-add 'elpaca-continue :before #'zetta--elpaca-resolve-source-dir-after-checkout)
 
+;; Restore treeless clones for lock-pinned recipes.  `elpaca-git--clone'
+;; ignores :depth whenever the recipe carries a :ref ("Ignoring :depth
+;; in favor of :ref"), so every lock-pinned package -- all of them: the
+;; lockfile writes :ref into every recipe -- is FULL-cloned on a cold
+;; install.  That is upstream over-caution: a treeless clone
+;; (--filter=tree:0) has the complete commit graph, so checking out an
+;; arbitrary pinned SHA works, fetching its trees on demand -- and a SHA
+;; unreachable from every ref is absent from a full clone too, so
+;; nothing is lost.  Full clones cost real bytes (measured 2026-07-24:
+;; consult-gh ~300MB of media history for a ~2MB checkout).  Mask :ref
+;; only while the clone command is constructed; the struct's recipe is
+;; restored as soon as the clone process has spawned, so the later
+;; checkout-ref step and the clone-failure fallback (re-clone with
+;; :depth nil) both see the real recipe.  Tradeoff (documented in
+;; ~/upgrade-elpaca.org): historical git operations inside sources/
+;; (blame, log -p, checking out unrelated old refs) lazy-fetch from the
+;; remote and need network; normal builds, pulls, and `zetta freeze'
+;; are unaffected.  Drop once upstream honors treeless/blobless
+;; alongside :ref.
+(defun zetta--elpaca-clone-treeless-with-ref (fn e)
+  "Keep the treeless/blobless filter for :ref recipes during E's clone.
+Mask only when a clone command will actually be constructed (source
+dir absent): in the dir-exists path `elpaca-git--clone' short-circuits
+into `elpaca-continue', which runs later build steps SYNCHRONOUSLY
+inside this advice -- a mono-repo partner's checkout-ref would then
+read the masked recipe and check out a branch tip instead of the pin
+(observed 2026-07-24: failed orders' event dumps carried :ref nil)."
+  (let* ((recipe (elpaca<-recipe e))
+         (depth (plist-get recipe :depth)))
+    (if (and (memq depth '(treeless blobless))
+             (plist-get recipe :ref)
+             (not (file-exists-p (elpaca<-source-dir e))))
+        (progn
+          (setf (elpaca<-recipe e) (plist-put (copy-sequence recipe) :ref nil))
+          (unwind-protect (funcall fn e)
+            (setf (elpaca<-recipe e) recipe)))
+      (funcall fn e))))
+(advice-add 'elpaca-git--clone :around #'zetta--elpaca-clone-treeless-with-ref)
+
 ;; Cap concurrent active builds EVERYWHERE, batch included.  History:
 ;; at the old 1508298 pin batch had to run unthrottled -- a stale
 ;; queue-length snapshot in `elpaca--finalize' finalized queues


### PR DESCRIPTION
Restores elpaca's default treeless (`--filter=tree:0`) clones for lock-pinned recipes. Upstream ignores `:depth` whenever a recipe carries a `:ref` — so since the lockfile landed, every package has been full-cloned on cold installs (Discovery 1 in `~/upgrade-elpaca.org`). A treeless clone has the complete commit graph, so pinned-SHA checkouts work fine, fetching trees on demand; a SHA unreachable from every ref is absent from a full clone too, so nothing is lost.

Implementation: `zetta--elpaca-clone-treeless-with-ref`, an `:around` advice on `elpaca-git--clone` that masks `:ref` only while a real clone command is constructed (source dir absent) and restores the recipe as soon as the process spawns. The dir-exists guard is load-bearing: in that path elpaca runs later build steps synchronously inside the advice, and a mono-repo partner's checkout-ref would read the masked recipe — caught during validation, fixed by never masking when no clone will spawn.

## Measured (local cold install)

- consult-gh: ~300MB → **3.8M**; swiper 3.0M; magit 9.2M — all `tree:0`
- `elpaca/sources` total: ~2GB → **1.1G** (remaining bulk is the emacs-mirror clone for track-changes — separate follow-up)
- Pin integrity verified: 323/324 source HEADs exactly match lockfile refs (exception: track-changes, whose bootstrap order bypasses the lock — pre-existing Discovery 3 behavior, identical under full clones)
- `ci-sync` + `ci-test`: `ZETTA-OK packages=332 modules=280`, zero failures; daemon test green

## Tradeoff

Historical git operations inside `elpaca/sources/` (blame, `log -p`, checking out unrelated old refs) lazy-fetch from the remote and need network. Builds, pulls, `zetta freeze`, and normal offline use are unaffected. Drop the advice once upstream honors treeless/blobless alongside `:ref`.

Note: PR CI runs warm (prefix-restored caches), so the treeless path shows on the next cold rehearsal/dispatch rather than in this PR's run. Merge before the prebuilt-artifacts PR — artifact size depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVwQJcUBQYdtq5w1s23dh5