### PR TITLE
kb era: capture pipelines, retargets, and logseq retirement

### DIFF
--- a/modules/app/eww.el
+++ b/modules/app/eww.el
@@ -83,14 +83,53 @@
     (apply orig args))
   (advice-add 'eww-display-pdf :around #'zetta-eww--remember-pdf-url)
 
+  (defun zetta-eww--link-text-at-point ()
+    "Text of the shr link at point, when it looks like a real title."
+    (when (get-text-property (point) 'shr-url)
+      (let* ((start (or (previous-single-property-change (1+ (point)) 'shr-url)
+                        (point-min)))
+             (end (or (next-single-property-change (point) 'shr-url)
+                      (point-max)))
+             (text (string-trim (buffer-substring-no-properties start end))))
+        ;; skip generic link labels like "PDF", "[pdf]", "Download"
+        (when (and (> (length text) 7)
+                   (not (string-match-p "\\`\\[?\\(pdf\\|download\\|link\\|here\\)"
+                                        (downcase text))))
+          text))))
+
+  (defun zetta-kb--pdf-title (file)
+    "FILE's PDF metadata title, when present and plausible."
+    (when (fboundp 'pdf-info-metadata)
+      (let ((title (ignore-errors (cdr (assq 'title (pdf-info-metadata file))))))
+        (when (and title
+                   (> (length title) 3)
+                   (not (string-match-p "\\`[0-9v. -]+\\'" title)))
+          title))))
+
+  (defun zetta-kb--sanitize-file-name (name)
+    "Collapse whitespace and strip filesystem-hostile chars from NAME.
+Quotes vanish; path separators and friends become dashes; no leading
+or trailing dash debris."
+    (string-trim
+     (replace-regexp-in-string
+      "\\` *- *\\| *- *\\'" ""
+      (replace-regexp-in-string
+       "[/\\:*?<>|]+" "-"
+       (replace-regexp-in-string
+        "[\"']+" ""
+        (replace-regexp-in-string "[ \t\n]+" " " name))))))
+
   (defun zetta-eww-save-pdf-to-kb (&optional url)
     "Download the PDF at point or URL into `zetta-kb-pdf-directory'.
-Uses the link at point, else the current page's URL, else prompts.
-Files land in ~/kb/pdfs/<domain>/<name>.pdf; a missing .pdf suffix is
-added (arxiv-style URLs), and an existing file is overwritten so
-re-downloading the same URL is idempotent."
+Grabs the link at point, else the current page's URL, else the URL of
+the PDF shown in the *eww pdf* buffer, else prompts.  The filename is
+imputed from the PDF's metadata title when present, else the link text
+at point, else the URL basename — always confirmed via minibuffer, so
+RET accepts and editing fixes garbage metadata.  Files land in
+~/kb/pdf/<domain>/."
     (interactive)
-    (let* ((url (or url
+    (let* ((link-text (zetta-eww--link-text-at-point))
+           (url (or url
                     (get-text-property (point) 'shr-url)
                     (and (derived-mode-p 'eww-mode) (eww-current-url))
                     (and (derived-mode-p 'pdf-view-mode 'doc-view-mode)
@@ -98,20 +137,24 @@ re-downloading the same URL is idempotent."
                     (read-string "PDF URL: ")))
            (parsed (url-generic-parse-url url))
            (host (or (url-host parsed) "unknown"))
-           (path (car (url-path-and-query parsed)))
-           (name (url-unhex-string (file-name-nondirectory
-                                    (directory-file-name (or path "")))))
-           (name (if (string-empty-p name) "document" name))
-           (name (if (string-suffix-p ".pdf" (downcase name))
-                     name
-                   (concat name ".pdf")))
-           (dir (file-name-as-directory
-                 (expand-file-name host zetta-kb-pdf-directory)))
-           (target (expand-file-name name dir)))
-      (make-directory dir t)
-      (url-copy-file url target t)
-      (message "kb pdf: %s" (abbreviate-file-name target))
-      target))
+           (base (url-unhex-string (file-name-nondirectory
+                                    (directory-file-name
+                                     (or (car (url-path-and-query parsed)) "")))))
+           (base (file-name-sans-extension
+                  (if (string-empty-p base) "document" base)))
+           (tmp (make-temp-file "kb-pdf-" nil ".pdf")))
+      (url-copy-file url tmp t)
+      (let* ((title (or (zetta-kb--pdf-title tmp) link-text base))
+             (name (read-string "kb pdf name: "
+                                (concat (zetta-kb--sanitize-file-name title)
+                                        ".pdf")))
+             (dir (file-name-as-directory
+                   (expand-file-name host zetta-kb-pdf-directory)))
+             (target (expand-file-name name dir)))
+        (make-directory dir t)
+        (rename-file tmp target t)
+        (message "kb pdf: %s" (abbreviate-file-name target))
+        target)))
 
   :general
   (

--- a/modules/app/eww.el
+++ b/modules/app/eww.el
@@ -66,8 +66,8 @@
   ;; PDFs land in the synced kb tree, per-domain like org-remark notes;
   ;; they sync everywhere and are annotatable on iOS in Preview via
   ;; Files -> Synctrain.
-  (defvar zetta-kb-pdf-directory (expand-file-name "~/kb/pdfs/")
-    "Root for PDFs saved into the synced kb tree.")
+  (defvar zetta-kb-pdf-directory (expand-file-name "~/kb/pdf/")
+    "Root for PDFs saved into the synced kb tree (existing kb layout).")
 
   ;; eww renders PDFs into a separate "*eww pdf*" pdf-view buffer that is
   ;; not eww-mode and knows nothing of its URL.  Stash the URL on the way

--- a/modules/app/eww.el
+++ b/modules/app/eww.el
@@ -63,12 +63,47 @@
     (interactive)
     (browse-url (thing-at-point 'url)))
 
+  ;; PDFs land in the synced kb tree, per-domain like org-remark notes;
+  ;; they sync everywhere and are annotatable on iOS in Preview via
+  ;; Files -> Synctrain.
+  (defvar zetta-kb-pdf-directory (expand-file-name "~/kb/pdfs/")
+    "Root for PDFs saved into the synced kb tree.")
+
+  (defun zetta-eww-save-pdf-to-kb (&optional url)
+    "Download the PDF at point or URL into `zetta-kb-pdf-directory'.
+Uses the link at point, else the current page's URL, else prompts.
+Files land in ~/kb/pdfs/<domain>/<name>.pdf; a missing .pdf suffix is
+added (arxiv-style URLs), and an existing file is overwritten so
+re-downloading the same URL is idempotent."
+    (interactive)
+    (let* ((url (or url
+                    (get-text-property (point) 'shr-url)
+                    (and (derived-mode-p 'eww-mode) (eww-current-url))
+                    (read-string "PDF URL: ")))
+           (parsed (url-generic-parse-url url))
+           (host (or (url-host parsed) "unknown"))
+           (path (car (url-path-and-query parsed)))
+           (name (url-unhex-string (file-name-nondirectory
+                                    (directory-file-name (or path "")))))
+           (name (if (string-empty-p name) "document" name))
+           (name (if (string-suffix-p ".pdf" (downcase name))
+                     name
+                   (concat name ".pdf")))
+           (dir (file-name-as-directory
+                 (expand-file-name host zetta-kb-pdf-directory)))
+           (target (expand-file-name name dir)))
+      (make-directory dir t)
+      (url-copy-file url target t)
+      (message "kb pdf: %s" (abbreviate-file-name target))
+      target))
+
   :general
   (
    :keymaps '(eww-mode-map)
    :states '(normal)
    "C-&" 'zetta-eww-switch-to-eaf
    "<return>" 'zetta-eww-follow-link
+   "D" 'zetta-eww-save-pdf-to-kb
    "x" '(lambda () (interactive) (kill-buffer (current-buffer)))
    "s-i" 'eww-toggle-images
    "s-j" 'treesit-tap-next

--- a/modules/app/eww.el
+++ b/modules/app/eww.el
@@ -156,6 +156,52 @@ RET accepts and editing fixes garbage metadata.  Files land in
         (message "kb pdf: %s" (abbreviate-file-name target))
         target)))
 
+  ;; Images: same idea as PDFs — point at it, one key, lands in kb.
+  (defvar zetta-kb-image-directory (expand-file-name "~/kb/images/")
+    "Root for images saved into the synced kb tree.")
+
+  (defun zetta-eww--wikimedia-fullsize (url)
+    "Upgrade a wikimedia thumbnail URL to its full-size original."
+    (if (and (string-match-p "upload\\.wikimedia\\.org" url)
+             (string-match "\\`\\(.*\\)/thumb/\\(.*\\)/[0-9]+px-[^/]*\\'" url))
+        (concat (match-string 1 url) "/" (match-string 2 url))
+      url))
+
+  (defun zetta-eww-save-image-to-kb ()
+    "Save the image at point into `zetta-kb-image-directory'.
+Files land in images/<page-domain>/ (the page you are reading, not the
+CDN host serving the image); wikimedia thumbnails are upgraded to the
+full-size original.  The name is confirmed via minibuffer."
+    (interactive)
+    (let* ((img-url (or (get-text-property (point) 'image-url)
+                        (user-error "No image at point")))
+           (img-url (zetta-eww--wikimedia-fullsize img-url))
+           (page-host (or (and (derived-mode-p 'eww-mode)
+                               (url-host (url-generic-parse-url
+                                          (eww-current-url))))
+                          (url-host (url-generic-parse-url img-url))
+                          "unknown"))
+           (base (url-unhex-string
+                  (file-name-nondirectory
+                   (or (car (url-path-and-query
+                             (url-generic-parse-url img-url)))
+                       ""))))
+           (base (if (string-empty-p base) "image" base))
+           (name (read-string "kb image name: "
+                              (zetta-kb--sanitize-file-name base)))
+           (dir (file-name-as-directory
+                 (expand-file-name page-host zetta-kb-image-directory)))
+           (target (expand-file-name name dir)))
+      (make-directory dir t)
+      (url-copy-file img-url target t)
+      (message "kb image: %s" (abbreviate-file-name target))
+      target))
+
+  ;; Images carry shr-image-map as a text property, which outranks evil
+  ;; state maps — bind there too so I works with point ON the image.
+  (with-eval-after-load 'shr
+    (define-key shr-image-map "I" 'zetta-eww-save-image-to-kb))
+
   :general
   (
    :keymaps '(eww-mode-map)
@@ -163,6 +209,7 @@ RET accepts and editing fixes garbage metadata.  Files land in
    "C-&" 'zetta-eww-switch-to-eaf
    "<return>" 'zetta-eww-follow-link
    "D" 'zetta-eww-save-pdf-to-kb
+   "I" 'zetta-eww-save-image-to-kb
    "x" '(lambda () (interactive) (kill-buffer (current-buffer)))
    "s-i" 'eww-toggle-images
    "s-j" 'treesit-tap-next

--- a/modules/app/eww.el
+++ b/modules/app/eww.el
@@ -69,6 +69,20 @@
   (defvar zetta-kb-pdf-directory (expand-file-name "~/kb/pdfs/")
     "Root for PDFs saved into the synced kb tree.")
 
+  ;; eww renders PDFs into a separate "*eww pdf*" pdf-view buffer that is
+  ;; not eww-mode and knows nothing of its URL.  Stash the URL on the way
+  ;; through: when `eww-display-pdf' is called, the current buffer is the
+  ;; url retrieval buffer, which carries `url-current-object'.
+  (defvar zetta-eww--pdf-url nil
+    "URL of the PDF most recently displayed by eww.")
+
+  (defun zetta-eww--remember-pdf-url (orig &rest args)
+    "Record the PDF's URL before eww hands it to pdf-view."
+    (when (bound-and-true-p url-current-object)
+      (setq zetta-eww--pdf-url (url-recreate-url url-current-object)))
+    (apply orig args))
+  (advice-add 'eww-display-pdf :around #'zetta-eww--remember-pdf-url)
+
   (defun zetta-eww-save-pdf-to-kb (&optional url)
     "Download the PDF at point or URL into `zetta-kb-pdf-directory'.
 Uses the link at point, else the current page's URL, else prompts.
@@ -79,6 +93,8 @@ re-downloading the same URL is idempotent."
     (let* ((url (or url
                     (get-text-property (point) 'shr-url)
                     (and (derived-mode-p 'eww-mode) (eww-current-url))
+                    (and (derived-mode-p 'pdf-view-mode 'doc-view-mode)
+                         zetta-eww--pdf-url)
                     (read-string "PDF URL: ")))
            (parsed (url-generic-parse-url url))
            (host (or (url-host parsed) "unknown"))
@@ -108,6 +124,11 @@ re-downloading the same URL is idempotent."
    "s-i" 'eww-toggle-images
    "s-j" 'treesit-tap-next
    "s-k" 'treesit-tap-prev
+   )
+  (
+   :keymaps 'pdf-view-mode-map
+   :states '(normal)
+   "D" 'zetta-eww-save-pdf-to-kb
    )
   (
    :keymaps 'menu-lookup-map

--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -208,6 +208,19 @@ otherwise appear as a bogus `zsh#...' completion candidate."
   (advice-add 'hywiki-maybe-highlight-wikiwords-in-frame :around
               #'zetta-hywiki-debounce-frame-rehighlight)
 
+  ;; The buffer-(de)highlight paths force a redisplay per buffer the same
+  ;; way (sit-for 0, "display before font-locking") -- a flash on buffer
+  ;; switches/opens and referent-table updates.  Same cure: run them with
+  ;; sit-for neutralized; normal redisplay paints the results anyway.
+  (defun zetta-hywiki-quiet-sit-for (orig &rest args)
+    "Run ORIG with `sit-for' neutralized to suppress forced redisplays."
+    (cl-letf (((symbol-function 'sit-for) #'ignore))
+      (apply orig args)))
+  (advice-add 'hywiki-word-highlight-in-buffers :around
+              #'zetta-hywiki-quiet-sit-for)
+  (advice-add 'hywiki-word-dehighlight-in-buffers :around
+              #'zetta-hywiki-quiet-sit-for)
+
   ;; Keep zsh's `no matches found' glob error out of HyWiki completion
   ;; candidates (see `zetta-hywiki-completion-posix-shell').
   (advice-add 'hywiki-completion-at-point :around

--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -279,7 +279,8 @@ otherwise appear as a bogus `zsh#...' completion candidate."
       (kbd "M-<return>") 'hkey-either))
 
   ;; --- HyRolo: search the Logseq pages as the rolo source ---
-  (setq hyrolo-file-list '("~/.rolo.org" "~/logseq/pages/"))
+  (setq hyrolo-file-list '("~/.rolo.org" "~/kb/notes/" "~/kb/wiki/"
+                           "~/kb/todo/" "~/kb/inbox.org"))
   ;; Make the consult-driven grep commands resolve their matched files
   ;; correctly (see `zetta-hyrolo-fix-consult-handoff' above).
   (advice-add 'hyrolo-grep-input :filter-return

--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -139,8 +139,14 @@ triggers (typing, directory mtime churn) into a single repaint."
              (lambda ()
                (setq zetta--hywiki-rehighlight-timer nil)
                (when zetta--hywiki-rehighlight-pending
-                 (apply (car zetta--hywiki-rehighlight-pending)
-                        (cdr zetta--hywiki-rehighlight-pending)))))))))
+                 ;; Upstream's pass forces a redisplay per window via
+                 ;; `sit-for 0' ("display buffer before font-locking") —
+                 ;; meaningless at idle in already-displayed windows, and
+                 ;; the source of the residual once-per-burst flash.
+                 ;; Neutralize it for this deferred invocation only.
+                 (cl-letf (((symbol-function 'sit-for) #'ignore))
+                   (apply (car zetta--hywiki-rehighlight-pending)
+                          (cdr zetta--hywiki-rehighlight-pending))))))))))
 
 ;; HyWiki completion offers a bogus `zsh#no matches found...' candidate.
 ;; `hywiki-completion-at-point' lists page candidates by globbing `./PREFIX*.org'

--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -108,27 +108,39 @@ open in a buffer, are untouched."
       (let ((title (file-name-sans-extension (file-name-nondirectory file))))
         (write-region (format "#+title: %s\n\n" title) nil file nil 0)))))
 
-;; HyWiki flashes the whole frame on every keystroke of a capital-letter word
-;; when `~/hywiki/' holds NO pages.  With an empty referent hash,
-;; `hywiki-get-referent-hasht' computes an empty `hywiki--any-wikiword-regexp-list'
-;; (nil `mapcar'), so its own `(unless ... regexp-list ...)' guard never latches
-;; and it re-highlights every window in the frame -- each via `sit-for 0' -- on
-;; every WikiWord lookup, which HyWiki performs per `post-self-insert' while you
-;; type a candidate WikiWord.  Each forced redisplay repaints the SVG tab/mode/
-;; header lines: a visible whole-frame flash on every keystroke.  With zero pages
-;; there is nothing to highlight, so skip the frame-wide re-highlight pass while
-;; the referent hash is empty.  (Upstream Hyperbole bug; guarded here.)
-(defun zetta-hywiki-skip-empty-rehighlight (orig &rest args)
-  "Skip HyWiki's frame-wide WikiWord re-highlight when there are no pages.
-Around advice for `hywiki-maybe-highlight-wikiwords-in-frame'.  When the HyWiki
-referent hash is empty there are no WikiWords to highlight, yet
-`hywiki-get-referent-hasht' still triggers the re-highlight (with `sit-for') on
-every lookup -- a whole-frame flash on each keystroke of a candidate WikiWord.
-Run ORIG only when the referent hash is non-empty."
+;; HyWiki's frame-wide WikiWord re-highlight walks every window with a
+;; `sit-for 0' redisplay each -- with SVG tab/mode/header lines that is a
+;; visible whole-frame flash plus cursor churn (`with-selected-window').
+;; It fires per `post-self-insert' lookup while typing capital-letter
+;; words, and on every `hywiki-directory' mtime change (lockfiles,
+;; autosaves, the .hywiki.eld cache, syncthing deliveries -- the wiki now
+;; lives in the synced ~/kb tree).  The original empty-hash skip
+;; (#98) only masked the zero-pages case; with real pages the pass ran
+;; raw again.  Debounce instead: coalesce every trigger into ONE pass,
+;; run after Emacs has been idle -- never mid-keystroke.  The empty-hash
+;; skip is preserved.  (Upstream Hyperbole issue; guarded here.)
+(defvar zetta--hywiki-rehighlight-pending nil
+  "Cons of (ORIG . ARGS) for the most recent coalesced re-highlight call.")
+(defvar zetta--hywiki-rehighlight-timer nil)
+(defun zetta-hywiki-debounce-frame-rehighlight (orig &rest args)
+  "Coalesce HyWiki frame-wide re-highlights into one idle-time pass.
+Around advice for `hywiki-maybe-highlight-wikiwords-in-frame'.  Skips
+entirely while the referent hash is empty (nothing to highlight);
+otherwise defers ORIG until 0.7s of idle time, collapsing bursts of
+triggers (typing, directory mtime churn) into a single repaint."
   (unless (and (boundp 'hywiki--referent-hasht)
                (hash-table-p hywiki--referent-hasht)
                (zerop (hash-table-count hywiki--referent-hasht)))
-    (apply orig args)))
+    (setq zetta--hywiki-rehighlight-pending (cons orig args))
+    (unless (timerp zetta--hywiki-rehighlight-timer)
+      (setq zetta--hywiki-rehighlight-timer
+            (run-with-idle-timer
+             0.7 nil
+             (lambda ()
+               (setq zetta--hywiki-rehighlight-timer nil)
+               (when zetta--hywiki-rehighlight-pending
+                 (apply (car zetta--hywiki-rehighlight-pending)
+                        (cdr zetta--hywiki-rehighlight-pending)))))))))
 
 ;; HyWiki completion offers a bogus `zsh#no matches found...' candidate.
 ;; `hywiki-completion-at-point' lists page candidates by globbing `./PREFIX*.org'
@@ -170,6 +182,7 @@ otherwise appear as a bogus `zsh#...' completion candidate."
   ;; where the generated chiply.dev WikiWord pages live.  Follow a WikiWord
   ;; with the Action Key {s-H} (relocated from {M-RET} below).
   ;;(require 'hywiki)
+  (setq hywiki-directory (expand-file-name "~/kb/wiki"))
   (hywiki-mode 1)
 
   (add-to-list 'brushup-styles
@@ -183,10 +196,11 @@ otherwise appear as a bogus `zsh#...' completion candidate."
   ;; disk have drifted apart (see `zetta-hywiki-ensure-page-file').
   (advice-add 'hywiki-display-page :before #'zetta-hywiki-ensure-page-file)
 
-  ;; Stop the whole-frame flash when typing WikiWords with an empty ~/hywiki/
-  ;; (see `zetta-hywiki-skip-empty-rehighlight').
+  ;; Debounce the whole-frame WikiWord re-highlight: one idle-time pass
+  ;; instead of a sit-for flash per trigger (see
+  ;; `zetta-hywiki-debounce-frame-rehighlight').
   (advice-add 'hywiki-maybe-highlight-wikiwords-in-frame :around
-              #'zetta-hywiki-skip-empty-rehighlight)
+              #'zetta-hywiki-debounce-frame-rehighlight)
 
   ;; Keep zsh's `no matches found' glob error out of HyWiki completion
   ;; candidates (see `zetta-hywiki-completion-posix-shell').

--- a/modules/app/hywiki-alias.el
+++ b/modules/app/hywiki-alias.el
@@ -602,8 +602,8 @@ visible buffers."
 ;; Enable automatically once HyWiki is available.  This file loads at startup,
 ;; before Hyperbole's deferred load, so the mode turns on as soon as HyWiki
 ;; provides.  Toggle it off any time with `M-x zetta-hywiki-alias-mode'.
-(with-eval-after-load 'hywiki
-  (zetta-hywiki-alias-mode 1))
+;;(with-eval-after-load 'hywiki
+  ;;(zetta-hywiki-alias-mode 1))
 
 (provide 'hywiki-alias)
 ;;; hywiki-alias.el ends here

--- a/modules/app/llm-convo.el
+++ b/modules/app/llm-convo.el
@@ -1,0 +1,22 @@
+;;; app/llm-convo.el --- ChatGPT conversations -> kb -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Mac-side entry to the llm-convo pipeline: converts a ChatGPT share
+;; link into ~/kb/llm-convo/<title>.org immediately by running the hub's
+;; converter script locally (it lives in the dotfiles repo, so this
+;; machine has it too).  The phone path is the share-sheet shortcut that
+;; appends to llm-convo/queue.txt, drained by the hub every 15 minutes.
+
+;;; Code:
+
+(defun zetta-kb-save-llm-convo (url)
+  "Convert the ChatGPT share URL into ~/kb/llm-convo/ right now."
+  (interactive (list (read-string "ChatGPT share URL: ")))
+  (async-shell-command
+   (format "python3 %s %s"
+           (shell-quote-argument
+            (expand-file-name "~/.files/hub/bin/llm_convo_sync.py"))
+           (shell-quote-argument url))
+   "*kb llm-convo*"))
+
+;;; app/llm-convo.el ends here

--- a/modules/app/yt-transcript.el
+++ b/modules/app/yt-transcript.el
@@ -1,0 +1,119 @@
+;;; app/yt-transcript.el --- YouTube transcripts -> kb -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; `zetta-kb-save-yt-transcript': prompt for a YouTube URL, fetch its
+;; transcript via yt-dlp (manual subtitles preferred, auto-captions as
+;; fallback), and write an Org file of timestamp-linked lines into
+;; ~/kb/yt-transcript/.  Returns the file path and takes the URL as a
+;; plain argument, so it composes for bulk imports:
+;;
+;;   (dolist (u my-url-list) (zetta-kb-save-yt-transcript u))
+;;
+;; The json3 caption format is parsed directly (rather than VTT) because
+;; auto-captions in VTT arrive as rolling duplicated windows; json3
+;; events are clean per-caption lines.
+
+;;; Code:
+
+(require 'cl-lib)
+(declare-function zetta-kb--sanitize-file-name "eww")
+
+(defvar zetta-kb-yt-transcript-directory
+  (expand-file-name "~/kb/yt-transcript/")
+  "Root for YouTube transcripts saved into the synced kb tree.")
+
+(defun zetta-kb--yt-video-json (url)
+  "Return yt-dlp's metadata for URL as an alist."
+  (unless (executable-find "yt-dlp")
+    (user-error "yt-dlp not found — brew install yt-dlp"))
+  (with-temp-buffer
+    (let ((status (call-process "yt-dlp" nil (list t nil) nil
+                                "--no-warnings" "--skip-download" "-J" url)))
+      (unless (eq status 0)
+        (user-error "yt-dlp failed (%s) for %s" status url)))
+    (goto-char (point-min))
+    (json-parse-buffer :object-type 'alist :array-type 'list)))
+
+(defun zetta-kb--yt-caption-url (meta)
+  "Return (JSON3-URL . KIND) for the best English track in META.
+Manual subtitles win over auto-captions."
+  (let ((pick (lambda (tracks kind)
+                (cl-loop for (lang . fmts) in tracks
+                         when (string-match-p "\\`en" (format "%s" lang))
+                         return (cl-loop for fmt in fmts
+                                         when (equal (alist-get 'ext fmt) "json3")
+                                         return (cons (alist-get 'url fmt) kind))))))
+    (or (funcall pick (alist-get 'subtitles meta) "subtitles")
+        (funcall pick (alist-get 'automatic_captions meta) "auto-captions")
+        (user-error "No English transcript available for this video"))))
+
+(defun zetta-kb--yt-transcript-lines (caption-url)
+  "Fetch CAPTION-URL (json3) and return a list of (SECONDS . TEXT)."
+  (with-current-buffer (url-retrieve-synchronously caption-url t t 30)
+    (goto-char (point-min))
+    (re-search-forward "\n\n" nil t)    ; past HTTP headers
+    (let* ((data (json-parse-buffer :object-type 'alist :array-type 'list))
+           (events (alist-get 'events data))
+           lines prev)
+      (kill-buffer)
+      (dolist (ev events)
+        (let ((text (string-trim
+                     (replace-regexp-in-string
+                      "[ \t\n]+" " "
+                      (mapconcat (lambda (s) (or (alist-get 'utf8 s) ""))
+                                 (alist-get 'segs ev) "")))))
+          (when (and (not (string-empty-p text))
+                     (not (equal text prev)))  ; auto-caption echo guard
+            (setq prev text)
+            (push (cons (/ (or (alist-get 'tStartMs ev) 0) 1000) text)
+                  lines))))
+      (nreverse lines))))
+
+(defun zetta-kb--yt-stamp (secs)
+  "SECS as M:SS or H:MM:SS."
+  (let ((h (/ secs 3600)) (m (/ (% secs 3600) 60)) (s (% secs 60)))
+    (if (> h 0) (format "%d:%02d:%02d" h m s) (format "%d:%02d" m s))))
+
+;;;###autoload
+(defun zetta-kb-save-yt-transcript (url)
+  "Fetch the transcript for the YouTube video at URL into kb.
+Writes ~/kb/yt-transcript/<title>.org — one line per caption, each
+timestamped with an org link that opens the video at that moment.
+Interactively, prompts for URL.  Returns the file path, so bulk
+imports are just a `dolist' over this function."
+  (interactive (list (read-string "YouTube URL: ")))
+  (let* ((meta (zetta-kb--yt-video-json url))
+         (id (alist-get 'id meta))
+         (title (or (alist-get 'title meta) id))
+         (channel (or (alist-get 'uploader meta) (alist-get 'channel meta)))
+         (canonical (format "https://youtu.be/%s" id))
+         (cap (zetta-kb--yt-caption-url meta))
+         (lines (zetta-kb--yt-transcript-lines (car cap)))
+         (dir (file-name-as-directory zetta-kb-yt-transcript-directory))
+         (target (expand-file-name
+                  (concat (zetta-kb--sanitize-file-name title) ".org") dir)))
+    ;; same title, different video -> disambiguate with the id
+    (when (and (file-exists-p target)
+               (not (with-temp-buffer
+                      (insert-file-contents target nil 0 2000)
+                      (search-forward id nil t))))
+      (setq target (expand-file-name
+                    (concat (zetta-kb--sanitize-file-name title)
+                            " -- " id ".org")
+                    dir)))
+    (make-directory dir t)
+    (with-temp-file target
+      (insert "#+title: " title "\n")
+      (when channel (insert "#+channel: " (format "%s" channel) "\n"))
+      (insert "#+source: " canonical "\n"
+              "#+transcript_kind: " (cdr cap) "\n"
+              "#+filetags: :yt:transcript:\n\n")
+      (dolist (l lines)
+        (insert (format "[[%s?t=%d][%s]] %s\n"
+                        canonical (car l) (zetta-kb--yt-stamp (car l))
+                        (cdr l)))))
+    (message "kb yt: %s (%d lines, %s)"
+             (abbreviate-file-name target) (length lines) (cdr cap))
+    target))
+
+;;; app/yt-transcript.el ends here

--- a/modules/app/yt-transcript.el
+++ b/modules/app/yt-transcript.el
@@ -74,6 +74,32 @@ Manual subtitles win over auto-captions."
   (let ((h (/ secs 3600)) (m (/ (% secs 3600) 60)) (s (% secs 60)))
     (if (> h 0) (format "%d:%02d:%02d" h m s) (format "%d:%02d" m s))))
 
+(defvar zetta-kb-yt-paragraph-stamps nil
+  "When non-nil, prefix each Transcript paragraph with its start-time link.")
+
+(defvar zetta-kb-yt-paragraph-gap 4
+  "Silence (seconds between captions) that starts a new paragraph.")
+
+(defvar zetta-kb-yt-paragraph-max 90
+  "Maximum seconds of speech per paragraph before forcing a break.")
+
+(defun zetta-kb--yt-paragraphs (lines)
+  "Group caption LINES ((SECONDS . TEXT)...) into (START-SECONDS . PROSE)."
+  (let (paras cur cur-start prev-start)
+    (dolist (l lines)
+      (let ((start (car l)))
+        (when (and cur
+                   (or (> (- start prev-start) zetta-kb-yt-paragraph-gap)
+                       (> (- start cur-start) zetta-kb-yt-paragraph-max)))
+          (push (cons cur-start (string-join (nreverse cur) " ")) paras)
+          (setq cur nil))
+        (unless cur (setq cur-start start))
+        (push (cdr l) cur)
+        (setq prev-start start)))
+    (when cur
+      (push (cons cur-start (string-join (nreverse cur) " ")) paras))
+    (nreverse paras)))
+
 ;;;###autoload
 (defun zetta-kb-save-yt-transcript (url)
   "Fetch the transcript for the YouTube video at URL into kb.
@@ -108,6 +134,16 @@ imports are just a `dolist' over this function."
       (insert "#+source: " canonical "\n"
               "#+transcript_kind: " (cdr cap) "\n"
               "#+filetags: :yt:transcript:\n\n")
+      ;; readable prose first: pause-segmented paragraphs, one line each
+      ;; (visual-line wraps; grep hits carry whole-paragraph context)
+      (insert "* Transcript\n\n")
+      (dolist (p (zetta-kb--yt-paragraphs lines))
+        (when zetta-kb-yt-paragraph-stamps
+          (insert (format "[[%s?t=%d][%s]] "
+                          canonical (car p) (zetta-kb--yt-stamp (car p)))))
+        (insert (cdr p) "\n\n"))
+      ;; fine-grained navigation at the end, folded away by org
+      (insert "* Timestamped\n")
       (dolist (l lines)
         (insert (format "[[%s?t=%d][%s]] %s\n"
                         canonical (car l) (zetta-kb--yt-stamp (car l))

--- a/modules/core/line-utils.el
+++ b/modules/core/line-utils.el
@@ -587,7 +587,9 @@ Shown whenever `flycheck-mode' is active."
        ;; keymap, so it would render as plain, non-clickable text).
        (if (fboundp 'breadcrumb-imenu-crumbs)
            (concat (ignore-errors (concat (nerd-icons-mdicon "nf-md-format_list_bulleted") " "))
-                   (breadcrumb-imenu-crumbs))
+                   ;; crumbs can signal on malformed imenu indexes (e.g.
+                   ;; pdf-view outlines); never let that escape redisplay
+                   (or (ignore-errors (breadcrumb-imenu-crumbs)) ""))
          (propertize
           (or (ignore-errors (org-display-outline-path nil t "/" t)) "/")
           'face '(:height 0.8))))
@@ -598,7 +600,7 @@ Shown whenever `flycheck-mode' is active."
        (concat (jpt-yaml-path-to-point)))
       (t (when (fboundp 'breadcrumb-imenu-crumbs)
            (concat (ignore-errors (concat (nerd-icons-mdicon "nf-md-format_list_bulleted") " "))
-                   (breadcrumb-imenu-crumbs)))))))
+                   (or (ignore-errors (breadcrumb-imenu-crumbs)) "")))))))
   "Mode-line construct for header-line row 2 (lsp / org / imenu crumbs).")
 
 (defun zetta-header-line-svg--line1 ()

--- a/modules/core/project.el
+++ b/modules/core/project.el
@@ -6,6 +6,11 @@
   :demand t
   :config
 
+  ;; Non-VC project roots (e.g. ~/kb, whose .git lives only on the sync
+  ;; hub): a .project marker file makes project-try-vc treat the dir as
+  ;; a root, and the marker syncs to every device with the folder.
+  (setq project-vc-extra-root-markers '(".project"))
+
   ;; Fallback for directories not recognized by project-find-functions.
   ;; Must use with-eval-after-load since nested use-package :config
   ;; may not reliably run with elpaca.

--- a/modules/org/org-remark.el
+++ b/modules/org/org-remark.el
@@ -1,7 +1,5 @@
 ;;; org-remark.el --- Configure org-remark -*- lexical-binding: t; -*-
 
-;; TODO cleanup my-org-remark-notes-file-name
-
 (use-package org-remark
   :demand t
   :after org
@@ -119,71 +117,77 @@ Builds the same string as elfeed's own store function: link
     (when (equal major-mode 'elfeed-show-mode)
       (my-org-remark-elfeed-link-string)))
 
-  ;; Sanitize filenames to match logseq's :triple-lowbar naming format.
-  ;; Logseq uses ___ for / and percent-encoding for other unsafe chars.
-  (defun my-org-remark-sanitize-notes-file-name (filename)
-    (string-replace
-     "/" "___"
-     (string-replace
-      ":" "%3A"
-      (string-replace
-       "?" "%3F"
-       (string-replace
-        "|" "%7C"
-        (string-replace
-         "\\" "%5C"
-         filename))))))
+  ;; Notes land in the synced kb tree, mirroring the readwise layout
+  ;; (<source>/<middle-dimension>/<title-slug>.org) where it makes sense.
+  (defvar my-org-remark-directory (expand-file-name "~/kb/org-remark/")
+    "Root for org-remark notes files, inside the synced kb tree.")
 
-  (defun my-org-remark-notes-file-name-url (url)
-    (my-org-remark-sanitize-notes-file-name
-     (let ((url-parsed (url-generic-parse-url url)))
-       (concat
-        (url-host url-parsed)
-        (url-filename url-parsed)
-        "-annotations.org"))))
+  (defun my-org-remark-slugify (s &optional maxlen)
+    "Lowercase-hyphenate S readwise-style; never empty."
+    (let ((slug (string-trim (replace-regexp-in-string
+                              "[^a-z0-9]+" "-" (downcase (or s "")))
+                             "-+" "-+")))
+      (if (string-empty-p slug)
+          "untitled"
+        (substring slug 0 (min (length slug) (or maxlen 80))))))
 
-  ;; TODO cleanup references to logseq dir, maybe use a directory
+  (defun my-org-remark-url-notes-path (subdir url)
+    "Notes path for URL under SUBDIR: <subdir>/<host>/<path-slug>.org."
+    (let* ((u (url-generic-parse-url url))
+           (host (or (url-host u) "unknown"))
+           (path-slug (my-org-remark-slugify (url-filename u))))
+      (expand-file-name
+       (concat subdir "/" host "/"
+               (if (string= path-slug "untitled") "index" path-slug)
+               ".org")
+       my-org-remark-directory)))
+
   (defun my-org-remark-notes-file-name ()
     (cond
-     ;; Logseq files
-     ((and buffer-file-name
-           (string-match-p (expand-file-name "~/logseq/graphs/") buffer-file-name))
-      (concat (file-name-sans-extension buffer-file-name) "-annotations.org"))
-     ;; Elfeed
+     ;; Elfeed: feed domain is the middle dimension
      ((eq major-mode 'elfeed-show-mode)
-      (expand-file-name
-       (concat
-        "~/logseq/pages/(highlights elfeed) "
-        (let ((link-parts (split-string (my-org-remark-elfeed-link-string)
-                                        "\\]\\[")))
-          (my-org-remark-sanitize-notes-file-name
-           (concat (nth 0 (split-string (nth 1 link-parts) "\\]\\]"))
-                   "-annotations.org"))))))
-     ;; Wombag
+      (let* ((id (elfeed-entry-id elfeed-show-entry))
+             (feed-host (or (url-host (url-generic-parse-url (car id)))
+                            "unknown")))
+        (expand-file-name
+         (concat "elfeed/" feed-host "/"
+                 (my-org-remark-slugify (elfeed-entry-title elfeed-show-entry))
+                 ".org")
+         my-org-remark-directory)))
+     ;; Wombag / Eww: page domain is the middle dimension
      ((eq major-mode 'wombag-show-mode)
-      (expand-file-name
-       (concat
-        "~/logseq/pages/(highlights wombag) "
-        (my-org-remark-notes-file-name-url
-         (alist-get 'url wombag-show-entry)))))
-     ;; Wombag
-     ((eq major-mode 'pubmed-show-mode)
-      (expand-file-name
-       (concat
-        "~/logseq/pages/(highlights pubmed) "
-        (my-org-remark-notes-file-name-url
-         (pubmed-extract-pmid)))))
-     ;; Eww
+      (my-org-remark-url-notes-path "wombag" (alist-get 'url wombag-show-entry)))
      ((eq major-mode 'eww-mode)
+      (my-org-remark-url-notes-path "eww" (eww-current-url)))
+     ;; Pubmed: pmid is already a unique flat id
+     ((eq major-mode 'pubmed-show-mode)
+      (expand-file-name (concat "pubmed/" (pubmed-extract-pmid) ".org")
+                        my-org-remark-directory))
+     ;; Info manuals: one notes file per manual
+     ((eq major-mode 'Info-mode)
       (expand-file-name
-       (concat
-        "~/logseq/pages/(highlights eww) "
-        (my-org-remark-notes-file-name-url
-         (eww-current-url)))))
-     ;; if it is a file
+       (concat "info/"
+               (my-org-remark-slugify
+                (file-name-sans-extension
+                 (file-name-nondirectory Info-current-file)))
+               ".org")
+       my-org-remark-directory))
+     ;; Epubs via nov.el
+     ((eq major-mode 'nov-mode)
+      (expand-file-name
+       (concat "books/"
+               (my-org-remark-slugify
+                (file-name-sans-extension (file-name-nondirectory nov-file-name)))
+               ".org")
+       my-org-remark-directory))
+     ;; kb's own notes: annotations live next to the file they annotate
+     ((and buffer-file-name
+           (string-prefix-p (expand-file-name "~/kb/") buffer-file-name))
+      (concat (file-name-sans-extension buffer-file-name) "-annotations.org"))
+     ;; any other file: marginalia.org in the file's own directory
      (buffer-file-name "marginalia.org")
-     ;; otherwise
-     (t (expand-file-name "marginalia.org" user-emacs-directory))))
+     ;; otherwise: synced catch-all
+     (t (expand-file-name "marginalia.org" my-org-remark-directory))))
 
   (setq org-remark-notes-file-name 'my-org-remark-notes-file-name)
 

--- a/modules/org/org.el
+++ b/modules/org/org.el
@@ -56,7 +56,10 @@ TYPE is a character: ?a alphabetic, ?t timestamp, ?p priority, ?o TODO order."
 
 (use-package org
   :ensure nil
-  :mode ("\\.org" . org-mode)
+  ;; \\' anchor is load-bearing: unanchored, this matched ".org" anywhere
+  ;; in the PATH — e.g. kb/images/en.wikipedia.org/photo.jpg opened as an
+  ;; org buffer of raw JPEG bytes.
+  :mode ("\\.org\\'" . org-mode)
 
   :config
   (setq-default org-indent-mode nil)

--- a/modules/org/org.el
+++ b/modules/org/org.el
@@ -386,7 +386,7 @@ Set this in ~/.private.el before modules load.")
         (append
          '(("o" "Simple capture"
             entry
-            (file "~/logseq/pages/capture.org")
+            (file "~/kb/inbox.org")
             "* %?\n%a"
             :prepend t))
          (zetta-logseq-generate-capture-templates)))

--- a/modules/org/pdfnote.el
+++ b/modules/org/pdfnote.el
@@ -23,6 +23,17 @@
   :commands (pdfnote-sync-file pdfnote-sync-buffer pdfnote-sync-all
              pdfnote-preview pdfnote-visit-notes)
   :init
+  ;; kb targeting (was the Logseq graph): PDFs live under ~/kb/pdf/
+  ;; (domain subdirs); notes are a SIBLING <name>-annotations.org next
+  ;; to each PDF — the same convention org-remark uses for kb files —
+  ;; so pdf: links are same-dir relative and resolve against the note's
+  ;; own directory.
+  (setq pdfnote-assets-directory (expand-file-name "~/kb/pdf/")
+        pdfnote-pages-directory  (expand-file-name "~/kb/pdf/")
+        pdfnote-asset-link-directory "."
+        pdfnote-page-file-function
+        (lambda (pdf)
+          (concat (file-name-sans-extension pdf) "-annotations.org")))
   ;; Register the `pdf:' backlink early (before the package is first
   ;; loaded) so those links are followable in any Org buffer; following
   ;; one autoloads the package on demand.

--- a/modules/org/pdfnote.el
+++ b/modules/org/pdfnote.el
@@ -28,7 +28,8 @@
   ;; to each PDF — the same convention org-remark uses for kb files —
   ;; so pdf: links are same-dir relative and resolve against the note's
   ;; own directory.
-  (setq pdfnote-assets-directory (expand-file-name "~/kb/pdf/")
+  (setq pdfnote-file-prefix ""      ; logseq-era naming; dir context suffices
+        pdfnote-assets-directory (expand-file-name "~/kb/pdf/")
         pdfnote-pages-directory  (expand-file-name "~/kb/pdf/")
         pdfnote-asset-link-directory "."
         pdfnote-page-file-function

--- a/modules/tools/irs.el
+++ b/modules/tools/irs.el
@@ -1,7 +1,7 @@
 ;;; tools/irs.el --- information-retrieval-service (irs) client -*- lexical-binding: t; -*-
 
 ;;; Commentary:
-;; Search over the personal corpus (logseq pages/journals, hywiki, design
+;; Search over the personal corpus (kb notes/todo/readwise, hywiki, design
 ;; docs) via the irs FastAPI backend at
 ;; ~/source_code/information-retrieval-service.  Design doc:
 ;; text-search.org at the repo root.

--- a/modules/ui/theme.el
+++ b/modules/ui/theme.el
@@ -4,32 +4,27 @@
   :init
   (load-theme zetta-theme t))
 
-(message "nord-theme")
-(use-package nord-theme)
 
-(message "poet-theme")
-(use-package poet-theme)
 
-(message "heroku-theme")
-(use-package heroku-theme)
+;;(message "nord-theme")
+;;(use-package nord-theme)
+;;(message "poet-theme")
+;;(use-package poet-theme)
+;;(message "heroku-theme")
+;;(use-package heroku-theme)
+;;(message "jbeans-theme")
+;;(use-package jbeans-theme)
+;;(message "leuven-theme")
+;;(use-package leuven-theme)
+;;(message "rebecca-theme")
+;;(use-package rebecca-theme)
+;;(message "zenburn-theme")
+;;(use-package zenburn-theme)
+;;(message "lavender-theme")
+;;(use-package lavender-theme)
+;;(message "chocolate-theme")
+;;(use-package chocolate-theme)
 
-(message "jbeans-theme")
-(use-package jbeans-theme)
-
-(message "leuven-theme")
-(use-package leuven-theme)
-
-(message "rebecca-theme")
-(use-package rebecca-theme)
-
-(message "zenburn-theme")
-(use-package zenburn-theme)
-
-(message "lavender-theme")
-(use-package lavender-theme)
-
-(message "chocolate-theme")
-(use-package chocolate-theme)
 (custom-set-faces
  '(cursor ((t (:background "gray"))))
  '(header-line-inactive ((t (:background unspecified :foreground unspecified :inherit header-line)))))

--- a/source/bootstrap/bootstrap-modules.el
+++ b/source/bootstrap/bootstrap-modules.el
@@ -17,7 +17,8 @@ Download Terminus TTF from https://files.ax86.net/terminus-ttf/")
 (defvar zetta-literature-dir "~/.lit/"
   "Directory for bibliography files and PDFs.  Set in ~/.zetta.el.")
 
-(defvar zetta-logseq-dir "~/logseq/pages/"
+;; name is vestigial (logseq era); points at the kb todo dir since 2026-07
+(defvar zetta-logseq-dir "~/kb/todo/"
   "Directory containing Logseq pages.  Set in ~/.zetta.el.")
 
 (defvar zetta-use-lockfile t

--- a/source/zettapkg/irs/irs.el
+++ b/source/zettapkg/irs/irs.el
@@ -687,8 +687,8 @@ simply does not appear -- better than offering a search that 503s."
 ;;
 ;; Full minibuffer grammar (worked examples in text-search.org):
 ;;   QUERY [FLAGS...] [-- LITERAL-QUERY-TEXT] [,ORDERLESS-COMPONENT...]
-;; e.g. `server --root=logseq -- -v,proxy,section' -- query "server -v"
-;; scoped to logseq, rows then narrowed on "proxy" and "section".
+;; e.g. `server --root=notes -- -v,proxy,section' -- query "server -v"
+;; scoped to notes, rows then narrowed on "proxy" and "section".
 
 (defconst irs--flag-regexp "\\`--?\\([a-z]+\\)=\\(.*\\)\\'"
   "One `--key=value' flag.  Matched generically and dispatched on the key,
@@ -780,7 +780,7 @@ rendering identically would leave one of them permanently unreachable."
 The candidate is `label  snippet'; marginalia's columns (root, type,
 kind, score) are right-aligned AFTER it, so an unbounded candidate fills
 the line and pushes the annotation off the right edge — which is exactly
-what a logseq readwise title like
+what a long capture title like
 \"(highlights eww) github.com/namilus/completions-overlay-annotations\"
 does.  Bounding both parts reserves room for the annotation."
   :type 'natnum)
@@ -1117,7 +1117,7 @@ filter -- a source that is not shown never fires its request.
 Scope with flags in the input, which are passed to the backend:
 
   svg rendering --root=blog --type=org
-  kubernetes deploy --root=logseq,zetta
+  kubernetes deploy --root=notes,zetta
   emacs --type=pdf --limit=50
 
 `--root=' (`-r=') takes a corpus root alias.  `--type=' (`-t=') takes an

--- a/source/zettapkg/pdfnote/pdfnote.el
+++ b/source/zettapkg/pdfnote/pdfnote.el
@@ -460,7 +460,7 @@ With prefix arg FORCE, overwrite even a non-pdfnote-managed page."
   "Sync every annotated PDF in `pdfnote-assets-directory'.
 Return the list of written files."
   (interactive "P")
-  (let ((pdfs (directory-files pdfnote-assets-directory t "\\.pdf\\'"))
+  (let ((pdfs (directory-files-recursively pdfnote-assets-directory "\\.pdf\\'"))
         (written 0) (empty 0) (refused 0) files)
     (dolist (pdf pdfs)
       (let ((r (ignore-errors (pdfnote--sync-1 pdf force))))


### PR DESCRIPTION
Migrates the config from the Logseq-centric setup to the synced ~/kb knowledge base, and adds the capture pipelines built alongside it.

## Retargets (logseq → kb)
- org-remark notes route to `~/kb/org-remark/<source>/<domain>/`; logseq filename encoding removed
- org agenda/capture: todo scan dir → `~/kb/todo/`, simple capture → `~/kb/inbox.org` (old target no longer existed)
- pdfnote → sibling `<name>-annotations.org` next to each PDF under `~/kb/pdf/`; recursive sync-all; logseq title prefix dropped
- hyrolo → kb dirs; irs docstrings → kb-era root names
- `~/kb` recognized as a project.el root via `.project` marker (`project-vc-extra-root-markers`)

## New capture commands
- `zetta-eww-save-pdf-to-kb` (`D` in eww and in the `*eww pdf*` buffer): PDFs → `pdf/<domain>/`, filename imputed from PDF metadata title / link text
- `zetta-eww-save-image-to-kb` (`I` on images): → `images/<page-domain>/`, wikimedia thumbs upgraded to originals
- `zetta-kb-save-yt-transcript`: prose-first transcript + timestamped section, bulk-import capable
- `zetta-kb-save-llm-convo`: ChatGPT share links → org (turbo-stream parser lives in the dotfiles hub tooling)

## Fixes
- HyWiki frame-flash: debounce the frame-wide re-highlight into one idle pass and neutralize all three `sit-for` sites (typing + navigation paths); candidate for upstreaming
- breadcrumb crumbs guarded in the SVG header-line eval (pdf-view imenu made it error per-redisplay)
- `auto-mode-alist` org pattern anchored — unanchored, it matched `.org` *domains* in paths, opening JPEGs under `en.wikipedia.org/` as org buffers