### PR TITLE
feat(config): mail modules — nano-mu4e, org-msg, mu4e-dashboard

### DIFF
--- a/elpaca-lock.el
+++ b/elpaca-lock.el
@@ -2545,6 +2545,12 @@
                              multiple-cursors :type git :protocol
                              https :inherit t :depth treeless :ref
                              "ddd677091afc7d65ce56d11866e18aeded110ada"))
+ (mu4e-dashboard :source "elpaca-menu-lock-file" :recipe
+                 (:source "elpaca-menu-lock-file" :package "mu4e-dashboard"
+                          :id mu4e-dashboard :host github :repo
+                          "rougier/mu4e-dashboard" :type git :protocol https
+                          :inherit t :depth treeless :ref
+                          "d40f501edad5078386e43a74b2bc3e2b22e33009"))
  (mw-thesaurus :source "elpaca-menu-lock-file" :recipe
                (:package "mw-thesaurus" :repo "agzam/mw-thesaurus.el"
                          :fetcher github :files
@@ -2728,6 +2734,12 @@
                      :type git :protocol https :inherit t :depth
                      treeless :ref
                      "ffaad784a8597ee52842a578c01bd347d3e0281d"))
+ (org-msg :source "elpaca-menu-lock-file" :recipe
+          (:source "elpaca-menu-lock-file" :package "org-msg"
+                   :id org-msg :host github :repo
+                   "jeremy-compostella/org-msg" :type git :protocol https
+                   :inherit t :depth treeless :ref
+                   "7b45df759340f3e388e84f497052b7cf3a41698c"))
  (org-noter :source "elpaca-menu-lock-file" :recipe
             (:package "org-noter" :fetcher github :repo
                       "org-noter/org-noter" :files

--- a/elpaca-lock.el
+++ b/elpaca-lock.el
@@ -2561,6 +2561,12 @@
                          mw-thesaurus :type git :protocol https
                          :inherit t :depth treeless :ref
                          "c44d793595c2d0f6789621da457da065920968ac"))
+ (nano-mu4e :source "elpaca-menu-lock-file" :recipe
+            (:source "elpaca-menu-lock-file" :package "nano-mu4e"
+                     :id nano-mu4e :host github :repo
+                     "rougier/nano-mu4e" :type git :protocol https
+                     :inherit t :depth treeless :ref
+                     "068086f5cc633595130b273647dda13d5f158973"))
  (nano-theme :source "elpaca-menu-lock-file" :recipe
              (:package "nano-theme" :repo
                        ("https://github.com/rougier/nano-theme"

--- a/modules/app/mu4e-dashboard.el
+++ b/modules/app/mu4e-dashboard.el
@@ -1,0 +1,22 @@
+;;; mu4e-dashboard.el --- Configure mu4e-dashboard -*- lexical-binding: t; -*-
+
+;; Rougier's org-based mail dashboard: an org file of [[mu:query]]
+;; links with live counts, activated by `mu4e-dashboard'.  The
+;; dashboard file itself is personal (it names maildirs/addresses), so
+;; it lives outside this repo at `mu4e-dashboard-file'.
+
+;; mu4e comes from the homebrew site-lisp, not an elpaca menu (same
+;; treatment as nano-mu4e.el; add-to-list is idempotent).
+(add-to-list 'elpaca-ignored-dependencies 'mu4e)
+
+(use-package mu4e-dashboard
+  :if (executable-find "mu")
+  :ensure (mu4e-dashboard :host github :repo "rougier/mu4e-dashboard")
+  :after mu4e
+  :config
+  (setq mu4e-dashboard-file "~/.mu4e-dashboard.org")
+  (general-define-key
+   :keymaps 'launch-map
+   "M" 'mu4e-dashboard))
+
+;;; mu4e-dashboard.el ends here

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -65,13 +65,14 @@
   (define-key nano-mu4e-mode-map (kbd "C-l") nil)
   (define-key nano-mu4e-mode-map (kbd "g") nil)
   (define-key nano-mu4e-mode-map (kbd "g r") #'nano-mu4e-rerun)
-  ;; Leave ":" (ex) and "G" (bottom) to evil; tag editing moves under
-  ;; the g prefix, and gg is restored inside it.
+  ;; Leave ":" (ex) and "G" (bottom) to evil; gg is restored inside the
+  ;; g prefix.  Tag editing lives on g a / g A ("annotate") — g t
+  ;; belongs to spacetree, g l to mu4e-show-log.
   (define-key nano-mu4e-mode-map (kbd ":") nil)
   (define-key nano-mu4e-mode-map (kbd "G") nil)
   (define-key nano-mu4e-mode-map (kbd "g g") #'beginning-of-buffer)
-  (define-key nano-mu4e-mode-map (kbd "g t") #'nano-mu4e-edit-tags-root)
-  (define-key nano-mu4e-mode-map (kbd "g T") #'nano-mu4e-edit-tags)
+  (define-key nano-mu4e-mode-map (kbd "g a") #'nano-mu4e-edit-tags-root)
+  (define-key nano-mu4e-mode-map (kbd "g A") #'nano-mu4e-edit-tags)
 
   ;; Let mu4e's and nano-mu4e's own keys through the modal layers.
   ;; Both meow-normal and evil-normal sit in emulation-mode-map-alists

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -56,6 +56,30 @@
         (mu4e-search-rerun))
       (message "nano-mu4e display %s" (if enable "enabled" "disabled"))))
 
+  ;; Upstream bug: nano-mu4e sets/executes a `tag' mark, but stock
+  ;; mu4e-marks has no such entry — nano's mode-on styling creates a
+  ;; :char-only stub whose nil :action/:show-target crash execution
+  ;; ("void function nil").  Define a real mark.  nano passes the
+  ;; complete final tag list; mu4e-action-retag-message wants +/-
+  ;; deltas, so diff against the message's current tags.
+  (defun zetta-nano-mu4e--retag-absolute (_docid msg target)
+    "Set MSG's tags to exactly TARGET, a comma-separated list."
+    (let* ((want (split-string (or target "") "," t "[ \t]+"))
+           (have (mu4e-message-field msg :tags))
+           (delta (append
+                   (mapcar (lambda (tag) (concat "+" tag))
+                           (cl-set-difference want have :test #'string=))
+                   (mapcar (lambda (tag) (concat "-" tag))
+                           (cl-set-difference have want :test #'string=)))))
+      (when delta
+        (mu4e-action-retag-message msg (mapconcat #'identity delta ",")))))
+  (setf (alist-get 'tag mu4e-marks)
+        (list :char '("(T)" . " ")
+              :prompt "tag"
+              :ask-target (lambda () (read-string "Tags (comma separated): "))
+              :show-target (lambda (target) target)
+              :action #'zetta-nano-mu4e--retag-absolute))
+
   ;; Keys: C-j/C-k for message motion; C-l unbound so it falls through
   ;; to the global recenter-top-bottom; vim-style "g r" reruns the
   ;; search (making g a prefix displaces the map's g =

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -24,6 +24,12 @@
   :ensure (nano-mu4e :host github :repo "rougier/nano-mu4e")
   :after mu4e
   :hook (mu4e-headers-mode . nano-mu4e-mode)
+  :config
+  ;; Body excerpts under messages in the headers view.  The stock
+  ;; predicate previews only NEW messages that aren't github
+  ;; notifications or list mail.
+  (setq nano-mu4e-msg-preview t
+        nano-mu4e-msg-preview-func #'nano-mu4e-msg-preview-p)
   :init
   (defvar zetta-nano-mu4e--fontset-done nil)
   (defun zetta-nano-mu4e--fontset (&optional frame)

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -65,6 +65,13 @@
   (define-key nano-mu4e-mode-map (kbd "C-l") nil)
   (define-key nano-mu4e-mode-map (kbd "g") nil)
   (define-key nano-mu4e-mode-map (kbd "g r") #'nano-mu4e-rerun)
+  ;; Leave ":" (ex) and "G" (bottom) to evil; tag editing moves under
+  ;; the g prefix, and gg is restored inside it.
+  (define-key nano-mu4e-mode-map (kbd ":") nil)
+  (define-key nano-mu4e-mode-map (kbd "G") nil)
+  (define-key nano-mu4e-mode-map (kbd "g g") #'beginning-of-buffer)
+  (define-key nano-mu4e-mode-map (kbd "g t") #'nano-mu4e-edit-tags-root)
+  (define-key nano-mu4e-mode-map (kbd "g T") #'nano-mu4e-edit-tags)
 
   ;; Let mu4e's and nano-mu4e's own keys through the modal layers.
   ;; Both meow-normal and evil-normal sit in emulation-mode-map-alists
@@ -75,8 +82,16 @@
   (with-eval-after-load 'meow
     (dolist (mode '(mu4e-main-mode mu4e-headers-mode mu4e-view-mode))
       (add-to-list 'meow-mode-state-list (cons mode 'motion))))
+  ;; Headers: evil NORMAL state with nano-mu4e's map overriding it
+  ;; (evil-collection-style) — nano keys (TAB, g r, n/p, x, t...) win,
+  ;; everything else stays evil (j/k, "," leader, /-search, gg/G, :).
+  ;; Main and view keep emacs state: they're menu/reading buffers whose
+  ;; single-letter mu4e keys (s, r, f, q...) evil normal would eat.
   (with-eval-after-load 'evil
-    (dolist (mode '(mu4e-main-mode mu4e-headers-mode mu4e-view-mode))
+    (evil-set-initial-state 'mu4e-headers-mode 'normal)
+    (evil-make-overriding-map nano-mu4e-mode-map 'normal)
+    (add-hook 'nano-mu4e-mode-hook #'evil-normalize-keymaps)
+    (dolist (mode '(mu4e-main-mode mu4e-view-mode))
       (evil-set-initial-state mode 'emacs)))
 
   ;; Re-apply brushup styles now that the faces below exist.

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -80,6 +80,22 @@
               :show-target (lambda (target) target)
               :action #'zetta-nano-mu4e--retag-absolute))
 
+  ;; Retagging edits the message file and reindexes asynchronously,
+  ;; but nano's immediate refresh re-renders from cached message
+  ;; plists, so the new tag never shows (and the stock per-message
+  ;; update handler jitters the custom layout).  Re-query the server
+  ;; shortly after any tag operation instead.
+  (defun zetta-nano-mu4e--rerun-after-tag (&rest _)
+    (run-at-time 0.4 nil
+                 (lambda ()
+                   (when-let* ((buf (mu4e-get-headers-buffer)))
+                     (when (buffer-live-p buf)
+                       (with-current-buffer buf
+                         (ignore-errors (nano-mu4e-rerun))))))))
+  (advice-add 'nano-mu4e-toggle-todo :after #'zetta-nano-mu4e--rerun-after-tag)
+  (advice-add 'nano-mu4e-edit-tags :after #'zetta-nano-mu4e--rerun-after-tag)
+  (advice-add 'nano-mu4e-edit-tags-root :after #'zetta-nano-mu4e--rerun-after-tag)
+
   ;; Keys: C-j/C-k for message motion; C-l unbound so it falls through
   ;; to the global recenter-top-bottom; vim-style "g r" reruns the
   ;; search (making g a prefix displaces the map's g =

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -56,45 +56,13 @@
         (mu4e-search-rerun))
       (message "nano-mu4e display %s" (if enable "enabled" "disabled"))))
 
-  ;; Upstream bug: nano-mu4e sets/executes a `tag' mark, but stock
-  ;; mu4e-marks has no such entry — nano's mode-on styling creates a
-  ;; :char-only stub whose nil :action/:show-target crash execution
-  ;; ("void function nil").  Define a real mark.  nano passes the
-  ;; complete final tag list; mu4e-action-retag-message wants +/-
-  ;; deltas, so diff against the message's current tags.
-  (defun zetta-nano-mu4e--retag-absolute (_docid msg target)
-    "Set MSG's tags to exactly TARGET, a comma-separated list."
-    (let* ((want (split-string (or target "") "," t "[ \t]+"))
-           (have (mu4e-message-field msg :tags))
-           (delta (append
-                   (mapcar (lambda (tag) (concat "+" tag))
-                           (cl-set-difference want have :test #'string=))
-                   (mapcar (lambda (tag) (concat "-" tag))
-                           (cl-set-difference have want :test #'string=)))))
-      (when delta
-        (mu4e-action-retag-message msg (mapconcat #'identity delta ",")))))
-  (setf (alist-get 'tag mu4e-marks)
-        (list :char '("(T)" . " ")
-              :prompt "tag"
-              :ask-target (lambda () (read-string "Tags (comma separated): "))
-              :show-target (lambda (target) target)
-              :action #'zetta-nano-mu4e--retag-absolute))
-
-  ;; Retagging edits the message file and reindexes asynchronously,
-  ;; but nano's immediate refresh re-renders from cached message
-  ;; plists, so the new tag never shows (and the stock per-message
-  ;; update handler jitters the custom layout).  Re-query the server
-  ;; shortly after any tag operation instead.
-  (defun zetta-nano-mu4e--rerun-after-tag (&rest _)
-    (run-at-time 0.4 nil
-                 (lambda ()
-                   (when-let* ((buf (mu4e-get-headers-buffer)))
-                     (when (buffer-live-p buf)
-                       (with-current-buffer buf
-                         (ignore-errors (nano-mu4e-rerun))))))))
-  (advice-add 'nano-mu4e-toggle-todo :after #'zetta-nano-mu4e--rerun-after-tag)
-  (advice-add 'nano-mu4e-edit-tags :after #'zetta-nano-mu4e--rerun-after-tag)
-  (advice-add 'nano-mu4e-edit-tags-root :after #'zetta-nano-mu4e--rerun-after-tag)
+  ;; Tags feature deliberately disabled: mu4e tags are local-only,
+  ;; upstream's tag mark is broken without private config (missing
+  ;; mu4e-marks entry), and the async retag/refresh dance flashes the
+  ;; buffer.  Mail todos go through org-capture ("m" template) instead.
+  ;; Unbind nano's tag keys so they can't hit the broken path.
+  (define-key nano-mu4e-mode-map (kbd "t") nil)
+  (define-key nano-mu4e-mode-map (kbd "T") nil)
 
   ;; Keys: C-j/C-k for message motion; C-l unbound so it falls through
   ;; to the global recenter-top-bottom; vim-style "g r" reruns the
@@ -106,13 +74,10 @@
   (define-key nano-mu4e-mode-map (kbd "g") nil)
   (define-key nano-mu4e-mode-map (kbd "g r") #'nano-mu4e-rerun)
   ;; Leave ":" (ex) and "G" (bottom) to evil; gg is restored inside the
-  ;; g prefix.  Tag editing lives on g a / g A ("annotate") — g t
-  ;; belongs to spacetree, g l to mu4e-show-log.
+  ;; g prefix.
   (define-key nano-mu4e-mode-map (kbd ":") nil)
   (define-key nano-mu4e-mode-map (kbd "G") nil)
   (define-key nano-mu4e-mode-map (kbd "g g") #'beginning-of-buffer)
-  (define-key nano-mu4e-mode-map (kbd "g a") #'nano-mu4e-edit-tags-root)
-  (define-key nano-mu4e-mode-map (kbd "g A") #'nano-mu4e-edit-tags)
 
   ;; Let mu4e's and nano-mu4e's own keys through the modal layers.
   ;; Both meow-normal and evil-normal sit in emulation-mode-map-alists

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -56,6 +56,19 @@
         (mu4e-search-rerun))
       (message "nano-mu4e display %s" (if enable "enabled" "disabled"))))
 
+  ;; Let mu4e's and nano-mu4e's own keys through the modal layers.
+  ;; Both meow-normal and evil-normal sit in emulation-mode-map-alists
+  ;; above nano-mu4e's minor-mode map: meow suppresses unbound
+  ;; printables (P/U/g...) and evil normal binds TAB (evil-jump-forward)
+  ;; among others.  meow motion reserves only j/k/SPC; evil emacs state
+  ;; reserves nothing.  The "," launch-map is bound in motion state.
+  (with-eval-after-load 'meow
+    (dolist (mode '(mu4e-main-mode mu4e-headers-mode mu4e-view-mode))
+      (add-to-list 'meow-mode-state-list (cons mode 'motion))))
+  (with-eval-after-load 'evil
+    (dolist (mode '(mu4e-main-mode mu4e-headers-mode mu4e-view-mode))
+      (evil-set-initial-state mode 'emacs)))
+
   ;; Re-apply brushup styles now that the faces below exist.
   (when (fboundp 'brushup) (brushup))
 

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -112,7 +112,7 @@
     (evil-set-initial-state 'mu4e-view-mode 'normal)
     (evil-make-overriding-map mu4e-view-mode-map 'normal)
     (add-hook 'mu4e-view-mode-hook #'evil-normalize-keymaps)
-    (evil-set-initial-state 'mu4e-main-mode 'emacs)))
+    (evil-set-initial-state 'mu4e-main-mode 'emacs))
 
   ;; Re-apply brushup styles now that the faces below exist.
   (when (fboundp 'brushup) (brushup))

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -25,11 +25,11 @@
   :after mu4e
   :hook (mu4e-headers-mode . nano-mu4e-mode)
   :config
-  ;; Body excerpts under messages in the headers view.  The stock
-  ;; predicate previews only NEW messages that aren't github
-  ;; notifications or list mail.
+  ;; Body excerpts under messages in the headers view, for ALL new
+  ;; messages (the stock predicate `nano-mu4e-msg-preview-p' would
+  ;; exclude github notifications and list mail).
   (setq nano-mu4e-msg-preview t
-        nano-mu4e-msg-preview-func #'nano-mu4e-msg-preview-p)
+        nano-mu4e-msg-preview-func #'nano-mu4e-msg-is-new)
 
   ;; Upstream bug: `nano-mu4e-msg-preview' binds charset inside its
   ;; when-let*, so a MIME part with no explicit charset= parameter

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -31,6 +31,34 @@
   (setq nano-mu4e-msg-preview t
         nano-mu4e-msg-preview-func #'nano-mu4e-msg-is-new)
 
+  ;; Threads start folded after every search, like upstream's
+  ;; screenshots: read messages collapse into the "N hidden messages"
+  ;; line, unread stay visible.  TAB unfolds a thread (remembered per
+  ;; thread), S-TAB flips all.  nano-mu4e's found-handler bypasses the
+  ;; stock handler that would normally arrange folding, hence the
+  ;; advice; `mu4e-thread--fold-status' is mu4e's global default state.
+  (defun zetta-nano-mu4e--fold-all (&rest _)
+    (when (buffer-live-p (mu4e-get-headers-buffer))
+      (with-current-buffer (mu4e-get-headers-buffer)
+        (ignore-errors (mu4e-thread-fold-apply-all)))))
+  (setq mu4e-thread--fold-status t)
+  (advice-add 'nano-mu4e-found-handler :after #'zetta-nano-mu4e--fold-all)
+
+  (defun zetta-nano-mu4e-toggle ()
+    "Toggle between the nano-mu4e and stock mu4e headers display."
+    (interactive)
+    (let ((enable (not (memq 'nano-mu4e-mode mu4e-headers-mode-hook))))
+      (if enable
+          (add-hook 'mu4e-headers-mode-hook 'nano-mu4e-mode)
+        (remove-hook 'mu4e-headers-mode-hook 'nano-mu4e-mode))
+      (when (derived-mode-p 'mu4e-headers-mode)
+        (nano-mu4e-mode (if enable 1 -1))
+        (mu4e-search-rerun))
+      (message "nano-mu4e display %s" (if enable "enabled" "disabled"))))
+
+  ;; Re-apply brushup styles now that the faces below exist.
+  (when (fboundp 'brushup) (brushup))
+
   ;; Upstream bug: `nano-mu4e-msg-preview' binds charset inside its
   ;; when-let*, so a MIME part with no explicit charset= parameter
   ;; (RFC-legal, defaults to us-ascii) nils the chain and the preview
@@ -64,6 +92,27 @@
                         (t "No message body found"))))
             (mm-destroy-parts handles))))))
   (advice-add 'nano-mu4e-msg-preview :override #'zetta-nano-mu4e--msg-preview)
+
+  :brushup
+  ;; Upstream faces inherit `link' (blue + underline) for new/unread
+  ;; and `widget-field' (underlined here) for the gutter; previews
+  ;; inherit `italic', which Terminus doesn't have.  Restyle: purple
+  ;; drawn from the theme's keyword face for new/unread/flagged, shadow
+  ;; (theme-adaptive gray) for previews, no underlines anywhere.
+  (add-to-list 'brushup-styles
+               '(when (facep 'nano-mu4e-new)
+                  (let ((purple (or (face-foreground 'font-lock-keyword-face nil t)
+                                    brushup-fg)))
+                    (set-face-attribute 'nano-mu4e-new nil
+                                        :inherit 'bold :foreground purple :underline nil)
+                    (set-face-attribute 'nano-mu4e-unread nil
+                                        :inherit nil :foreground purple :underline nil)
+                    (set-face-attribute 'nano-mu4e-flagged nil
+                                        :inherit nil :foreground purple :underline nil))
+                  (set-face-attribute 'nano-mu4e-preview nil
+                                      :inherit 'shadow :slant 'normal)
+                  (set-face-attribute 'nano-mu4e-gutter-body nil :underline nil)
+                  (set-face-attribute 'nano-mu4e-gutter-match nil :underline nil)))
   :init
   (defvar zetta-nano-mu4e--fontset-done nil)
   (defun zetta-nano-mu4e--fontset (&optional frame)

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -1,0 +1,41 @@
+;;; nano-mu4e.el --- Configure nano-mu4e -*- lexical-binding: t; -*-
+
+;; mu4e is set up in ~/.private.el (loaded eagerly before modules), so
+;; :after mu4e fires here without needing further deferral.
+;;
+;; nano-mu4e is Rougier's boxed headers view for mu4e.  Its glyphs are
+;; NERD-font codepoints in the private-use planes with no ASCII
+;; fallback (`nano-mu4e-symbol' always returns the NERD variant), and
+;; Terminus has no private-use coverage, so those ranges are routed to
+;; the NERD-patched Terminess installed system-wide.
+;;
+;; Threading is off by default here (~/.private.el sets
+;; `mu4e-headers-show-threads' nil); nano-mu4e handles both, but its
+;; thread boxes/folding only show up when threading is on — toggle
+;; per-search with "P" (`mu4e-search-toggle-property') in headers view.
+
+;; nano-mu4e's Package-Requires lists mu4e, but mu4e is provided by the
+;; homebrew mu install (site-lisp), not by any elpaca menu — without
+;; this the order fails at the dependency-queue step.
+(add-to-list 'elpaca-ignored-dependencies 'mu4e)
+
+(use-package nano-mu4e
+  :if (executable-find "mu")
+  :ensure (nano-mu4e :host github :repo "rougier/nano-mu4e")
+  :after mu4e
+  :hook (mu4e-headers-mode . nano-mu4e-mode)
+  :init
+  (defvar zetta-nano-mu4e--fontset-done nil)
+  (defun zetta-nano-mu4e--fontset (&optional frame)
+    "Route NERD private-use glyph ranges to Terminess on the first GUI FRAME."
+    (when (and (not zetta-nano-mu4e--fontset-done)
+               (display-graphic-p frame))
+      (set-fontset-font t '(#xe000 . #xf8ff) "Terminess Nerd Font Mono" nil 'prepend)
+      (set-fontset-font t '(#xf0000 . #xfffff) "Terminess Nerd Font Mono" nil 'prepend)
+      (setq zetta-nano-mu4e--fontset-done t)))
+  ;; The daemon has no GUI frame at init time, so also catch the first
+  ;; frame created after startup.
+  (add-hook 'after-make-frame-functions #'zetta-nano-mu4e--fontset)
+  (zetta-nano-mu4e--fontset))
+
+;;; nano-mu4e.el ends here

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -56,6 +56,16 @@
         (mu4e-search-rerun))
       (message "nano-mu4e display %s" (if enable "enabled" "disabled"))))
 
+  ;; Keys: C-j/C-k for message motion; C-l unbound so it falls through
+  ;; to the global recenter-top-bottom; vim-style "g r" reruns the
+  ;; search (making g a prefix displaces the map's g =
+  ;; nano-mu4e-edit-tags-root; G still edits tags at point).
+  (define-key nano-mu4e-mode-map (kbd "C-j") #'nano-mu4e-next-msg)
+  (define-key nano-mu4e-mode-map (kbd "C-k") #'nano-mu4e-prev-msg)
+  (define-key nano-mu4e-mode-map (kbd "C-l") nil)
+  (define-key nano-mu4e-mode-map (kbd "g") nil)
+  (define-key nano-mu4e-mode-map (kbd "g r") #'nano-mu4e-rerun)
+
   ;; Let mu4e's and nano-mu4e's own keys through the modal layers.
   ;; Both meow-normal and evil-normal sit in emulation-mode-map-alists
   ;; above nano-mu4e's minor-mode map: meow suppresses unbound

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -93,12 +93,26 @@
   ;; everything else stays evil (j/k, "," leader, /-search, gg/G, :).
   ;; Main and view keep emacs state: they're menu/reading buffers whose
   ;; single-letter mu4e keys (s, r, f, q...) evil normal would eat.
+  ;; Article view: same arrangement as headers — evil normal with the
+  ;; view map overriding.  Free evil's essentials first: "," is the
+  ;; launch leader (was mu4e-sexp-at-point, a debug helper), k is
+  ;; line-up (save-url moves to g U), g becomes a prefix (go-to-url on
+  ;; g u, gg restored).
+  (define-key mu4e-view-mode-map (kbd ",") nil)
+  (define-key mu4e-view-mode-map (kbd "k") nil)
+  (define-key mu4e-view-mode-map (kbd "g") nil)
+  (define-key mu4e-view-mode-map (kbd "g g") #'beginning-of-buffer)
+  (define-key mu4e-view-mode-map (kbd "g u") #'mu4e-view-go-to-url)
+  (define-key mu4e-view-mode-map (kbd "g U") #'mu4e-view-save-url)
+
   (with-eval-after-load 'evil
     (evil-set-initial-state 'mu4e-headers-mode 'normal)
     (evil-make-overriding-map nano-mu4e-mode-map 'normal)
     (add-hook 'nano-mu4e-mode-hook #'evil-normalize-keymaps)
-    (dolist (mode '(mu4e-main-mode mu4e-view-mode))
-      (evil-set-initial-state mode 'emacs)))
+    (evil-set-initial-state 'mu4e-view-mode 'normal)
+    (evil-make-overriding-map mu4e-view-mode-map 'normal)
+    (add-hook 'mu4e-view-mode-hook #'evil-normalize-keymaps)
+    (evil-set-initial-state 'mu4e-main-mode 'emacs)))
 
   ;; Re-apply brushup styles now that the faces below exist.
   (when (fboundp 'brushup) (brushup))

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -30,6 +30,40 @@
   ;; notifications or list mail.
   (setq nano-mu4e-msg-preview t
         nano-mu4e-msg-preview-func #'nano-mu4e-msg-preview-p)
+
+  ;; Upstream bug: `nano-mu4e-msg-preview' binds charset inside its
+  ;; when-let*, so a MIME part with no explicit charset= parameter
+  ;; (RFC-legal, defaults to us-ascii) nils the chain and the preview
+  ;; silently disappears.  Corrected copy; drop when fixed upstream.
+  (defun zetta-nano-mu4e--msg-preview (&optional msg size)
+    "Extract a short preview from MSG, limiting it to SIZE characters."
+    (let* ((msg (or msg (mu4e-message-at-point)))
+           (size (or size 256))
+           (filename (mu4e-message-readable-path msg)))
+      (with-temp-buffer
+        (insert-file-contents-literally filename)
+        (let* ((handles (mm-dissect-buffer t)))
+          (unwind-protect
+              (when-let* ((handle (if (bufferp (car handles))
+                                      handles
+                                    (or (mm-find-part-by-type (cdr handles) "text/plain" nil t)
+                                        (mm-find-part-by-type (cdr handles) "text/html" nil t))))
+                          (media-type (mm-handle-media-type handle))
+                          (content (mm-get-part handle)))
+                (let ((charset (or (mail-content-type-get (mm-handle-type handle) 'charset)
+                                   'us-ascii)))
+                  (cond ((string= media-type "text/plain")
+                         (with-temp-buffer
+                           (insert (mm-decode-string content charset))
+                           (nano-mu4e-preview--process size)))
+                        ((string= media-type "text/html")
+                         (with-temp-buffer
+                           (insert (mm-decode-string content charset))
+                           (shr-render-region (point-min) (point-max))
+                           (nano-mu4e-preview--process size)))
+                        (t "No message body found"))))
+            (mm-destroy-parts handles))))))
+  (advice-add 'nano-mu4e-msg-preview :override #'zetta-nano-mu4e--msg-preview)
   :init
   (defvar zetta-nano-mu4e--fontset-done nil)
   (defun zetta-nano-mu4e--fontset (&optional frame)

--- a/modules/app/org-msg.el
+++ b/modules/app/org-msg.el
@@ -1,0 +1,22 @@
+;;; org-msg.el --- Configure org-msg -*- lexical-binding: t; -*-
+
+;; Compose mail in org-mode, delivered as multipart text+HTML.
+;; mu4e is set up in ~/.private.el (loaded eagerly before modules), so
+;; :after mu4e fires here without further deferral.
+
+(use-package org-msg
+  :if (executable-find "mu")
+  :ensure (org-msg :host github :repo "jeremy-compostella/org-msg")
+  :after mu4e
+  :config
+  (setq org-msg-options "html-postamble:nil H:5 num:nil ^:{} toc:nil author:nil email:nil \\n:t"
+        org-msg-startup "hidestars indent inlineimages"
+        ;; no boilerplate greeting/signature; write those yourself
+        org-msg-greeting-fmt nil
+        ;; reply in kind: org/HTML compose for HTML mail, plain for plain
+        org-msg-default-alternatives '((new . (text html))
+                                       (reply-to-html . (text html))
+                                       (reply-to-text . (text))))
+  (org-msg-mode))
+
+;;; org-msg.el ends here

--- a/modules/app/org-msg.el
+++ b/modules/app/org-msg.el
@@ -9,6 +9,11 @@
   :ensure (org-msg :host github :repo "jeremy-compostella/org-msg")
   :after mu4e
   :config
+  ;; org-msg picks its MUA integration from `mail-user-agent'; without
+  ;; this it wires itself to gnus/message and mu4e compose buffers stay
+  ;; plain mu4e-compose-mode.
+  (setq mail-user-agent 'mu4e-user-agent
+        read-mail-command 'mu4e)
   (setq org-msg-options "html-postamble:nil H:5 num:nil ^:{} toc:nil author:nil email:nil \\n:t"
         org-msg-startup "hidestars indent inlineimages"
         ;; no boilerplate greeting/signature; write those yourself

--- a/modules/editor/evil-collection.el
+++ b/modules/editor/evil-collection.el
@@ -3,6 +3,11 @@
 (use-package evil-collection
   :after evil
   :config
+  ;; app/nano-mu4e.el owns mu4e modal behavior (per-mode evil states +
+  ;; an evil-overriding nano-mu4e-mode-map).  evil-collection-mu4e's
+  ;; evil-define-key aux maps outrank that overriding map, hijacking
+  ;; C-j/C-k/g r — so keep its mu4e module out entirely.
+  (setq evil-collection-mode-list (remove 'mu4e evil-collection-mode-list))
   (evil-collection-init)
   (evil-set-initial-state 'org-agenda-mode 'normal))
 ;;; evil-collection.el ends here

--- a/modules/org/org-remark.el
+++ b/modules/org/org-remark.el
@@ -117,6 +117,44 @@ Builds the same string as elfeed's own store function: link
     (when (equal major-mode 'elfeed-show-mode)
       (my-org-remark-elfeed-link-string)))
 
+  ;; mu4e support
+  (defun my-org-remark-mu4e-link-string ()
+    "Org bracket link for the viewed mu4e message, without `org-store-link'.
+Message-ids are stable across re-syncs (unlike maildir paths, which
+Gmail moves around), so they make a durable source identity."
+    (let ((msg (mu4e-message-at-point)))
+      (org-link-make-string
+       (concat "mu4e:msgid:" (plist-get msg :message-id))
+       (or (plist-get msg :subject) "No subject"))))
+
+  (define-minor-mode org-remark-mu4e-mode
+    "Enable Org-remark to work with mu4e's article view."
+    :global t
+    :group 'org-remark-mu4e
+    (if org-remark-mu4e-mode
+        ;; Enable
+        (progn
+          (add-hook 'mu4e-view-rendered-hook #'org-remark-auto-on)
+          (add-hook 'org-remark-source-find-file-name-functions
+                    #'org-remark-mu4e-find-file-name)
+          (add-hook 'org-remark-highlight-link-to-source-functions
+                    #'org-remark-mu4e-highlight-link-to-source))
+      ;; Disable
+      (remove-hook 'mu4e-view-rendered-hook #'org-remark-auto-on)
+      (remove-hook 'org-remark-source-find-file-name-functions
+                   #'org-remark-mu4e-find-file-name)
+      (remove-hook 'org-remark-highlight-link-to-source-functions
+                   #'org-remark-mu4e-highlight-link-to-source)))
+
+  (defun org-remark-mu4e-find-file-name ()
+    (when (equal major-mode 'mu4e-view-mode)
+      (my-org-remark-transform-org-link-to-filename
+       (my-org-remark-mu4e-link-string))))
+
+  (defun org-remark-mu4e-highlight-link-to-source (_filename _point)
+    (when (equal major-mode 'mu4e-view-mode)
+      (my-org-remark-mu4e-link-string)))
+
   ;; Notes land in the synced kb tree, mirroring the readwise layout
   ;; (<source>/<middle-dimension>/<title-slug>.org) where it makes sense.
   (defvar my-org-remark-directory (expand-file-name "~/kb/org-remark/")
@@ -144,6 +182,16 @@ Builds the same string as elfeed's own store function: link
 
   (defun my-org-remark-notes-file-name ()
     (cond
+     ;; mu4e: sender domain is the middle dimension
+     ((eq major-mode 'mu4e-view-mode)
+      (let* ((msg (mu4e-message-at-point))
+             (from (mu4e-contact-email (car (mu4e-message-field msg :from))))
+             (domain (or (cadr (split-string (or from "") "@")) "unknown")))
+        (expand-file-name
+         (concat "mail/" domain "/"
+                 (my-org-remark-slugify (mu4e-message-field msg :subject))
+                 ".org")
+         my-org-remark-directory)))
      ;; Elfeed: feed domain is the middle dimension
      ((eq major-mode 'elfeed-show-mode)
       (let* ((id (elfeed-entry-id elfeed-show-entry))
@@ -201,6 +249,7 @@ Builds the same string as elfeed's own store function: link
   (org-remark-wombag-mode)
   (org-remark-elfeed-mode)
   (org-remark-pubmed-mode)
+  (org-remark-mu4e-mode)
   (use-package org-remark-info :ensure nil :after info
     :config (org-remark-info-mode +1))
   (use-package org-remark-eww  :ensure nil :after eww

--- a/modules/org/org.el
+++ b/modules/org/org.el
@@ -382,12 +382,21 @@ Set this in ~/.private.el before modules load.")
 ;;; org-capture configuration (deferred until org loads)
 (with-eval-after-load 'org
   (require 'org-capture)
+  ;; mu4e-org (ships with mu4e's site-lisp) registers mu4e: org links so
+  ;; %a from a mu4e buffer captures a link back to the message.
+  (when (locate-library "mu4e-org")
+    (require 'mu4e-org))
   (setq org-capture-templates
         (append
          '(("o" "Simple capture"
             entry
             (file "~/kb/inbox.org")
             "* %?\n%a"
+            :prepend t)
+           ("m" "Mail (capture message link)"
+            entry
+            (file "~/kb/inbox.org")
+            "* TODO %:fromname: %:subject\n%a\n%?"
             :prepend t))
          (zetta-logseq-generate-capture-templates)))
   (zetta-logseq-update-agenda-files))

--- a/source/bootstrap/bootstrap-modules.el
+++ b/source/bootstrap/bootstrap-modules.el
@@ -119,7 +119,8 @@ in the order they appear in the `zetta-modules!' declaration.")
             "bookmark.el" "bookmark+.el" "bookmark-in-project.el" "dogears.el"
             "olivetti.el" "activities.el" "spot4e.el" "elfeed.el" "wombag.el"
             "whisper.el" "say.el" "md4rd.el" "wttrin.el" "nov.el" "eca-emacs.el"
-            "mastodon.el" "erc.el" "eww.el" "nano-mu4e.el" "flappy-fish.el" "speed-type.el"
+            "mastodon.el" "erc.el" "eww.el" "nano-mu4e.el" "mu4e-dashboard.el"
+            "org-msg.el" "flappy-fish.el" "speed-type.el"
             "spray.el" "touchtype.el" "key-quiz.el"))
     (org . ("org.el" "org-ql.el" "org-capture.el" "org-ref.el" "ob-mermaid.el"
             "pdf-tools.el" "biblio.el" "citar.el" "org-remark.el"

--- a/source/bootstrap/bootstrap-modules.el
+++ b/source/bootstrap/bootstrap-modules.el
@@ -119,7 +119,7 @@ in the order they appear in the `zetta-modules!' declaration.")
             "bookmark.el" "bookmark+.el" "bookmark-in-project.el" "dogears.el"
             "olivetti.el" "activities.el" "spot4e.el" "elfeed.el" "wombag.el"
             "whisper.el" "say.el" "md4rd.el" "wttrin.el" "nov.el" "eca-emacs.el"
-            "mastodon.el" "erc.el" "eww.el" "flappy-fish.el" "speed-type.el"
+            "mastodon.el" "erc.el" "eww.el" "nano-mu4e.el" "flappy-fish.el" "speed-type.el"
             "spray.el" "touchtype.el" "key-quiz.el"))
     (org . ("org.el" "org-ql.el" "org-capture.el" "org-ref.el" "ob-mermaid.el"
             "pdf-tools.el" "biblio.el" "citar.el" "org-remark.el"


### PR DESCRIPTION
## Summary
Three mail modules plus supporting config:

- **modules/app/nano-mu4e.el** — [rougier/nano-mu4e](https://github.com/rougier/nano-mu4e) boxed/threaded headers view, hooked into `mu4e-headers-mode`; NERD PUA glyph ranges fontset-routed to Terminess Nerd Font Mono (Terminus has no PUA coverage).
- **modules/app/org-msg.el** — org-mode HTML mail composing; reply-in-kind alternatives, no boilerplate greeting/signature.
- **modules/app/mu4e-dashboard.el** — [rougier/mu4e-dashboard](https://github.com/rougier/mu4e-dashboard) org-based mail dashboard on `launch-map M`; the dashboard org file is personal and untracked (`~/.mu4e-dashboard.org`).
- **modules/org/org.el** — require `mu4e-org` for `mu4e:` org links; new `m` capture template that links back to the captured message.
- **elpaca-lock.el** — pins for nano-mu4e `068086f`, org-msg `7b45df7`, mu4e-dashboard `d40f501`.

## Notes
- mu4e is provided by the homebrew mu site-lisp, not any elpaca menu, so mu4e-dependent modules add `mu4e` to `elpaca-ignored-dependencies` at top level (the use-package body runs post-install — too late).
- Like consult-mu, these packages run uncompiled: elpaca's compile subprocess is `emacs -Q --batch` with no site-lisp, so their `(require 'mu4e)` compile errors are logged and tolerated.
- Lockfile entries hand-added because local `bin/zetta freeze` currently dies in `bootstrap-keys` under `--batch` (`use-package-ensure-function` reverts to package.el despite `elpaca-use-package-mode` being on) — pre-existing, unrelated.

## Verification
- All three installed and verified live in the running daemon (features load, hooks/keybindings active, org-msg-mode on, capture template registered).
- Lockfile round-trips: 340 entries parse, all three refs read back correctly.