### PR TITLE
ci: Emacs 31 release branch replaces snapshot; no cache saves from PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,10 @@ jobs:
         emacs-version:
           - 29.4
           - 30.2
-          - snapshot  # Emacs 31 (pre-release)
+          # Master (emacs-snapshot) proved too unstable to gate on and
+          # its artifacts (Emacs 32.x) matched no real users; the release
+          # branch tracks the latest Emacs 31 pretest instead.
+          - release-snapshot  # Emacs 31 (release branch)
 
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +132,15 @@ jobs:
         # from a verified-clean fresh install.  Skipped on exact cache
         # hits (nothing new to save); if the key already exists from a
         # concurrent job, the save is a no-op warning.
-        if: success() && steps.cache-elpaca.outputs.cache-hit != 'true'
+        # NEVER saved from pull_request runs: branch-scoped PR caches
+        # (~775MB x 3 versions per key-changing PR) are dead weight
+        # after merge but count against the repo's 10GB quota, and a
+        # burst of PRs evicts the MAIN-scope caches (measured: the
+        # first package run went full cold, 30123672876).  PRs restore
+        # main's caches via the prefix key, and the package job
+        # refreshes main-scope on every merge, so PR-side saves buy
+        # nothing but quota pressure.
+        if: success() && steps.cache-elpaca.outputs.cache-hit != 'true' && github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           path: elpaca
@@ -168,7 +179,10 @@ jobs:
         emacs-version:
           - 29.4
           - 30.2
-          - snapshot  # Emacs 31 (pre-release)
+          # Master (emacs-snapshot) proved too unstable to gate on and
+          # its artifacts (Emacs 32.x) matched no real users; the release
+          # branch tracks the latest Emacs 31 pretest instead.
+          - release-snapshot  # Emacs 31 (release branch)
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Two changes per review of CI stability and cache-quota math:

1. **Matrix: `snapshot` → `release-snapshot`** (both jobs). Master is too unstable to gate on, and its prebuilt artifacts (Emacs 32.x) matched no real users. nix-emacs-ci's `emacs-release-snapshot` tracks the latest Emacs 31 pretest (31.0.91 today) — the third artifact becomes `zetta-elpaca-31.0.tar.zst`, matching actual Emacs 31 users.
2. **Cache saves: never from `pull_request` runs.** Branch-scoped PR caches (~775MB × 3 per key-changing PR) are post-merge dead weight against the 10GB quota; a burst of PRs evicted the main-scope caches and sent the first package run full cold. PRs restore main's caches via the prefix key, and the package job refreshes main-scope on every merge — steady-state cache use becomes just ~775MB × versions (headroom for ~12 versions).

One-time cost: the release-snapshot store builds cold twice (this PR's CI + the post-merge package job, since PR runs no longer save), each under the 150-minute ceiling. After the 31 artifact publishes, the stale snapshot(32) caches and the `zetta-elpaca-32.0.tar.zst` asset get deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVwQJcUBQYdtq5w1s23dh5