### PR TITLE
fix: batch-clean init — gate reader from batch; fix zettapkg load-path ordering

### DIFF
--- a/modules/app/reader.el
+++ b/modules/app/reader.el
@@ -7,7 +7,19 @@
 ;; with (file-missing "render-core") -- which is exactly how the 29.4 CI job
 ;; failed its serious-errors check (run 29946929141) after an otherwise
 ;; clean cold build.
-(when (eq system-type 'darwin)
+;;
+;; ...and interactive-only by construction: in batch the declaration only
+;; queues a build that nothing can use, and it broke `zetta install' twice
+;; over (measured 2026-07-25, first prebuilt-seeded install): the package's
+;; `make' runs in elpaca's non-login subprocess env where it produced no
+;; dylib, and reader's build/activation machinery raced batch teardown --
+;; an "error in process sentinel: Cannot open load file: render-core"
+;; during exit turned the whole batch run into exit 255, aborting install
+;; phases 2-3.  Slow source builds never hit the window; a 2-minute seeded
+;; install reaches teardown while the reader subprocess chain is still in
+;; flight.  Interactive startups build it on first launch in the user's
+;; real login env, where the same `make' works.
+(when (and (eq system-type 'darwin) (not noninteractive))
   (use-package reader
     :ensure (:host codeberg :repo "MonadicSheep/emacs-reader"
              :files ("*.el" "render-core.dylib")

--- a/modules/completion/embark-scope.el
+++ b/modules/completion/embark-scope.el
@@ -10,9 +10,19 @@
 ;;   from `treesit-tap-embark-types' if treesit-tap-embark is loaded).
 ;; - Optional: enables `embark-scope-target-word-at-point' as a finder.
 
+;; Both zettapkg paths, not just embark-scope's own: the PACKAGE
+;; (require 'treesit-tap)s at top level, but treesit-tap's load-path
+;; entry lives in its wrapper module `treesit-tap.el', which loads
+;; AFTER this one (alphabetical within the category).  Whenever embark
+;; is already resident during module loading -- every batch run -- the
+;; :after fires immediately and embark-scope loaded before the path
+;; existed: "Cannot open load file: treesit-tap", cascading into
+;; batch byte-compile failures for every org/term module that touches
+;; `embark-scope-nav-type-map'.  Declaring both paths here removes the
+;; ordering dependency outright.
 (use-package embark-scope
   :ensure nil
-  :load-path "source/zettapkg/embark-scope"
+  :load-path ("source/zettapkg/embark-scope" "source/zettapkg/treesit-tap")
   :after embark
   :config
   ;; Enable the suite (capture-mode + sort + back-cycle + bindings +


### PR DESCRIPTION
The first prebuilt-seeded install (6½ minutes end to end) exposed two latent batch-only defects — one aborted the install, the other has been producing the "known-benign" embark-scope/treesit-tap error cascade in every batch run on record.

## reader: interactive-only now (was darwin-only)

In batch, the declaration only queues a build nothing can use; its `make` runs in elpaca's non-login subprocess env where it produced no dylib, and the build/activation machinery raced batch teardown — an `error in process sentinel: Cannot open load file: render-core` during exit turned phase 1 into exit 255, aborting `zetta install` before the byte-compile/native phases. Slow source builds never hit the window; a 2-minute seeded install reaches teardown while the reader chain is still in flight. First interactive launch builds it in the real login env, where the same `make` demonstrably works.

## embark-scope wrapper: declare both zettapkg load-paths

The embark-scope *package* `(require 'treesit-tap)`s at top level, but treesit-tap's load-path entry was registered by its own wrapper module — which loads after embark-scope's (alphabetical within the category). Whenever embark is already resident during module loading (every batch run), `:after` fires immediately and the require fails: `Cannot open load file: treesit-tap`, cascading into batch byte-compile failures for every org/term module touching `embark-scope-nav-type-map` (17 modules in the install log). Declaring both paths in the embark-scope wrapper removes the ordering dependency outright.

## Validation (live darwin machine)

Batch `init.el` load + `elpaca-wait`: **exit 0** — the first clean batch exit on record for this config — with **zero** compile-angel errors (previously 17) and no sentinel errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVwQJcUBQYdtq5w1s23dh5