### PR TITLE
feat: prebuilt package stores — CI-published, lock-bound, auto-consumed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,21 @@
 name: CI
 
 on:
-  # CI runs on PRs only.  The merge commit on main is byte-for-byte
-  # identical to the PR's last-tested commit, so re-testing on push to
-  # main catches nothing new -- but doubles CI usage per merge, and
-  # quadruples it across a feature-PR -> release-PR cycle.  Branch
-  # protection requires PR review, so direct pushes to main are not a
-  # supported flow.  release-please still fires on push to main via
-  # release.yml; that workflow is unaffected.
+  # The TEST matrix runs on PRs only.  The merge commit on main is
+  # byte-for-byte identical to the PR's last-tested commit, so
+  # re-TESTING on push to main catches nothing new -- but doubles CI
+  # usage per merge, and quadruples it across a feature-PR ->
+  # release-PR cycle.  Branch protection requires PR review, so direct
+  # pushes to main are not a supported flow.  release-please still
+  # fires on push to main via release.yml; that workflow is unaffected.
+  #
+  # Push to main triggers ONLY the `package` job below: it produces
+  # something a PR run cannot (prebuilt store artifacts bound to the
+  # merged lockfile, plus fresh main-scope caches), reconciling and
+  # re-validating warm rather than re-testing cold.
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
   # Weekly cold-install rehearsal.  Warm-cache PR runs only prove the
   # config loads against already-built packages; the install path itself
@@ -39,6 +46,8 @@ env:
 
 jobs:
   test:
+    # Push-to-main runs the package job instead (see trigger comment).
+    if: github.event_name != 'push'
     runs-on: ${{ matrix.os }}
     # A fully cold elpaca build measured ~25 minutes at the old
     # 1508298 pin; the 7484867 elpaca's event system costs 2-3x main-
@@ -122,3 +131,104 @@ jobs:
         with:
           path: elpaca
           key: elpaca-v3-${{ matrix.emacs-version }}-${{ hashFiles('early-init.el', 'init.el', 'source/**', 'modules/**', 'elpaca-lock.el') }}
+
+  package:
+    # Publish prebuilt package stores so fresh installs can skip the
+    # source build (~105 min on CI-class hardware, ~1h on modest user
+    # machines -> minutes; see README "Prebuilt installs").  Runs on
+    # push to main INSTEAD of the test matrix (see trigger comment).
+    #
+    # The store is never published untested: the job reconciles the
+    # restored main-scope cache to the merged commit with ci-sync,
+    # validates with ci-test, saves the refreshed cache, and only then
+    # packages.  The manifest binds each artifact to the sha256 of the
+    # exact elpaca-lock.el it was built from -- bin/zetta install
+    # compares that against the local lock and falls back to a source
+    # build on any mismatch, so a stale or missing artifact can never
+    # produce a wrong install, only a slower one.
+    #
+    # Side benefit: main-scope caches now refresh on every merge
+    # instead of only at the weekly rehearsal.  Worst case (no
+    # restorable cache, e.g. right after a cache-epoch bump) this is a
+    # full cold build -- the ceiling matches the test job's.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version:
+          - 29.4
+          - 30.2
+          - snapshot  # Emacs 31 (pre-release)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Emacs
+        uses: jcs090218/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+
+      - name: Restore elpaca cache
+        id: cache-elpaca
+        uses: actions/cache/restore@v4
+        with:
+          path: elpaca
+          key: elpaca-v3-${{ matrix.emacs-version }}-${{ hashFiles('early-init.el', 'init.el', 'source/**', 'modules/**', 'elpaca-lock.el') }}
+          restore-keys: |
+            elpaca-v3-${{ matrix.emacs-version }}-
+
+      - name: Create stub files
+        run: |
+          touch ~/.dir-locals.el
+          echo ";;" > ~/.private.el
+          cp templates/zetta.example.el ~/.zetta.el
+
+      - name: Sync missing packages
+        if: steps.cache-elpaca.outputs.cache-hit != 'true'
+        shell: bash
+        run: bin/zetta ci-sync
+
+      - name: Run CI test
+        shell: bash
+        run: bin/zetta ci-test
+
+      - name: Save elpaca cache
+        if: success() && steps.cache-elpaca.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: elpaca
+          key: elpaca-v3-${{ matrix.emacs-version }}-${{ hashFiles('early-init.el', 'init.el', 'source/**', 'modules/**', 'elpaca-lock.el') }}
+
+      - name: Package prebuilt store
+        shell: bash
+        run: |
+          set -euo pipefail
+          MM=$(emacs -Q --batch --eval '(princ (format "%s.%s" emacs-major-version emacs-minor-version))')
+          FULL=$(emacs -Q --batch --eval '(princ emacs-version)')
+          LOCK_SHA=$(sha256sum elpaca-lock.el | cut -d' ' -f1)
+          # Menu caches regenerate cheaply and may embed absolute
+          # paths: drop them.  Build dirs symlink into sources/ with
+          # ABSOLUTE targets, so tar dereferences (-h) to materialize
+          # portable copies.
+          rm -rf elpaca/cache
+          printf '{"emacs": "%s", "emacs_mm": "%s", "matrix": "%s", "lock_sha256": "%s", "commit": "%s", "created": "%s"}\n' \
+            "$FULL" "$MM" "${{ matrix.emacs-version }}" "$LOCK_SHA" "${{ github.sha }}" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > elpaca-manifest.json
+          tar --zstd -chf "zetta-elpaca-$MM.tar.zst" elpaca-manifest.json elpaca
+          ls -lh "zetta-elpaca-$MM.tar.zst"
+
+      - name: Upload to rolling prebuilt release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          MM=$(emacs -Q --batch --eval '(princ (format "%s.%s" emacs-major-version emacs-minor-version))')
+          gh release view prebuilt >/dev/null 2>&1 || \
+            gh release create prebuilt --prerelease --title "Prebuilt package stores (rolling)" \
+              --notes "Rolling prebuilt elpaca stores, refreshed on every merge to main.  Consumed automatically by bin/zetta install; each artifact's manifest binds it to the exact elpaca-lock.el it was built from, and installs fall back to a source build on any mismatch."
+          gh release upload prebuilt "zetta-elpaca-$MM.tar.zst" --clobber

--- a/README.md
+++ b/README.md
@@ -45,8 +45,35 @@ The install command will:
    installer. Reinstalling over an existing checkout is safe because of
    this step; if you ever roll back package state by restoring an
    `elpaca.pre-*.bak` snapshot, purge `eln-cache/` the same way.
-3. Install and byte-compile all packages via Elpaca
+3. Seed the package store from a prebuilt artifact when one matches
+   (see below) — otherwise install and byte-compile all packages via
+   Elpaca
 4. Native-compile everything (a few minutes)
+
+### Prebuilt package stores
+
+CI publishes a prebuilt, pre-verified elpaca store (byte-compiled
+builds plus treeless source clones) for each supported Emacs version
+on every merge to main, and `bin/zetta install` uses one automatically
+on fresh installs — turning the ~1 hour build-everything-from-source
+step into a few minutes of download.
+
+Safety model: each artifact's manifest records the sha256 of the exact
+`elpaca-lock.el` it was built from and the Emacs major.minor that
+byte-compiled it (`.elc` is portable across operating systems, but not
+across Emacs versions). Any mismatch — Emacs version, lockfile,
+download, extraction — silently falls back to the normal source build,
+so a stale artifact can only ever make an install slower, never wrong.
+Native-compiled `.eln` is never shipped; your Emacs regenerates it
+locally in the background.
+
+The seeded store contains real (treeless) git clones, so
+`elpaca-pull-all`, `zetta update`, and hacking on packages in place
+all work exactly as with a source install. Treeless means historical
+git operations inside `elpaca/sources/` (blame, `log -p`, checking out
+old refs) fetch from the network on demand.
+
+Opt out with `ZETTA_NO_PREBUILT=1 bin/zetta install`.
 
 ### With chemacs2
 

--- a/bin/zetta
+++ b/bin/zetta
@@ -33,6 +33,59 @@ _info()  { echo -e "${CYAN}::${NC} $*"; }
 _ok()    { echo -e "${GREEN}✓${NC} $*"; }
 _warn()  { echo -e "${YELLOW}!${NC} $*"; }
 _error() { echo -e "${RED}✗${NC} $*"; }
+_sha256() {
+    if command -v sha256sum &>/dev/null; then sha256sum "$1" | cut -d' ' -f1
+    else shasum -a 256 "$1" | cut -d' ' -f1; fi
+}
+
+# ——————————————————————————————————————————
+# prebuilt store
+# ——————————————————————————————————————————
+
+# CI publishes prebuilt elpaca stores (builds + treeless sources) to a
+# rolling GitHub release on every merge to main; seeding from one lets
+# a fresh install skip the package-build phase entirely (~1h on modest
+# hardware -> minutes).  Safety model: the artifact's manifest carries
+# the sha256 of the elpaca-lock.el it was built from and the Emacs
+# major.minor that byte-compiled it (.elc is portable across OSes but
+# NOT across Emacs versions); ANY mismatch -- version, lock, download,
+# extraction -- falls back to the normal source build, so a stale or
+# missing artifact can only make an install slower, never wrong.
+# Native-compiled .eln is never shipped: Emacs regenerates it locally
+# in the background.  Opt out with ZETTA_NO_PREBUILT=1; point
+# ZETTA_PREBUILT_URL at an alternate base URL (or file:// path) for
+# testing.
+PREBUILT_BASE="${ZETTA_PREBUILT_URL:-https://github.com/chiply/.zetta.d/releases/download/prebuilt}"
+
+try_prebuilt() {
+    [[ "${ZETTA_NO_PREBUILT:-}" == "1" ]] && return 1
+    # Fresh installs only: an existing store belongs to elpaca.
+    [[ -d "$ZETTA_DIR/elpaca/builds" ]] && return 1
+    local mm
+    mm=$("$EMACS" -Q --batch --eval '(princ (format "%s.%s" emacs-major-version emacs-minor-version))' 2>/dev/null) || return 1
+    local url="$PREBUILT_BASE/zetta-elpaca-${mm}.tar.zst"
+    local tmpdir
+    tmpdir=$(mktemp -d) || return 1
+    _info "Trying prebuilt store for Emacs ${mm}..."
+    if ! curl -fL --retry 2 --progress-bar -o "$tmpdir/store.tar.zst" "$url"; then
+        _info "No prebuilt store for Emacs $mm (building from source)"
+        rm -rf "$tmpdir"; return 1
+    fi
+    if ! tar -xf "$tmpdir/store.tar.zst" -C "$tmpdir"; then
+        _warn "Prebuilt store: extraction failed (tar with zstd support required); building from source"
+        rm -rf "$tmpdir"; return 1
+    fi
+    local lock_sha manifest_sha
+    lock_sha=$(_sha256 "$LOCK_FILE")
+    manifest_sha=$(grep -o '"lock_sha256": *"[a-f0-9]\{64\}"' "$tmpdir/elpaca-manifest.json" 2>/dev/null | grep -o '[a-f0-9]\{64\}')
+    if [[ -z "$manifest_sha" || "$manifest_sha" != "$lock_sha" ]]; then
+        _warn "Prebuilt store does not match elpaca-lock.el (stale artifact); building from source"
+        rm -rf "$tmpdir"; return 1
+    fi
+    mv "$tmpdir/elpaca" "$ZETTA_DIR/elpaca"
+    rm -rf "$tmpdir"
+    _ok "Prebuilt store installed (package builds will be skipped)"
+}
 
 # ——————————————————————————————————————————
 # install
@@ -67,6 +120,10 @@ cmd_install() {
     _info "Purging stale compiled artifacts (eln-cache, module/bootstrap .elc)..."
     rm -rf "$ZETTA_DIR/eln-cache"
     find "$ZETTA_DIR/modules" "$ZETTA_DIR/source" -name '*.elc' -delete 2>/dev/null || true
+
+    # Seed from a prebuilt store when possible (fresh installs only;
+    # every mismatch falls back to the source build below).
+    try_prebuilt || true
 
     _info "Starting Emacs to install and build packages..."
     "$EMACS" --init-directory="$ZETTA_DIR" --batch \
@@ -701,8 +758,10 @@ cmd_help() {
     echo "  help             Show this help message"
     echo ""
     echo "Environment:"
-    echo "  EMACS            Path to Emacs binary (default: emacs)"
-    echo "  ZETTA_DIR        Path to Zetta config (default: auto-detected)"
+    echo "  EMACS              Path to Emacs binary (default: emacs)"
+    echo "  ZETTA_DIR          Path to Zetta config (default: auto-detected)"
+    echo "  ZETTA_NO_PREBUILT  Set to 1 to skip the prebuilt store and build from source"
+    echo "  ZETTA_PREBUILT_URL Alternate base URL for prebuilt stores (testing)"
 }
 
 # ——————————————————————————————————————————


### PR DESCRIPTION
Fresh installs currently build ~330 packages from source (~1 hour on modest hardware after the elpaca upgrade). This publishes prebuilt, pre-verified package stores from CI and teaches `bin/zetta install` to consume them — cutting a fresh install to ~5–12 minutes of mostly download.

## Pipeline

New `package` job runs on **push to main** (the test matrix stays PR-only; packaging produces what a PR run cannot — artifacts bound to the merged lockfile, plus fresh main-scope caches). Per Emacs version it: restores the verified cache → reconciles with `ci-sync` → validates with `ci-test` → saves the refreshed cache → prunes `elpaca/cache` (regenerates; may embed absolute paths) → writes a manifest (lock sha256, Emacs version, commit) → `tar --zstd -ch` (dereferences the absolute build→source symlinks) → uploads `zetta-elpaca-<major.minor>.tar.zst` to a rolling `prebuilt` pre-release.

## Consumer

`bin/zetta install` seeds fresh installs from a matching artifact. Safety model: the manifest's lock sha256 must equal the local `elpaca-lock.el` hash and the Emacs major.minor must match (`.elc` is OS-portable but not version-portable); **any** mismatch — version, lock, download, extraction — falls back to the normal source build, so a stale artifact can only ever make an install slower, never wrong. `.eln` is never shipped (Emacs regenerates it locally, async). Opt out: `ZETTA_NO_PREBUILT=1`; override base URL for testing: `ZETTA_PREBUILT_URL`.

Artifacts include treeless source clones, so `elpaca-pull-all` / `zetta update` / hacking on packages in place all keep working — the prebuilt is purely a warm start.

## Validated locally (full roundtrip)

- Packaged the validated treeless store CI-style: **729M artifact in 47s**
- Seeded a pristine worktree from it via `ZETTA_PREBUILT_URL`: manifest verified, store installed, `ci-test` → `ZETTA-OK packages=332 modules=280`
- Stale-lock artifact: clean fallback, no partial state
- Bonus catch: macOS `/bin/bash` 3.2 parses `$var` followed by a non-ASCII char as one variable name — braced

## The canary is untouched

Scheduled/dispatched cold rehearsals still build everything from source. Prebuilts are a downstream snapshot of the verified caches — never a replacement for the fresh-install canary.

Merge after #123 (artifact size depends on treeless sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVwQJcUBQYdtq5w1s23dh5
