### PR TITLE
Mail, reddit, feeds, capture, and reading-stack overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ tree-sitter
 modules/**/*.elc
 source/**/*.elc
 
+# Runtime caches
+nano-mu4e-preview-cache.eld
+
 # Package manager caches
 elpaca/builds/
 elpaca/repos/

--- a/elfeed.org
+++ b/elfeed.org
@@ -193,3 +193,6 @@
 ** [[https://old.reddit.com/r/eink/.rss][r/eink]] :reddit:eink:
 ** [[https://www.chiply.dev/rss.xml][Charlie Holland's Blog]] :myblog:
 ** [[https://toobnix.org/feeds/videos.xml?videoChannelName=screwtape_channel][Lispy Gopher Climate extras]] :peertube:lisp:emacs:
+** [[https://fosstodon.org/tags/emacs.rss][Mastodon #emacs]] :mastodon:emacs:
+** [[https://mathstodon.xyz/@oantolin.rss][Omar Antolín (@oantolin@mathstodon.xyz)]] :mastodon:emacs:oantolin:
+** [[https://lobste.rs/t/emacs.rss][Lobsters #emacs]] :lobsters:emacs:

--- a/elpaca-lock.el
+++ b/elpaca-lock.el
@@ -166,6 +166,12 @@
                      :type git :protocol https :inherit t :depth
                      treeless :ref
                      "a755afa7db7f3fa515f8dd2c0518113be0b027f6"))
+ (anki :source "elpaca-menu-lock-file" :recipe
+       (:source nil :package "anki" :id anki :host github :repo
+                "chenyanming/anki.el" :build
+                (:not elpaca--byte-compile) :type git :protocol https
+                :inherit t :depth treeless :ref
+                "cc26dcf38ab6f7d566dd8049590f07321176bc80"))
  (annalist :source "elpaca-menu-lock-file" :recipe
            (:package "annalist" :fetcher github :repo
                      "noctuid/annalist.el" :files
@@ -1403,10 +1409,10 @@
  (flamegraph :source "elpaca-menu-lock-file" :recipe
              (:package "flamegraph" :repo "dgutov/emacs-flamegraph"
                        :tar "0.2" :host github :files
-                       ("*" (:exclude ".git")) :source "NonGNU ELPA"
-                       :id flamegraph :type git :protocol https
-                       :inherit t :depth treeless :ref
-                       "4ce420f28663fc11a979c5b665db69d46471f6bc"))
+                       ("*" (:exclude ".git")) :source
+                       "elpaca-menu-lock-file" :id flamegraph :type
+                       git :protocol https :inherit t :depth treeless
+                       :ref "4ce420f28663fc11a979c5b665db69d46471f6bc"))
  (flycheck :source "elpaca-menu-lock-file" :recipe
            (:package "flycheck" :repo "flycheck/flycheck" :fetcher
                      github :files

--- a/elpaca-lock.el
+++ b/elpaca-lock.el
@@ -3039,6 +3039,19 @@
                        :type git :protocol https :inherit t :depth
                        treeless :ref
                        "482789397c5e11dbb95438c87ccd0cad3d37a33a"))
+ (promise :source "elpaca-menu-lock-file" :recipe
+          (:package "promise" :repo "chuntaro/emacs-promise" :fetcher
+                    github :files
+                    ("*.el" "*.el.in" "dir" "*.info" "*.texi"
+                     "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
+                     "doc/*.texinfo" "lisp/*.el" "docs/dir"
+                     "docs/*.info" "docs/*.texi" "docs/*.texinfo"
+                     (:exclude ".dir-locals.el" "test.el" "tests.el"
+                               "*-test.el" "*-tests.el" "LICENSE"
+                               "README*" "*-pkg.el"))
+                    :source "MELPA" :id promise :type git :protocol
+                    https :inherit t :depth treeless :ref
+                    "cec51feb5f957e8febe6325335cf57dc2db6be30"))
  (pubmed :source "elpaca-menu-lock-file" :recipe
          (:package "pubmed" :fetcher gitlab :repo
                    "fvdbeek/emacs-pubmed" :files
@@ -3138,6 +3151,19 @@
                                 :protocol https :inherit t :depth
                                 treeless :ref
                                 "4805275937585102aba0047169f047032201c5b9"))
+ (reddigg :source "elpaca-menu-lock-file" :recipe
+          (:package "reddigg" :fetcher github :repo
+                    "thanhvg/emacs-reddigg" :files
+                    ("*.el" "*.el.in" "dir" "*.info" "*.texi"
+                     "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
+                     "doc/*.texinfo" "lisp/*.el" "docs/dir"
+                     "docs/*.info" "docs/*.texi" "docs/*.texinfo"
+                     (:exclude ".dir-locals.el" "test.el" "tests.el"
+                               "*-test.el" "*-tests.el" "LICENSE"
+                               "README*" "*-pkg.el"))
+                    :source "MELPA" :id reddigg :host github :type git
+                    :protocol https :inherit t :depth treeless :ref
+                    "4d22e06a6e2523fe6d83c0280847d3bde19fabb5"))
  (repeatable :source "elpaca-menu-lock-file" :recipe
              (:source "elpaca-menu-lock-file" :package "repeatable"
                       :id repeatable :host github :repo

--- a/elpaca-lock.el
+++ b/elpaca-lock.el
@@ -334,8 +334,9 @@
                      (:exclude ".dir-locals.el" "test.el" "tests.el"
                                "*-test.el" "*-tests.el" "LICENSE"
                                "README*" "*-pkg.el"))
-                    :source "MELPA" :id bluesky :host github :type git
-                    :protocol https :inherit t :depth treeless :ref
+                    :source "elpaca-menu-lock-file" :id bluesky :host
+                    github :type git :protocol https :inherit t :depth
+                    treeless :ref
                     "b4b7957a3af0533918535486f44afcb808d38d24"))
  (bookmark+ :source "elpaca-menu-lock-file" :recipe
             (:source "elpaca-menu-lock-file" :package "bookmark+" :id
@@ -1399,6 +1400,13 @@
                               fancy-compilation :type git :protocol
                               https :inherit t :depth treeless :ref
                               "502d36e0fb4c4daedc16ea5d732dcbc8285d6fb1"))
+ (flamegraph :source "elpaca-menu-lock-file" :recipe
+             (:package "flamegraph" :repo "dgutov/emacs-flamegraph"
+                       :tar "0.2" :host github :files
+                       ("*" (:exclude ".git")) :source "NonGNU ELPA"
+                       :id flamegraph :type git :protocol https
+                       :inherit t :depth treeless :ref
+                       "4ce420f28663fc11a979c5b665db69d46471f6bc"))
  (flycheck :source "elpaca-menu-lock-file" :recipe
            (:package "flycheck" :repo "flycheck/flycheck" :fetcher
                      github :files
@@ -1493,9 +1501,9 @@
         (:package "futur" :repo
                   ("https://github.com/emacsmirror/gnu_elpa" . "futur")
                   :tar "1.7" :host gnu :branch "externals/futur"
-                  :files ("*" (:exclude ".git")) :source "GNU ELPA"
-                  :id futur :type git :protocol https :inherit t
-                  :depth treeless :ref
+                  :files ("*" (:exclude ".git")) :source
+                  "elpaca-menu-lock-file" :id futur :type git
+                  :protocol https :inherit t :depth treeless :ref
                   "71e45426889d6c9bf61ad906ddb999c1a7aa2b3f"))
  (gcmh :source "elpaca-menu-lock-file" :recipe
        (:package "gcmh" :repo "koral/gcmh" :fetcher gitlab :files
@@ -3864,8 +3872,8 @@
                  (:exclude ".dir-locals.el" "test.el" "tests.el"
                            "*-test.el" "*-tests.el" "LICENSE"
                            "README*" "*-pkg.el"))
-                :source "MELPA" :id vui :type git :protocol https
-                :inherit t :depth treeless :ref
+                :source "elpaca-menu-lock-file" :id vui :type git
+                :protocol https :inherit t :depth treeless :ref
                 "9101db52a29c4276b45f85e63924008f0e41c39c"))
  (web-mode :source "elpaca-menu-lock-file" :recipe
            (:package "web-mode" :repo "fxbois/web-mode" :fetcher

--- a/elpaca-lock.el
+++ b/elpaca-lock.el
@@ -324,6 +324,19 @@
                    :source "elpaca-menu-lock-file" :id blamer :type
                    git :protocol https :inherit t :depth treeless :ref
                    "aa9b22d4e847d15a5c4659c0407aa8bf4242cc94"))
+ (bluesky :source "elpaca-menu-lock-file" :recipe
+          (:package "bluesky" :fetcher github :repo
+                    "ahyatt/emacs-bluesky" :files
+                    ("*.el" "*.el.in" "dir" "*.info" "*.texi"
+                     "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
+                     "doc/*.texinfo" "lisp/*.el" "docs/dir"
+                     "docs/*.info" "docs/*.texi" "docs/*.texinfo"
+                     (:exclude ".dir-locals.el" "test.el" "tests.el"
+                               "*-test.el" "*-tests.el" "LICENSE"
+                               "README*" "*-pkg.el"))
+                    :source "MELPA" :id bluesky :host github :type git
+                    :protocol https :inherit t :depth treeless :ref
+                    "b4b7957a3af0533918535486f44afcb808d38d24"))
  (bookmark+ :source "elpaca-menu-lock-file" :recipe
             (:source "elpaca-menu-lock-file" :package "bookmark+" :id
                      bookmark+ :fetcher github :repo
@@ -1476,6 +1489,14 @@
                           fringe-helper :type git :protocol https
                           :inherit t :depth treeless :ref
                           "ef4a9c023bae18ec1ddd7265f1f2d6d2e775efdd"))
+ (futur :source "elpaca-menu-lock-file" :recipe
+        (:package "futur" :repo
+                  ("https://github.com/emacsmirror/gnu_elpa" . "futur")
+                  :tar "1.7" :host gnu :branch "externals/futur"
+                  :files ("*" (:exclude ".git")) :source "GNU ELPA"
+                  :id futur :type git :protocol https :inherit t
+                  :depth treeless :ref
+                  "71e45426889d6c9bf61ad906ddb999c1a7aa2b3f"))
  (gcmh :source "elpaca-menu-lock-file" :recipe
        (:package "gcmh" :repo "koral/gcmh" :fetcher gitlab :files
                  ("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo"
@@ -3049,9 +3070,9 @@
                      (:exclude ".dir-locals.el" "test.el" "tests.el"
                                "*-test.el" "*-tests.el" "LICENSE"
                                "README*" "*-pkg.el"))
-                    :source "MELPA" :id promise :type git :protocol
-                    https :inherit t :depth treeless :ref
-                    "cec51feb5f957e8febe6325335cf57dc2db6be30"))
+                    :source "elpaca-menu-lock-file" :id promise :type
+                    git :protocol https :inherit t :depth treeless
+                    :ref "cec51feb5f957e8febe6325335cf57dc2db6be30"))
  (pubmed :source "elpaca-menu-lock-file" :recipe
          (:package "pubmed" :fetcher gitlab :repo
                    "fvdbeek/emacs-pubmed" :files
@@ -3161,8 +3182,9 @@
                      (:exclude ".dir-locals.el" "test.el" "tests.el"
                                "*-test.el" "*-tests.el" "LICENSE"
                                "README*" "*-pkg.el"))
-                    :source "MELPA" :id reddigg :host github :type git
-                    :protocol https :inherit t :depth treeless :ref
+                    :source "elpaca-menu-lock-file" :id reddigg :host
+                    github :type git :protocol https :inherit t :depth
+                    treeless :ref
                     "4d22e06a6e2523fe6d83c0280847d3bde19fabb5"))
  (repeatable :source "elpaca-menu-lock-file" :recipe
              (:source "elpaca-menu-lock-file" :package "repeatable"
@@ -3833,6 +3855,18 @@
                                 :protocol https :inherit t :depth
                                 treeless :ref
                                 "f68ac37451c1226d6f13c1b299ec7516f74888a1"))
+ (vui :source "elpaca-menu-lock-file" :recipe
+      (:package "vui" :fetcher github :repo "d12frosted/vui.el" :files
+                ("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo"
+                 "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
+                 "lisp/*.el" "docs/dir" "docs/*.info" "docs/*.texi"
+                 "docs/*.texinfo"
+                 (:exclude ".dir-locals.el" "test.el" "tests.el"
+                           "*-test.el" "*-tests.el" "LICENSE"
+                           "README*" "*-pkg.el"))
+                :source "MELPA" :id vui :type git :protocol https
+                :inherit t :depth treeless :ref
+                "9101db52a29c4276b45f85e63924008f0e41c39c"))
  (web-mode :source "elpaca-menu-lock-file" :recipe
            (:package "web-mode" :repo "fxbois/web-mode" :fetcher
                      github :files

--- a/init.el
+++ b/init.el
@@ -69,9 +69,11 @@ See .private.sample.el for an example.")
             (e-user (plist-get entry :user))
             (e-port (plist-get entry :port))
             (e-key  (plist-get entry :key)))
-        (when (and (or (null host) (equal host e-host))
-                   (or (null user) (equal user e-user))
-                   (or (null port) (equal port e-port)))
+        ;; t in a spec slot is auth-source's wildcard ("present, any
+        ;; value") — emacs-bluesky searches with :user t.
+        (when (and (or (null host) (eq host t) (equal host e-host))
+                   (or (null user) (eq user t) (equal user e-user))
+                   (or (null port) (eq port t) (equal port e-port)))
           (let ((secret-key e-key))
             (push (list :host e-host
                         :user e-user

--- a/modules/app/anki.el
+++ b/modules/app/anki.el
@@ -1,0 +1,171 @@
+;;; anki.el --- Configure anki.el flashcard reviewer -*- lexical-binding: t; -*-
+
+;; Review Anki decks inside Emacs with anki.el (chenyanming/anki.el).
+;; It reads a collection directory (collection.anki2 + collection.media),
+;; not .apkg archives, so `zetta-anki-open-apkg' imports an .apkg into
+;; `zetta-anki-cache-dir' (one subdir per deck), repairs the
+;; system-design-primer's dead camo.githubusercontent.com image links,
+;; and starts a review session.  `M-x anki' resumes the current deck.
+
+(require 'hex-util)
+
+(declare-function anki "anki")
+(declare-function emacsql-close "emacsql")
+(defvar anki-collection-dir)
+(defvar anki-search-entries)
+(defvar anki-full-entries)
+(defvar anki-number)
+(defvar anki-core-db-connection)
+
+(defvar zetta-anki-cache-dir (expand-file-name "~/.cache/emacs-anki/")
+  "Directory where .apkg archives are extracted, one subdir per deck.")
+
+(defun zetta-anki--emacsql-shim ()
+  "Provide the emacsql-sqlite library anki.el requires.
+emacsql 4.x (installed for forge) dropped emacsql-sqlite.el; the
+built-in-sqlite backend has the same constructor signature, so alias
+it and mark the feature as provided."
+  (unless (featurep 'emacsql-sqlite)
+    (require 'emacsql-sqlite-builtin)
+    (defalias 'emacsql-sqlite #'emacsql-sqlite-builtin)
+    (provide 'emacsql-sqlite)))
+
+(defun zetta-anki--repair-media (db-file media-dir)
+  "Localize remote card images in DB-FILE into MEDIA-DIR.
+anki.el resolves every <img src> against collection.media, so remote
+URLs can never render.  Rewrite each remote src (including the
+primer's dead camo.githubusercontent.com proxy links, whose hex
+payload decodes to the real imgur URL) to a bare filename and
+download the image into MEDIA-DIR.  Return (NOTES-CHANGED . FILES)."
+  (let ((db (sqlite-open db-file))
+        (urls nil)                      ; filename -> source url
+        (fixed 0))
+    (unwind-protect
+        (dolist (row (sqlite-select db "SELECT id, flds FROM notes"))
+          (let* ((id (car row))
+                 (flds (cadr row))
+                 (new (with-temp-buffer
+                        (insert flds)
+                        ;; Camo proxy links: recover the original URL.
+                        (goto-char (point-min))
+                        (while (re-search-forward
+                                "https?://camo\\.githubusercontent\\.com/[0-9a-f]+/\\([0-9a-f]+\\)"
+                                nil t)
+                          (replace-match (decode-hex-string (match-string 1))
+                                         t t))
+                        ;; Any remote src: note it for download, then
+                        ;; refer to it by bare filename.
+                        (goto-char (point-min))
+                        (while (re-search-forward
+                                "src=\"\\(https?://[^\"]+/\\([^\"/?]+\\)\\)\""
+                                nil t)
+                          (let ((url (replace-regexp-in-string
+                                      "\\`http://" "https://" (match-string 1)))
+                                (name (match-string 2)))
+                            (push (cons name url) urls)
+                            (replace-match (format "src=\"%s\"" name) t t)))
+                        (buffer-string))))
+            (unless (equal new flds)
+              (sqlite-execute db "UPDATE notes SET flds = ? WHERE id = ?"
+                              (list new id))
+              (setq fixed (1+ fixed)))))
+      (sqlite-close db))
+    (let ((files 0))
+      (pcase-dolist (`(,name . ,url) (delete-dups urls))
+        (let ((target (expand-file-name name media-dir)))
+          (unless (file-exists-p target)
+            (message "anki: fetching %s..." name)
+            (when (ignore-errors (url-copy-file url target) t)
+              (setq files (1+ files))))))
+      (cons fixed files))))
+
+(defun zetta-anki-open-apkg (apkg)
+  "Import APKG into `zetta-anki-cache-dir' and start reviewing it.
+An already-imported deck is reused as-is (delete its subdir under
+`zetta-anki-cache-dir' to force a fresh import).  Each .apkg is a
+separate collection; run this command again to switch decks."
+  (interactive
+   (list (read-file-name "Open .apkg: " nil nil t nil
+                         (lambda (f)
+                           (or (file-directory-p f)
+                               (string-suffix-p ".apkg" f t))))))
+  (zetta-anki--emacsql-shim)
+  (require 'anki)
+  (let* ((slug (replace-regexp-in-string "[^[:alnum:]]+" "-"
+                                         (downcase (file-name-base apkg))))
+         (dest (expand-file-name slug zetta-anki-cache-dir))
+         (db (expand-file-name "collection.anki2" dest)))
+    (unless (file-exists-p db)
+      (make-directory dest t)
+      (with-temp-buffer
+        (unless (zerop (call-process "unzip" nil t nil "-o"
+                                     (expand-file-name apkg) "-d" dest))
+          (error "unzip failed: %s" (buffer-string))))
+      (make-directory (expand-file-name "collection.media" dest) t)
+      (pcase-let ((`(,notes . ,files)
+                   (zetta-anki--repair-media
+                    db (expand-file-name "collection.media" dest))))
+        (when (> notes 0)
+          (message "anki: localized images in %d notes (%d files fetched)"
+                   notes files))))
+    (make-directory (expand-file-name "collection.media" dest) t)
+    ;; Reset per-collection state so switching decks doesn't leak the
+    ;; previous collection's cards or write review history to its db.
+    (when (bound-and-true-p anki-core-db-connection)
+      (ignore-errors (emacsql-close anki-core-db-connection))
+      (setq anki-core-db-connection nil))
+    (setq anki-search-entries nil
+          anki-full-entries nil
+          anki-number 0)
+    (setq anki-collection-dir dest)
+    (anki)))
+
+(use-package anki
+  ;; anki-core.el requires emacsql-sqlite at compile time, which no
+  ;; longer exists as a library; skip byte-compilation and rely on the
+  ;; runtime shim instead.
+  :ensure (:host github :repo "chenyanming/anki.el"
+           :build (:not elpaca--byte-compile))
+  :commands (anki anki-browser anki-list-decks)
+  :init
+  (with-eval-after-load 'emacsql (zetta-anki--emacsql-shim))
+  :config
+  (setq sql-sqlite-program (or (executable-find "sqlite3") "/usr/bin/sqlite3"))
+  (setq anki-audio-player (executable-find "afplay")))
+
+;; The review buffers bind plain keys (f, 1-4, n/p, q) on their mode
+;; maps; start them in emacs state so evil doesn't shadow them.
+(with-eval-after-load 'evil
+  (evil-set-initial-state 'anki-mode 'emacs)
+  (evil-set-initial-state 'anki-card-mode 'emacs)
+  (evil-set-initial-state 'anki-search-mode 'emacs))
+
+(with-eval-after-load 'anki-card
+  ;; Upstream bug: anki-render-img funcalls this for external image
+  ;; URLs, but no code ever defines it.  Capture the real renderer
+  ;; here, before anki's cl-letf override is in effect.
+  (defvar anki-original-shr-tag-img-function (symbol-function 'shr-tag-img))
+
+  ;; Upstream bug: anki-insert-image destructures with dash's -let*
+  ;; without requiring dash, so the shipped definition is broken (and
+  ;; compiles to garbage when dash isn't on the build load-path).
+  ;; Replace it with a dash-free equivalent.
+  (defun anki-insert-image (path alt)
+    "Insert the image at PATH, falling back to ALT text."
+    (let* ((edges (and (display-images-p)
+                       (file-exists-p path)
+                       (window-inside-pixel-edges
+                        (get-buffer-window (current-buffer) t))))
+           (image (and edges
+                       (ignore-errors
+                         (create-image
+                          path nil nil
+                          :ascent 100
+                          :max-width (truncate (* shr-max-image-proportion
+                                                  (- (nth 2 edges) (nth 0 edges))))
+                          :max-height (truncate (* shr-max-image-proportion
+                                                   (- (nth 3 edges) (nth 1 edges)))))))))
+      (if image
+          (insert-image image)
+        (insert alt)))))
+;;; anki.el ends here

--- a/modules/app/bluesky.el
+++ b/modules/app/bluesky.el
@@ -8,8 +8,11 @@
 ;; 1Password auth-source backend (init.el) via the guarded entry in
 ;; ~/.private.el — fields handle/app-password on op://Dev/Bluesky.
 
-(use-package bluesky
-  :ensure (bluesky :host github :repo "ahyatt/emacs-bluesky")
-  :commands (bluesky))
+;; Package-Requires (emacs "30.1") — skip entirely on older Emacsen
+;; (the CI matrix includes 29.4, where elpaca would fail the build).
+(when (version<= "30.1" emacs-version)
+  (use-package bluesky
+    :ensure (bluesky :host github :repo "ahyatt/emacs-bluesky")
+    :commands (bluesky)))
 
 ;;; bluesky.el ends here

--- a/modules/app/bluesky.el
+++ b/modules/app/bluesky.el
@@ -1,0 +1,15 @@
+;;; bluesky.el --- Configure bluesky -*- lexical-binding: t; -*-
+
+;; ahyatt/emacs-bluesky: timeline, threads, posting, replies.
+;;
+;; Auth: M-x bluesky looks up auth-source for `bluesky-default-host'
+;; (bsky.social) with the handle as user and a Bluesky app password
+;; (bsky.app → Settings → App Passwords) as secret.  Served by the
+;; 1Password auth-source backend (init.el) via the guarded entry in
+;; ~/.private.el — fields handle/app-password on op://Dev/Bluesky.
+
+(use-package bluesky
+  :ensure (bluesky :host github :repo "ahyatt/emacs-bluesky")
+  :commands (bluesky))
+
+;;; bluesky.el ends here

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -187,6 +187,8 @@ minibuffer with something like `exit-minibuffer'."
             ;; changes for old entries (fever's API has no better way).
             (evil-local-set-key 'normal "R" #'elfeed-update)
             (evil-local-set-key 'normal "gR" #'elfeed-protocol-fever-reinit)
+            ;; md4rd comments for the reddit entry at point (md4rd.el)
+            (evil-local-set-key 'normal "gc" #'md4rd-elfeed-search-reddit-comments)
             (evil-local-set-key 'normal "tt" #'prot-elfeed-search-tag-filter)
             ;; quick filters
             (evil-local-set-key 'normal "fu" (my-elfeed-filter "@6-months-ago +unread"))

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -809,4 +809,29 @@ can be a moved feed rather than one to delete."
     (message "miniflux-sync: %d added, %d failed, %d only-remote%s"
              (length added) (length failed) (length extra)
              (if dry-run " (dry run — nothing written)" ""))))
+
+;;; Org backlinks from elfeed — `org-store-link' (and so capture's %a)
+;; has no backend for elfeed buffers.  Store the entry's web URL with
+;; its title: portable https link, opens in the browser, survives the
+;; entry aging out of the elfeed db.
+(with-eval-after-load 'ol
+  (defun zetta-org-elfeed-store-link (&optional _interactive)
+    "Store the elfeed entry (shown, or at point in search) as an org link.
+Org 9.7+ calls :store functions with an INTERACTIVE? argument."
+    (when-let* ((entry (cond ((derived-mode-p 'elfeed-show-mode)
+                              (bound-and-true-p elfeed-show-entry))
+                             ((derived-mode-p 'elfeed-search-mode)
+                              (car (elfeed-search-selected)))))
+                (link (elfeed-entry-link entry)))
+      (org-link-store-props
+       :type "https"
+       :link link
+       :description (elfeed-entry-title entry))))
+  (org-link-set-parameters "elfeed-entry" :store #'zetta-org-elfeed-store-link)
+  ;; elfeed's own elfeed-link.el backend competes and wins: in search
+  ;; buffers it stores the FILTER (not the entry), and its elfeed: links
+  ;; die when entries age out of the db.  Drop its :store; keep :follow
+  ;; so existing elfeed: links still open.
+  (with-eval-after-load 'elfeed-link
+    (org-link-set-parameters "elfeed" :store nil)))
 ;;; elfeed.el ends here

--- a/modules/app/elfeed.el
+++ b/modules/app/elfeed.el
@@ -705,4 +705,108 @@ reset, which permanently wedges background updates."
                  (run-with-timer zetta-elfeed-auto-update-interval
                                  zetta-elfeed-auto-update-interval
                                  #'zetta-elfeed--auto-update))))))
+
+;;; Miniflux feed sync — elfeed.org is the single source of truth.
+;;
+;; Feeds were maintained in two places: subscribe in the Miniflux GUI,
+;; then mirror into elfeed.org for tags.  Instead, edit elfeed.org
+;; only and push the diff to Miniflux over its REST API (the v1 API,
+;; not the Fever endpoint elfeed reads).  Additive by design: feeds
+;; missing from Miniflux are added; feeds Miniflux has but the org
+;; file doesn't are only REPORTED, never deleted.
+;;
+;; Needs `zetta-miniflux-api-key' (Miniflux Settings → API keys),
+;; served from 1Password in ~/.private.el.
+
+(defvar url-http-end-of-headers)
+(defvar url-http-response-status)
+
+(defvar zetta-miniflux-api-url "https://reader.miniflux.app/v1"
+  "Base URL of the Miniflux REST API.")
+
+(defvar zetta-miniflux-api-key nil
+  "Miniflux API key (Settings → API keys).  Set from 1Password.")
+
+(defun zetta-miniflux--request (method endpoint &optional payload)
+  "Make a synchronous Miniflux API METHOD request to ENDPOINT.
+PAYLOAD, when given, is JSON-encoded as the request body.  Return
+the parsed JSON response (alists/lists), or nil for empty bodies.
+Signal an error on non-2xx responses."
+  (unless zetta-miniflux-api-key
+    (user-error "zetta-miniflux-api-key is not set (op://Dev/Miniflux/api-key)"))
+  (let* ((url-request-method method)
+         (url-request-data
+          (and payload (encode-coding-string (json-encode payload) 'utf-8)))
+         (url-request-extra-headers
+          `(("X-Auth-Token" . ,zetta-miniflux-api-key)
+            ("Content-Type" . "application/json")))
+         (buf (url-retrieve-synchronously
+               (concat zetta-miniflux-api-url endpoint) t nil 30)))
+    (unless buf (error "Miniflux: no response from %s" endpoint))
+    (with-current-buffer buf
+      (unwind-protect
+          (progn
+            (goto-char url-http-end-of-headers)
+            (if (and (>= url-http-response-status 200)
+                     (< url-http-response-status 300))
+                (unless (eobp)
+                  (json-parse-buffer :object-type 'alist :array-type 'list))
+              (error "Miniflux %s %s → %d: %s" method endpoint
+                     url-http-response-status
+                     (buffer-substring-no-properties
+                      (point) (min (point-max) (+ (point) 200))))))
+        (kill-buffer buf)))))
+
+(defun zetta-elfeed-org-feed-urls ()
+  "Return the feed URLs from `rmh-elfeed-org-files'."
+  (let (urls)
+    (dolist (file rmh-elfeed-org-files)
+      (with-temp-buffer
+        (insert-file-contents file)
+        (goto-char (point-min))
+        (while (re-search-forward "\\[\\[\\(https?://[^]]+\\)\\]" nil t)
+          (push (match-string-no-properties 1) urls))))
+    (nreverse urls)))
+
+(defun zetta-elfeed-miniflux-sync (&optional dry-run)
+  "Add feeds from elfeed.org that Miniflux doesn't have; report the diff.
+With prefix argument DRY-RUN, only report.  Feeds present in
+Miniflux but absent from elfeed.org are listed for manual review —
+Miniflux may rewrite a feed URL after redirects, so an entry there
+can be a moved feed rather than one to delete."
+  (interactive "P")
+  (let* ((org-urls (zetta-elfeed-org-feed-urls))
+         (remote (zetta-miniflux--request "GET" "/feeds"))
+         (remote-urls (mapcar (lambda (f) (alist-get 'feed_url f)) remote))
+         (missing (cl-set-difference org-urls remote-urls :test #'equal))
+         (extra (cl-set-difference remote-urls org-urls :test #'equal))
+         (category-id (alist-get 'id (car (zetta-miniflux--request "GET" "/categories"))))
+         (added nil) (failed nil))
+    (unless dry-run
+      (dolist (url missing)
+        (condition-case err
+            (progn
+              (zetta-miniflux--request
+               "POST" "/feeds" `((feed_url . ,url) (category_id . ,category-id)))
+              (push url added))
+          (error (push (cons url (error-message-string err)) failed)))))
+    (with-current-buffer (get-buffer-create "*miniflux-sync*")
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (format "Miniflux sync %s— org: %d feeds, miniflux: %d feeds\n\n"
+                        (if dry-run "(dry run) " "") (length org-urls) (length remote-urls)))
+        (insert (format "* In elfeed.org, missing from Miniflux (%d)%s:\n"
+                        (length missing) (if dry-run "" " — added")))
+        (dolist (url missing) (insert "  " url "\n"))
+        (when failed
+          (insert (format "\n* FAILED to add (%d) — dead feed or bad URL:\n" (length failed)))
+          (dolist (f failed) (insert "  " (car f) "\n    " (cdr f) "\n")))
+        (insert (format "\n* In Miniflux, not in elfeed.org (%d) — review manually:\n"
+                        (length extra)))
+        (dolist (url extra) (insert "  " url "\n"))
+        (special-mode))
+      (display-buffer (current-buffer)))
+    (message "miniflux-sync: %d added, %d failed, %d only-remote%s"
+             (length added) (length failed) (length extra)
+             (if dry-run " (dry run — nothing written)" ""))))
 ;;; elfeed.el ends here

--- a/modules/app/hyperbole.el
+++ b/modules/app/hyperbole.el
@@ -71,6 +71,30 @@ every file."
           result))
     result))
 
+;; --- HyRolo: retrieve matches WITH their ancestors ---
+;; HyRolo retrieval is downward-only: a match pulls in its entry plus all
+;; descendants, never the ancestor headings above it (verified empirically,
+;; 2026-08-06).  The logical-search engine can do better: with its
+;; INCLUDE-SUB-ENTRIES flag, `hyrolo-fgrep-logical' evaluates the query over
+;; each entry's whole subtree starting from the top level, so a deep match
+;; causes the top-level ancestor to match and the entire hierarchy is
+;; emitted -- ancestors, descendants, and siblings within that tree.  No
+;; defcustom exposes this, and the interactive spec feeds the same prefix
+;; arg to both COUNT-ONLY and INCLUDE-SUB-ENTRIES (so {C-u} gets you a
+;; count, not the hierarchy) -- hence this wrapper.  Caveat: unlike the
+;; consult-driven greps (ripgrep), the logic engine loads and scans every
+;; rolo file in elisp, so a search over the full ~/kb file list blocks for
+;; a while -- expect seconds, not instant.
+
+(defun zetta-hyrolo-grep-with-ancestors (term)
+  "HyRolo search for TERM, retrieving the full hierarchy around each match.
+Unlike `hyrolo-grep'/`hyrolo-fgrep', whose results show only the matching
+entry and its descendants, this emits the entire top-level record tree
+containing each match, ancestor headings included.  TERM is a plain string;
+multi-word terms match as an exact phrase."
+  (interactive "sFind rolo term (with ancestors): ")
+  (hyrolo-fgrep-logical (format "(and %S)" term) nil t))
+
 ;; --- HyWiki: make sure a WikiWord always has a real page file on disk ---
 ;; HyWiki writes a page file when it first creates the page, but a WikiWord can
 ;; end up registered in its referent hash with no file behind it -- the hash and
@@ -280,7 +304,9 @@ otherwise appear as a bogus `zsh#...' completion candidate."
 
   ;; --- HyRolo: search the Logseq pages as the rolo source ---
   (setq hyrolo-file-list '("~/.rolo.org" "~/kb/notes/" "~/kb/wiki/"
-                           "~/kb/todo/" "~/kb/inbox.org"))
+                           "~/kb/todo/" "~/kb/inbox.org"
+                           "~/kb/readwise/"
+                           ))
   ;; Make the consult-driven grep commands resolve their matched files
   ;; correctly (see `zetta-hyrolo-fix-consult-handoff' above).
   (advice-add 'hyrolo-grep-input :filter-return

--- a/modules/app/mastodon.el
+++ b/modules/app/mastodon.el
@@ -4,5 +4,37 @@
   ;;:ensure (mastodon :host codeberg :repo "martianh/mastodon.el")
   :config
   ;; Set `mastodon-instance-url' and `mastodon-active-user' in ~/.private.el
-  )
+
+  ;; Org backlinks (capture %a) from mastodon buffers: the toot at
+  ;; point, boost-aware (the boosted toot's own URL, not the boost),
+  ;; described as @author + a text snippet of the content.  https
+  ;; links, same policy as the elfeed/md4rd backends.
+  (require 'dom)
+  (with-eval-after-load 'ol
+    (defun zetta-org-mastodon-store-link (&optional _interactive)
+      "Store the toot at point as an org link."
+      (when (derived-mode-p 'mastodon-mode)
+        (when-let* ((toot (mastodon-tl--property 'item-json :no-move))
+                    (url (mastodon-tl--field 'url toot)))
+          (let* ((acct (alist-get 'acct (mastodon-tl--field 'account toot)))
+                 (content (mastodon-tl--field 'content toot))
+                 (snippet
+                  (when (and content (fboundp 'libxml-parse-html-region))
+                    (with-temp-buffer
+                      (insert content)
+                      (string-trim
+                       (replace-regexp-in-string
+                        "[ \n]+" " "
+                        (or (dom-texts (libxml-parse-html-region
+                                        (point-min) (point-max)))
+                            ""))))))
+                 (snippet (and snippet (not (string-empty-p snippet))
+                               (truncate-string-to-width snippet 60 nil nil "…"))))
+            (org-link-store-props
+             :type "https" :link url
+             :description (if snippet
+                              (format "@%s: %s" acct snippet)
+                            (format "@%s on Mastodon" acct)))))))
+    (org-link-set-parameters "mastodon-toot"
+                             :store #'zetta-org-mastodon-store-link)))
 ;;; mastodon.el ends here

--- a/modules/app/md4rd.el
+++ b/modules/app/md4rd.el
@@ -116,10 +116,14 @@ web/script apps must authenticate token requests as
     `(("User-Agent" . ,zetta-md4rd-user-agent)
       ("Authorization" . ,(concat "bearer " md4rd--oauth-access-token))))
 
+  (defvar zetta-md4rd-listing-limit 100
+    "Posts to fetch per subreddit.  Reddit caps a single request at 100.")
+
   (defun zetta-md4rd--fetch-sub (sub)
     "Fetch SUB's hot listing via the authenticated API."
     (zetta-md4rd--ensure-token)
-    (request (format "https://oauth.reddit.com/r/%s/hot" sub)
+    (request (format "https://oauth.reddit.com/r/%s/hot?limit=%d"
+                     sub zetta-md4rd-listing-limit)
              :complete (cl-function
                         (lambda (&rest data &allow-other-keys)
                           (apply #'md4rd--fetch-sub-callback sub data)))

--- a/modules/app/md4rd.el
+++ b/modules/app/md4rd.el
@@ -145,6 +145,20 @@ web/script apps must authenticate token requests as
   (advice-add 'md4rd--fetch-sub :override #'zetta-md4rd--fetch-sub)
   (advice-add 'md4rd--fetch-comments :override #'zetta-md4rd--fetch-comments)
 
+  ;; Votes and replies hit oauth.reddit.com with the raw access token
+  ;; and :complete nil, so a stale token means a silent 401.  Keep it
+  ;; fresh for writes too.
+  (advice-add 'md4rd--post-vote :before
+              (lambda (&rest _) (zetta-md4rd--ensure-token)))
+  (advice-add 'md4rd--post-reply :before
+              (lambda (&rest _) (zetta-md4rd--ensure-token)))
+
+  ;; md4rd-mode is a hand-rolled mode: no after-change-major-mode-hook
+  ;; (so global-tab-line-mode never fires) and kill-all-local-variables
+  ;; on every render (so a manually enabled tab-line vanishes).  The
+  ;; mode hook does run each render — re-enable it there.
+  (add-hook 'md4rd-mode-hook #'tab-line-mode)
+
   ;; needed to use this to set things up https://not-an-aardvark.github.io/reddit-oauth-helper/
   (setq
    md4rd-subs-active

--- a/modules/app/md4rd.el
+++ b/modules/app/md4rd.el
@@ -159,6 +159,12 @@ web/script apps must authenticate token requests as
   ;; mode hook does run each render — re-enable it there.
   (add-hook 'md4rd-mode-hook #'tab-line-mode)
 
+  ;; Tree-widget's GUI image theme (diamond icons, line bitmaps) looks
+  ;; wrong here; use its plain-text fallback (the emacs -nw look)
+  ;; everywhere.  Global, but md4rd/hierarchy are the only tree-widget
+  ;; consumers in this config.
+  (setq tree-widget-image-enable nil)
+
   ;; needed to use this to set things up https://not-an-aardvark.github.io/reddit-oauth-helper/
   (setq
    md4rd-subs-active

--- a/modules/app/md4rd.el
+++ b/modules/app/md4rd.el
@@ -54,6 +54,19 @@ URL should be a Reddit permalink or comments URL."
   (general-unbind :keymaps 'elfeed-show-mode-map "R")
   (general-define-key :keymaps 'elfeed-show-mode-map :states 'normal "R" 'md4rd-elfeed-show-reddit-comments)
 
+  ;; Same from the search listing, without opening the article first.
+  ;; Bound to gc in the elfeed-search hook (elfeed.el) — R there is
+  ;; already the incremental-update key.
+  (defun md4rd-elfeed-search-reddit-comments ()
+    "Show Reddit comments for the elfeed entry at point."
+    (interactive)
+    (if-let* ((entry (car (elfeed-search-selected)))
+              (url (elfeed-entry-link entry)))
+        (if (string-match-p "reddit\\.com" url)
+            (md4rd-load-comments-from-url url)
+          (message "Entry at point is not a Reddit URL"))
+      (message "No entry at point")))
+
   ;; --- OAuth reads --------------------------------------------------
   ;; Reddit 403-blocks the unauthenticated *.json endpoints md4rd uses
   ;; for ALL reads (any User-Agent; curl and url.el alike — verified

--- a/modules/app/md4rd.el
+++ b/modules/app/md4rd.el
@@ -54,6 +54,84 @@ URL should be a Reddit permalink or comments URL."
   (general-unbind :keymaps 'elfeed-show-mode-map "R")
   (general-define-key :keymaps 'elfeed-show-mode-map :states 'normal "R" 'md4rd-elfeed-show-reddit-comments)
 
+  ;; --- OAuth reads --------------------------------------------------
+  ;; Reddit 403-blocks the unauthenticated *.json endpoints md4rd uses
+  ;; for ALL reads (any User-Agent; curl and url.el alike — verified
+  ;; 2026-08-03), so listings/comments silently render nothing.  Route
+  ;; reads through oauth.reddit.com with the bearer token instead.
+  ;; Needs a token carrying the `read' scope: stock md4rd only asks for
+  ;; vote,submit, so widen the authorize URL for future logins.
+  (setq md4rd--oauth-url
+        (replace-regexp-in-string "scope=vote,submit" "scope=read,vote,submit"
+                                  md4rd--oauth-url))
+
+  (defvar zetta-md4rd-user-agent "emacs:md4rd:0.3.1 (personal reader)"
+    "Descriptive User-Agent, per Reddit API rules.")
+
+  (defvar zetta-md4rd--token-refreshed-at 0
+    "`float-time' of the last successful access-token refresh.")
+
+  (defun zetta-md4rd--refresh-token-sync ()
+    "Refresh the OAuth access token, blocking.  Return it, or nil."
+    (let* ((url-request-method "POST")
+           (url-request-data (format "grant_type=refresh_token&refresh_token=%s"
+                                     md4rd--oauth-refresh-token))
+           (url-request-extra-headers
+            `(("Content-Type" . "application/x-www-form-urlencoded")
+              ("User-Agent" . ,zetta-md4rd-user-agent)
+              ("Authorization" . ,(concat "Basic "
+                                          (base64-encode-string
+                                           (format "%s:" md4rd--oauth-client-id) t)))))
+           (buf (ignore-errors
+                  (url-retrieve-synchronously
+                   "https://www.reddit.com/api/v1/access_token" t nil 10))))
+      (when buf
+        (with-current-buffer buf
+          (when-let* ((json (ignore-errors
+                              (json-read-from-string
+                               (buffer-substring (1+ url-http-end-of-headers)
+                                                 (point-max)))))
+                      (token (alist-get 'access_token json)))
+            (setq md4rd--oauth-access-token token
+                  zetta-md4rd--token-refreshed-at (float-time))
+            token)))))
+
+  (defun zetta-md4rd--ensure-token ()
+    "Refresh the access token when older than 50 min (1 h lifetime)."
+    (when (> (- (float-time) zetta-md4rd--token-refreshed-at) 3000)
+      (or (zetta-md4rd--refresh-token-sync)
+          (message "md4rd: token refresh failed — run M-x md4rd-login"))))
+
+  (defun zetta-md4rd--oauth-headers ()
+    "Bearer auth headers for authenticated Reddit reads."
+    `(("User-Agent" . ,zetta-md4rd-user-agent)
+      ("Authorization" . ,(concat "bearer " md4rd--oauth-access-token))))
+
+  (defun zetta-md4rd--fetch-sub (sub)
+    "Fetch SUB's hot listing via the authenticated API."
+    (zetta-md4rd--ensure-token)
+    (request (format "https://oauth.reddit.com/r/%s/hot" sub)
+             :complete (cl-function
+                        (lambda (&rest data &allow-other-keys)
+                          (apply #'md4rd--fetch-sub-callback sub data)))
+             :sync nil
+             :parser #'json-read
+             :headers (zetta-md4rd--oauth-headers)))
+
+  (defun zetta-md4rd--fetch-comments (comment-url)
+    "Fetch COMMENT-URL via the authenticated API."
+    (zetta-md4rd--ensure-token)
+    (request (replace-regexp-in-string
+              "\\`https?://\\(www\\.\\)?reddit\\.com" "https://oauth.reddit.com"
+              comment-url)
+             :complete #'md4rd--fetch-comments-callback
+             :sync nil
+             :parser #'json-read
+             :headers (zetta-md4rd--oauth-headers)))
+
+  (advice-add 'md4rd--fetch-sub :override #'zetta-md4rd--fetch-sub)
+  (advice-add 'md4rd--fetch-comments :override #'zetta-md4rd--fetch-comments)
+
   ;; needed to use this to set things up https://not-an-aardvark.github.io/reddit-oauth-helper/
   (setq
    md4rd-subs-active

--- a/modules/app/md4rd.el
+++ b/modules/app/md4rd.el
@@ -145,10 +145,14 @@ web/script apps must authenticate token requests as
              :headers (zetta-md4rd--oauth-headers)))
 
   (defun zetta-md4rd--fetch-comments (comment-url)
-    "Fetch COMMENT-URL via the authenticated API."
+    "Fetch COMMENT-URL via the authenticated API.
+Any reddit host variant is rewritten — elfeed entries arriving via
+the Fever backend link to old.reddit.com, which the stock
+convert-to-json-url helper passes through unchanged."
     (zetta-md4rd--ensure-token)
     (request (replace-regexp-in-string
-              "\\`https?://\\(www\\.\\)?reddit\\.com" "https://oauth.reddit.com"
+              "\\`https?://\\(?:old\\.\\|www\\.\\|api\\.\\|m\\.\\)?reddit\\.com"
+              "https://oauth.reddit.com"
               comment-url)
              :complete #'md4rd--fetch-comments-callback
              :sync nil

--- a/modules/app/md4rd.el
+++ b/modules/app/md4rd.el
@@ -182,6 +182,45 @@ convert-to-json-url helper passes through unchanged."
   ;; consumers in this config.
   (setq tree-widget-image-enable nil)
 
+  ;; Org backlinks (capture %a) from md4rd buffers.  The listing's
+  ;; widgets keep their post item in a closure, so match the post whose
+  ;; title appears on the current line; the comments buffer links its
+  ;; thread (the first listing in the cached response).  https links,
+  ;; like the elfeed backend.
+  (with-eval-after-load 'ol
+    (defun zetta-org-md4rd-store-link (&optional _interactive)
+      "Store the reddit post at point (listing) or the shown thread (comments)."
+      (when (derived-mode-p 'md4rd-mode)
+        (if (string= (buffer-name) "*subreddits*")
+            (let* ((line (buffer-substring-no-properties
+                          (line-beginning-position) (line-end-position)))
+                   (found nil))
+              (maphash
+               (lambda (_sub posts)
+                 (unless found
+                   (setq found
+                         (cl-find-if
+                          (lambda (p)
+                            (let ((title (alist-get 'title p)))
+                              (and title (> (length title) 0)
+                                   (string-search title line))))
+                          posts))))
+               md4rd--sub-composite)
+              (when found
+                (org-link-store-props
+                 :type "https"
+                 :link (concat "https://www.reddit.com" (alist-get 'permalink found))
+                 :description (alist-get 'title found))))
+          (when-let* ((post (ignore-errors
+                              (let-alist (alist-get 'data (elt md4rd--cache-comments 0))
+                                (alist-get 'data (elt .children 0)))))
+                      (permalink (alist-get 'permalink post)))
+            (org-link-store-props
+             :type "https"
+             :link (concat "https://www.reddit.com" permalink)
+             :description (alist-get 'title post))))))
+    (org-link-set-parameters "md4rd-post" :store #'zetta-org-md4rd-store-link))
+
   ;; needed to use this to set things up https://not-an-aardvark.github.io/reddit-oauth-helper/
   (setq
    md4rd-subs-active

--- a/modules/app/md4rd.el
+++ b/modules/app/md4rd.el
@@ -68,6 +68,13 @@ URL should be a Reddit permalink or comments URL."
   (defvar zetta-md4rd-user-agent "emacs:md4rd:0.3.1 (personal reader)"
     "Descriptive User-Agent, per Reddit API rules.")
 
+  (defvar zetta-md4rd-client-secret nil
+    "Reddit app client secret, or nil for secretless installed apps.
+md4rd assumes an installed app (Basic auth = \"client_id:\"), but
+web/script apps must authenticate token requests as
+\"client_id:secret\" — without it Reddit returns 401.  Set from
+1Password in ~/.private.el.")
+
   (defvar zetta-md4rd--token-refreshed-at 0
     "`float-time' of the last successful access-token refresh.")
 
@@ -81,7 +88,9 @@ URL should be a Reddit permalink or comments URL."
               ("User-Agent" . ,zetta-md4rd-user-agent)
               ("Authorization" . ,(concat "Basic "
                                           (base64-encode-string
-                                           (format "%s:" md4rd--oauth-client-id) t)))))
+                                           (format "%s:%s" md4rd--oauth-client-id
+                                                   (or zetta-md4rd-client-secret ""))
+                                           t)))))
            (buf (ignore-errors
                   (url-retrieve-synchronously
                    "https://www.reddit.com/api/v1/access_token" t nil 10))))

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -187,10 +187,15 @@ Exits evil visual state afterwards so the marks are visible."
   ;; (RFC-legal, defaults to us-ascii) nils the chain and the preview
   ;; silently disappears.  Corrected copy; drop when fixed upstream.
   (defun zetta-nano-mu4e--msg-preview (&optional msg size)
-    "Extract a short preview from MSG, limiting it to SIZE characters."
-    (let* ((msg (or msg (mu4e-message-at-point)))
-           (size (or size 256))
-           (filename (mu4e-message-readable-path msg)))
+    "Extract a short preview from MSG, limiting it to SIZE characters.
+Returns nil when MSG's file is not readable: executing marks renames
+maildir files (read = new/ → cur/ + S flag) and nano-mu4e's delayed
+refresh re-renders from cached paths, so a signaling
+`mu4e-message-readable-path' would abort the refresh mid-render and
+leave the headers buffer half-drawn."
+    (when-let* ((msg (or msg (mu4e-message-at-point)))
+                (size (or size 256))
+                (filename (ignore-errors (mu4e-message-readable-path msg))))
       (with-temp-buffer
         (insert-file-contents-literally filename)
         (let* ((handles (mm-dissect-buffer t)))

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -78,6 +78,10 @@
   (define-key nano-mu4e-mode-map (kbd ":") nil)
   (define-key nano-mu4e-mode-map (kbd "G") nil)
   (define-key nano-mu4e-mode-map (kbd "g g") #'beginning-of-buffer)
+  ;; "r" marks for read.  mu4e's stock r (refile) is already eaten by
+  ;; evil normal here, and nano-mu4e leaves r unbound, so nothing
+  ;; useful is displaced; "!" still works too.
+  (define-key nano-mu4e-mode-map (kbd "r") #'mu4e-headers-mark-for-read)
 
   ;; Let mu4e's and nano-mu4e's own keys through the modal layers.
   ;; Both meow-normal and evil-normal sit in emulation-mode-map-alists
@@ -136,8 +140,12 @@
                                         (mm-find-part-by-type (cdr handles) "text/html" nil t))))
                           (media-type (mm-handle-media-type handle))
                           (content (mm-get-part handle)))
+                ;; utf-8, not the RFC 2046 default us-ascii: ASCII is a
+                ;; subset of UTF-8 so conforming parts decode the same,
+                ;; and undeclared-UTF-8 senders render correctly (matches
+                ;; the upstream PR after Rougier's review).
                 (let ((charset (or (mail-content-type-get (mm-handle-type handle) 'charset)
-                                   'us-ascii)))
+                                   'utf-8)))
                   (cond ((string= media-type "text/plain")
                          (with-temp-buffer
                            (insert (mm-decode-string content charset))

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -132,6 +132,10 @@ Exits evil visual state afterwards so the marks are visible."
   (define-key mu4e-view-mode-map (kbd "g g") #'beginning-of-buffer)
   (define-key mu4e-view-mode-map (kbd "g u") #'mu4e-view-go-to-url)
   (define-key mu4e-view-mode-map (kbd "g U") #'mu4e-view-save-url)
+  ;; "r" replies, matching r = mark-read in headers as the "obvious"
+  ;; key.  Displaces the stock mu4e-view-mark-for-refile; refiling
+  ;; still works from the headers view.
+  (define-key mu4e-view-mode-map (kbd "r") #'mu4e-compose-reply)
 
   (with-eval-after-load 'evil
     (evil-set-initial-state 'mu4e-headers-mode 'normal)

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -82,6 +82,30 @@
   ;; evil normal here, and nano-mu4e leaves r unbound, so nothing
   ;; useful is displaced; "!" still works too.
   (define-key nano-mu4e-mode-map (kbd "r") #'mu4e-headers-mark-for-read)
+  ;; RET opens the message.  Without this, RET reaches evil's evil-ret,
+  ;; which activates the button under point — usually the sender name,
+  ;; whose action is a from:<sender> search.  Mouse still clicks buttons.
+  (define-key nano-mu4e-mode-map (kbd "RET") #'mu4e-headers-view-message)
+
+  ;; Region marking: mu4e-mark-set's own region loop advances with
+  ;; mu4e-headers-next, which cannot step across nano-mu4e's
+  ;; multi-line boxes (it immediately reports no-more-messages), so it
+  ;; would only mark the first message.  Walk the msg text-property
+  ;; blocks instead — one contiguous block per message.
+  (defun zetta-nano-mu4e-visual-mark-read (beg end)
+    "Mark every message touched by the region BEG..END for read.
+Exits evil visual state afterwards so the marks are visible."
+    (interactive "r")
+    (deactivate-mark)
+    (save-excursion
+      (let ((pos beg))
+        (while (and pos (< pos end))
+          (when (get-text-property pos 'msg)
+            (goto-char pos)
+            (mu4e-mark-set 'read))
+          (setq pos (next-single-property-change pos 'msg nil end)))))
+    (when (and (fboundp 'evil-visual-state-p) (evil-visual-state-p))
+      (evil-exit-visual-state)))
 
   ;; Let mu4e's and nano-mu4e's own keys through the modal layers.
   ;; Both meow-normal and evil-normal sit in emulation-mode-map-alists
@@ -112,6 +136,10 @@
   (with-eval-after-load 'evil
     (evil-set-initial-state 'mu4e-headers-mode 'normal)
     (evil-make-overriding-map nano-mu4e-mode-map 'normal)
+    ;; The overriding map only covers normal state; in visual state r
+    ;; would fall back to evil-replace, so bind it there explicitly.
+    (evil-define-key 'visual nano-mu4e-mode-map
+      (kbd "r") #'zetta-nano-mu4e-visual-mark-read)
     (add-hook 'nano-mu4e-mode-hook #'evil-normalize-keymaps)
     (evil-set-initial-state 'mu4e-view-mode 'normal)
     (evil-make-overriding-map mu4e-view-mode-map 'normal)

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -179,13 +179,18 @@ Exits evil visual state afterwards so the marks are visible."
     (add-hook 'mu4e-view-mode-hook #'evil-normalize-keymaps)
     (evil-set-initial-state 'mu4e-main-mode 'emacs))
 
-  ;; Re-apply brushup styles now that the faces below exist.
-  (when (fboundp 'brushup) (brushup))
-
   ;; Upstream bug: `nano-mu4e-msg-preview' binds charset inside its
   ;; when-let*, so a MIME part with no explicit charset= parameter
   ;; (RFC-legal, defaults to us-ascii) nils the chain and the preview
   ;; silently disappears.  Corrected copy; drop when fixed upstream.
+  ;; Previews are recomputed synchronously on EVERY render upstream —
+  ;; measured 29s of a 29.3s render for the 16k-unread inbox (~1500
+  ;; lines with include-related, all "new" so all previewed, digests
+  ;; through shr).  Bodies are immutable, so cache by docid: repeat
+  ;; renders (mark-refreshes, reruns, fold toggles) become free.
+  (defvar zetta-nano-mu4e--preview-cache (make-hash-table :test 'eql)
+    "Message docid → preview string.")
+
   (defun zetta-nano-mu4e--msg-preview (&optional msg size)
     "Extract a short preview from MSG, limiting it to SIZE characters.
 Returns nil when MSG's file is not readable: executing marks renames
@@ -193,36 +198,48 @@ maildir files (read = new/ → cur/ + S flag) and nano-mu4e's delayed
 refresh re-renders from cached paths, so a signaling
 `mu4e-message-readable-path' would abort the refresh mid-render and
 leave the headers buffer half-drawn."
-    (when-let* ((msg (or msg (mu4e-message-at-point)))
-                (size (or size 256))
-                (filename (ignore-errors (mu4e-message-readable-path msg))))
-      (with-temp-buffer
-        (insert-file-contents-literally filename)
-        (let* ((handles (mm-dissect-buffer t)))
-          (unwind-protect
-              (when-let* ((handle (if (bufferp (car handles))
-                                      handles
-                                    (or (mm-find-part-by-type (cdr handles) "text/plain" nil t)
-                                        (mm-find-part-by-type (cdr handles) "text/html" nil t))))
-                          (media-type (mm-handle-media-type handle))
-                          (content (mm-get-part handle)))
-                ;; utf-8, not the RFC 2046 default us-ascii: ASCII is a
-                ;; subset of UTF-8 so conforming parts decode the same,
-                ;; and undeclared-UTF-8 senders render correctly (matches
-                ;; the upstream PR after Rougier's review).
-                (let ((charset (or (mail-content-type-get (mm-handle-type handle) 'charset)
-                                   'utf-8)))
-                  (cond ((string= media-type "text/plain")
-                         (with-temp-buffer
-                           (insert (mm-decode-string content charset))
-                           (nano-mu4e-preview--process size)))
-                        ((string= media-type "text/html")
-                         (with-temp-buffer
-                           (insert (mm-decode-string content charset))
-                           (shr-render-region (point-min) (point-max))
-                           (nano-mu4e-preview--process size)))
-                        (t "No message body found"))))
-            (mm-destroy-parts handles))))))
+    (let* ((msg (or msg (mu4e-message-at-point)))
+           (docid (and msg (plist-get msg :docid))))
+      (or (and docid (gethash docid zetta-nano-mu4e--preview-cache))
+          (when-let* ((msg msg)
+                      (size (or size 256))
+                      (filename (ignore-errors (mu4e-message-readable-path msg))))
+            (when (> (hash-table-count zetta-nano-mu4e--preview-cache) 5000)
+              (clrhash zetta-nano-mu4e--preview-cache))
+            (let ((preview
+                   (with-temp-buffer
+                     (insert-file-contents-literally filename)
+                     (let* ((handles (mm-dissect-buffer t)))
+                       (unwind-protect
+                           (when-let* ((handle (if (bufferp (car handles))
+                                                   handles
+                                                 (or (mm-find-part-by-type (cdr handles) "text/plain" nil t)
+                                                     (mm-find-part-by-type (cdr handles) "text/html" nil t))))
+                                       (media-type (mm-handle-media-type handle))
+                                       (content (mm-get-part handle)))
+                             ;; utf-8, not the RFC 2046 default us-ascii:
+                             ;; ASCII is a subset of UTF-8 so conforming
+                             ;; parts decode the same, and undeclared-UTF-8
+                             ;; senders render correctly (matches the
+                             ;; upstream PR after Rougier's review).
+                             (let ((charset (or (mail-content-type-get (mm-handle-type handle) 'charset)
+                                                'utf-8)))
+                               (cond ((string= media-type "text/plain")
+                                      (with-temp-buffer
+                                        (insert (mm-decode-string content charset))
+                                        (nano-mu4e-preview--process size)))
+                                     ((string= media-type "text/html")
+                                      (with-temp-buffer
+                                        (insert (mm-decode-string content charset))
+                                        ;; text output only — image work is waste
+                                        (let ((shr-inhibit-images t))
+                                          (shr-render-region (point-min) (point-max)))
+                                        (nano-mu4e-preview--process size)))
+                                     (t "No message body found"))))
+                         (mm-destroy-parts handles))))))
+              (when (and docid preview)
+                (puthash docid preview zetta-nano-mu4e--preview-cache))
+              preview)))))
   (advice-add 'nano-mu4e-msg-preview :override #'zetta-nano-mu4e--msg-preview)
 
   :brushup
@@ -245,6 +262,12 @@ leave the headers buffer half-drawn."
                                       :inherit 'shadow :slant 'normal)
                   (set-face-attribute 'nano-mu4e-gutter-body nil :underline nil)
                   (set-face-attribute 'nano-mu4e-gutter-match nil :underline nil)))
+  ;; Re-apply NOW: the :brushup keyword is appended at the END of
+  ;; use-package-keywords, so this section runs after :config — a
+  ;; re-apply there fires before the form above is registered, and the
+  ;; faces (created by nano-mu4e loading, long after the theme was
+  ;; applied) stay at upstream defaults until the first theme toggle.
+  (when (fboundp 'brushup) (brushup))
   :init
   (defvar zetta-nano-mu4e--fontset-done nil)
   (defun zetta-nano-mu4e--fontset (&optional frame)

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -186,10 +186,52 @@ Exits evil visual state afterwards so the marks are visible."
   ;; Previews are recomputed synchronously on EVERY render upstream —
   ;; measured 29s of a 29.3s render for the 16k-unread inbox (~1500
   ;; lines with include-related, all "new" so all previewed, digests
-  ;; through shr).  Bodies are immutable, so cache by docid: repeat
-  ;; renders (mark-refreshes, reruns, fold toggles) become free.
-  (defvar zetta-nano-mu4e--preview-cache (make-hash-table :test 'eql)
-    "Message docid → preview string.")
+  ;; through shr).  Bodies are immutable, so cache them — keyed by
+  ;; message-id, which survives reindexing (docids renumber) — and
+  ;; persist the cache across sessions so only genuinely new mail
+  ;; pays the extraction cost.
+  (require 'dom)
+
+  (defvar zetta-nano-mu4e--preview-cache (make-hash-table :test 'equal)
+    "Message-id → preview string.")
+
+  (defvar zetta-nano-mu4e--preview-cache-file
+    (expand-file-name "nano-mu4e-preview-cache.eld" user-emacs-directory)
+    "Persisted preview cache (gitignored).")
+
+  (defvar zetta-nano-mu4e--preview-cache-dirty nil)
+
+  (defun zetta-nano-mu4e--preview-cache-load ()
+    "Merge the persisted preview cache into the in-memory table."
+    (when (file-readable-p zetta-nano-mu4e--preview-cache-file)
+      (ignore-errors
+        (with-temp-buffer
+          (insert-file-contents zetta-nano-mu4e--preview-cache-file)
+          (dolist (pair (read (current-buffer)))
+            (puthash (car pair) (cdr pair) zetta-nano-mu4e--preview-cache))))))
+
+  (defun zetta-nano-mu4e--preview-cache-save ()
+    "Write the preview cache to disk when it has new entries."
+    (when zetta-nano-mu4e--preview-cache-dirty
+      (setq zetta-nano-mu4e--preview-cache-dirty nil)
+      (ignore-errors
+        (with-temp-file zetta-nano-mu4e--preview-cache-file
+          (let ((print-length nil) (print-level nil) (pairs nil))
+            (maphash (lambda (k v) (push (cons k v) pairs))
+                     zetta-nano-mu4e--preview-cache)
+            (prin1 pairs (current-buffer)))))))
+
+  (zetta-nano-mu4e--preview-cache-load)
+  (add-hook 'kill-emacs-hook #'zetta-nano-mu4e--preview-cache-save)
+  (run-with-idle-timer 120 t #'zetta-nano-mu4e--preview-cache-save)
+
+  (defun zetta-nano-mu4e--dom-text (node)
+    "Text content of NODE, skipping style/script/head/title subtrees.
+`dom-texts' would include CSS from marketing mail's <style> blocks."
+    (cond
+     ((stringp node) node)
+     ((memq (dom-tag node) '(style script head title comment)) "")
+     (t (mapconcat #'zetta-nano-mu4e--dom-text (dom-children node) " "))))
 
   (defun zetta-nano-mu4e--msg-preview (&optional msg size)
     "Extract a short preview from MSG, limiting it to SIZE characters.
@@ -199,8 +241,8 @@ refresh re-renders from cached paths, so a signaling
 `mu4e-message-readable-path' would abort the refresh mid-render and
 leave the headers buffer half-drawn."
     (let* ((msg (or msg (mu4e-message-at-point)))
-           (docid (and msg (plist-get msg :docid))))
-      (or (and docid (gethash docid zetta-nano-mu4e--preview-cache))
+           (msgid (and msg (plist-get msg :message-id))))
+      (or (and msgid (gethash msgid zetta-nano-mu4e--preview-cache))
           (when-let* ((msg msg)
                       (size (or size 256))
                       (filename (ignore-errors (mu4e-message-readable-path msg))))
@@ -231,14 +273,24 @@ leave the headers buffer half-drawn."
                                      ((string= media-type "text/html")
                                       (with-temp-buffer
                                         (insert (mm-decode-string content charset))
-                                        ;; text output only — image work is waste
-                                        (let ((shr-inhibit-images t))
-                                          (shr-render-region (point-min) (point-max)))
+                                        ;; libxml (native C) + text walk beats
+                                        ;; shr's full layout pass by ~an order
+                                        ;; of magnitude; a 256-char excerpt
+                                        ;; doesn't need layout.
+                                        (if (fboundp 'libxml-parse-html-region)
+                                            (let ((dom (libxml-parse-html-region
+                                                        (point-min) (point-max))))
+                                              (erase-buffer)
+                                              (when dom
+                                                (insert (zetta-nano-mu4e--dom-text dom))))
+                                          (let ((shr-inhibit-images t))
+                                            (shr-render-region (point-min) (point-max))))
                                         (nano-mu4e-preview--process size)))
                                      (t "No message body found"))))
                          (mm-destroy-parts handles))))))
-              (when (and docid preview)
-                (puthash docid preview zetta-nano-mu4e--preview-cache))
+              (when (and msgid preview)
+                (puthash msgid preview zetta-nano-mu4e--preview-cache)
+                (setq zetta-nano-mu4e--preview-cache-dirty t))
               preview)))))
   (advice-add 'nano-mu4e-msg-preview :override #'zetta-nano-mu4e--msg-preview)
 

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -44,6 +44,27 @@
   (setq mu4e-thread--fold-status t)
   (advice-add 'nano-mu4e-found-handler :after #'zetta-nano-mu4e--fold-all)
 
+  ;; Keep conversation forks visible.  Upstream's nano-mu4e-thread-prefix
+  ;; blanks every tree glyph except the connection bar, flattening a
+  ;; thread to a plain sequence (depth-first order still groups each
+  ;; branch, but siblings are indistinguishable).  Restore minimal
+  ;; child/last-child glyphs; plain box-drawing only — Terminus has no
+  ;; arc glyphs.  Both cons cells identical so fancy-chars is moot.
+  (defun zetta-nano-mu4e-thread-prefix (msg)
+    "Thread prefix with fork structure (├/└) kept visible."
+    (let* ((meta (plist-get msg :meta))
+           (mu4e-headers-thread-root-prefix          '(""   . ""))
+           (mu4e-headers-thread-first-child-prefix   '(" ├" . " ├"))
+           (mu4e-headers-thread-child-prefix         '(" ├" . " ├"))
+           (mu4e-headers-thread-last-child-prefix    '(" └" . " └"))
+           (mu4e-headers-thread-connection-prefix    '(" │" . " │"))
+           (mu4e-headers-thread-blank-prefix         '("  " . "  "))
+           (mu4e-headers-thread-orphan-prefix        '(""   . ""))
+           (mu4e-headers-thread-single-orphan-prefix '(""   . ""))
+           (mu4e-headers-thread-duplicate-prefix     '(""   . "")))
+      (mu4e~headers-thread-prefix meta)))
+  (advice-add 'nano-mu4e-thread-prefix :override #'zetta-nano-mu4e-thread-prefix)
+
   (defun zetta-nano-mu4e-toggle ()
     "Toggle between the nano-mu4e and stock mu4e headers display."
     (interactive)

--- a/modules/app/nano-mu4e.el
+++ b/modules/app/nano-mu4e.el
@@ -136,6 +136,14 @@ Exits evil visual state afterwards so the marks are visible."
   ;; key.  Displaces the stock mu4e-view-mark-for-refile; refiling
   ;; still works from the headers view.
   (define-key mu4e-view-mode-map (kbd "r") #'mu4e-compose-reply)
+  ;; "e" always prompts for the save directory (stock needs C-u e;
+  ;; plain e dumps into mu4e-attachment-dir, which .private.el points
+  ;; at ~/Desktop — that stays the prompt's starting suggestion).
+  (defun zetta-mu4e-save-attachments-ask ()
+    "Save attachment(s), prompting for the target directory."
+    (interactive)
+    (mu4e-view-save-attachments t))
+  (define-key mu4e-view-mode-map (kbd "e") #'zetta-mu4e-save-attachments-ask)
 
   (with-eval-after-load 'evil
     (evil-set-initial-state 'mu4e-headers-mode 'normal)

--- a/modules/app/org-msg.el
+++ b/modules/app/org-msg.el
@@ -22,6 +22,17 @@
         org-msg-default-alternatives '((new . (text html))
                                        (reply-to-html . (text html))
                                        (reply-to-text . (text))))
-  (org-msg-mode))
+  (org-msg-mode)
+
+  ;; C-c C-c only sends when no org element at point claims it (org-msg
+  ;; sends via org-ctrl-c-ctrl-c-final-hook), and it should keep doing
+  ;; its org job anyway.  C-RET is the dedicated send key; the heading
+  ;; command it shadows (org-insert-heading-respect-content) is unused,
+  ;; and only in compose buffers.  C-u C-RET sends without exiting.
+  (defun zetta-org-msg-send ()
+    "Send the message, regardless of the org element at point."
+    (interactive)
+    (org-msg-ctrl-c-ctrl-c))
+  (define-key org-msg-edit-mode-map (kbd "C-<return>") #'zetta-org-msg-send))
 
 ;;; org-msg.el ends here

--- a/modules/app/reddigg.el
+++ b/modules/app/reddigg.el
@@ -1,0 +1,33 @@
+;;; reddigg.el --- Configure reddigg -*- lexical-binding: t; -*-
+
+;; Org-based Reddit reader, trialed 2026-08-03 alongside md4rd (see
+;; modules/app/md4rd.el) while deciding which to keep.
+;;
+;; Reddit 403-blocks the unauthenticated endpoints reddigg fetches
+;; (old.reddit.com/*.json, api.reddit.com), so every request — all
+;; funneled through reddigg--promise-json — is rewritten to
+;; oauth.reddit.com with the bearer token machinery from the md4rd
+;; module (loads before this one; both under modules/app/).
+
+(use-package reddigg
+  :ensure (reddigg :host github :repo "thanhvg/emacs-reddigg")
+  :commands (reddigg-view-main reddigg-view-sub reddigg-view-comments)
+  :config
+  ;; Same sub list as md4rd for a fair comparison.
+  (setq reddigg-subs md4rd-subs-active)
+
+  (defun zetta-reddigg--oauth-json (orig url)
+    "Call ORIG with URL rewritten to oauth.reddit.com plus bearer auth.
+The dynamic binding works because promise-new runs its executor —
+and thus url-retrieve — synchronously inside this extent."
+    (when (fboundp 'zetta-md4rd--ensure-token)
+      (zetta-md4rd--ensure-token))
+    (let ((url-request-extra-headers
+           `(("User-Agent" . ,zetta-md4rd-user-agent)
+             ("Authorization" . ,(concat "bearer " md4rd--oauth-access-token)))))
+      (funcall orig (replace-regexp-in-string
+                     "\\`https://\\(?:old\\.\\|www\\.\\|api\\.\\)?reddit\\.com"
+                     "https://oauth.reddit.com" url))))
+  (advice-add 'reddigg--promise-json :around #'zetta-reddigg--oauth-json))
+
+;;; reddigg.el ends here

--- a/modules/core/image.el
+++ b/modules/core/image.el
@@ -23,6 +23,13 @@
 ;; are lost.
 (setq imagemagick-types-inhibit t)
 
+;; The last sliver of graininess vs a browser: the default smoothing
+;; heuristic (image--default-smoothing) only detects downscales
+;; expressed via :scale, so :max-width/:max-height-capped images (all
+;; inline markdown images, image-mode fits) render WITHOUT
+;; interpolation.  Browsers always interpolate — do the same.
+(setq image-transform-smoothing t)
+
 (defvar zetta-image--remote-cache (make-hash-table :test 'equal)
   "URL -> downloaded temp file, for popping out remote images.")
 

--- a/modules/core/image.el
+++ b/modules/core/image.el
@@ -62,20 +62,27 @@ to fit-height so it can be scrolled, a tall one to fit-width."
 (defun zetta-image--clean-display ()
   "Drop text-editing chrome in image buffers.
 Line numbers render a giant number beside the image, hl-line draws
-a stripe straight through it, and the cursor paints an
-image-height bar.  Evil re-stamps `cursor-type' on every state
-refresh — and resets it to the default when a spec is nil — so its
-buffer-local specs get a zero-height hbar (invisible) instead."
+a stripe straight through it, and any visible cursor paints ON the
+image — an hbar's width is the glyph's width, i.e. the whole image."
   (setq-local display-line-numbers nil)
   (setq-local global-hl-line-mode nil)
   (when (fboundp 'global-hl-line-unhighlight) (global-hl-line-unhighlight))
-  (setq-local cursor-type '(hbar . 0))
-  (dolist (v '(evil-normal-state-cursor evil-motion-state-cursor
-               evil-emacs-state-cursor evil-insert-state-cursor
-               evil-visual-state-cursor evil-operator-state-cursor))
-    (set (make-local-variable v) '((hbar . 0)))))
+  (setq-local cursor-type nil))
 (add-hook 'image-mode-hook #'zetta-image--clean-display)
 (add-hook 'doc-view-mode-hook #'zetta-image--clean-display)
+
+;; Evil and meow both re-stamp `cursor-type' on every state refresh,
+;; and both reset a nil spec to their state default — all their
+;; writes funnel through these two functions, so make them leave
+;; image-ish buffers alone and the nil above sticks.
+(defun zetta-image--suppress-cursor-stamp (&rest _)
+  (derived-mode-p 'image-mode 'doc-view-mode 'pdf-view-mode))
+(with-eval-after-load 'evil
+  (advice-add 'evil-refresh-cursor :before-until
+              #'zetta-image--suppress-cursor-stamp))
+(with-eval-after-load 'meow
+  (advice-add 'meow--set-cursor-type :before-until
+              #'zetta-image--suppress-cursor-stamp))
 
 ;; global-display-line-numbers-mode re-enables numbers AFTER mode
 ;; hooks run (global minor modes fire in after-change-major-mode-hook),

--- a/modules/core/image.el
+++ b/modules/core/image.el
@@ -1,0 +1,97 @@
+;;; image.el --- Image viewing helpers -*- lexical-binding: t; -*-
+
+;; Shared machinery for popping document images out into an image-mode
+;; window (used by the markdown and org modules) and for toggling the
+;; fit axis inside any image buffer.
+
+(declare-function image-toggle-display-image "image-mode")
+(declare-function image-get-display-property "image-mode")
+(defvar image-transform-resize)
+
+(defvar zetta-image-inline-height-fraction 0.33
+  "Max height of inline document images, as a fraction of the frame height.")
+
+(defvar zetta-image--remote-cache (make-hash-table :test 'equal)
+  "URL -> downloaded temp file, for popping out remote images.")
+
+(defun zetta-image--remote-file (url)
+  "Download URL once and return a local cached copy."
+  (let ((cached (gethash url zetta-image--remote-cache)))
+    (if (and cached (file-exists-p cached))
+        cached
+      (let ((file (make-temp-file "zetta-image-")))
+        (url-copy-file url file t)
+        (puthash url file zetta-image--remote-cache)
+        file))))
+
+(defun zetta-image-pop-out-file (file &optional fit-width)
+  "Display image FILE in another window, fit to the window.
+The fit is orientation-aware: the whole image is scaled to be fully
+visible whichever way it is oriented.  With FIT-WIDTH non-nil, fit
+to the window width instead.  In the image buffer, t toggles
+fit-width/fit-height, H / W set them directly, q quits."
+  (unless (or (image-supported-file-p file)
+              (image-type-from-file-header file))
+    (user-error "Not a displayable image (broken link?): %s" file))
+  (find-file-other-window file)
+  (setq image-transform-resize (if fit-width 'fit-width 'fit-window))
+  (image-toggle-display-image))
+
+(defun zetta-image-toggle-fit ()
+  "Toggle the displayed image between fit-to-width and fit-to-height.
+From any other fit state (e.g. the fit-window default), switch to
+whichever axis the image is not already filling: a wide image goes
+to fit-height so it can be scrolled, a tall one to fit-width."
+  (interactive)
+  (setq image-transform-resize
+        (pcase image-transform-resize
+          ('fit-height 'fit-width)
+          ('fit-width 'fit-height)
+          (_ (let* ((size (image-size (image-get-display-property) t))
+                    (edges (window-inside-pixel-edges))
+                    (window-wide-p (> (/ (float (- (nth 2 edges) (nth 0 edges)))
+                                         (max 1 (- (nth 3 edges) (nth 1 edges))))
+                                      (/ (float (car size)) (max 1 (cdr size))))))
+               ;; Window proportionally wider than image: fit-window
+               ;; was height-constrained, so the toggle is fit-width.
+               (if window-wide-p 'fit-width 'fit-height)))))
+  (image-toggle-display-image)
+  (message "Fit to %s"
+           (if (eq image-transform-resize 'fit-width) "width" "height")))
+
+(defun zetta-image--clean-display ()
+  "Drop text-editing chrome in image buffers.
+Line numbers render a giant number beside the image, hl-line draws
+a stripe straight through it, and the cursor paints an
+image-height bar.  Evil re-stamps `cursor-type' on every state
+refresh — and resets it to the default when a spec is nil — so its
+buffer-local specs get a zero-height hbar (invisible) instead."
+  (setq-local display-line-numbers nil)
+  (setq-local global-hl-line-mode nil)
+  (when (fboundp 'global-hl-line-unhighlight) (global-hl-line-unhighlight))
+  (setq-local cursor-type '(hbar . 0))
+  (dolist (v '(evil-normal-state-cursor evil-motion-state-cursor
+               evil-emacs-state-cursor evil-insert-state-cursor
+               evil-visual-state-cursor evil-operator-state-cursor))
+    (set (make-local-variable v) '((hbar . 0)))))
+(add-hook 'image-mode-hook #'zetta-image--clean-display)
+(add-hook 'doc-view-mode-hook #'zetta-image--clean-display)
+
+;; global-display-line-numbers-mode re-enables numbers AFTER mode
+;; hooks run (global minor modes fire in after-change-major-mode-hook),
+;; so the hook's setq-local alone doesn't stick — exempt these modes
+;; at the turn-on function.
+(define-advice display-line-numbers--turn-on
+    (:before-until () zetta-image-exempt)
+  (derived-mode-p 'image-mode 'doc-view-mode 'pdf-view-mode))
+
+(with-eval-after-load 'image-mode
+  ;; Emacs state / non-evil.
+  (define-key image-mode-map "t" #'zetta-image-toggle-fit)
+  ;; Evil normal state (shadows evil-find-char-to, useless here).
+  (with-eval-after-load 'evil
+    (general-define-key
+     :states 'normal
+     :keymaps 'image-mode-map
+     "t" #'zetta-image-toggle-fit)))
+;;; image.el ends here

--- a/modules/core/image.el
+++ b/modules/core/image.el
@@ -11,6 +11,18 @@
 (defvar zetta-image-inline-height-fraction 0.33
   "Max height of inline document images, as a fraction of the frame height.")
 
+;; Emacs built with ImageMagick routes image-mode through IM for
+;; almost every format (image--imagemagick-wanted-p), and IM
+;; PRE-RESAMPLES the bitmap to the window's logical size — on a 2x
+;; display that bitmap is then pixel-doubled: guaranteed blur, in
+;; image buffers and inline images alike.  Inhibit IM entirely: the
+;; native pipeline keeps the original bitmap and scales at draw time
+;; at device resolution (browser-sharp).  Everything actually viewed
+;; here (png/jpeg/gif/webp/svg/tiff/heic) has native support; only
+;; IM's exotic formats (PSD, DDS, RAW…) and arbitrary-angle rotation
+;; are lost.
+(setq imagemagick-types-inhibit t)
+
 (defvar zetta-image--remote-cache (make-hash-table :test 'equal)
   "URL -> downloaded temp file, for popping out remote images.")
 

--- a/modules/lang/markdown.el
+++ b/modules/lang/markdown.el
@@ -1,0 +1,88 @@
+;;; markdown.el --- Configure markdown-mode -*- lexical-binding: t; -*-
+
+;; Inline image handling for markdown buffers:
+;; - Inline images (C-c C-x C-i) are capped to a fraction of the frame
+;;   height so large diagrams never dominate the buffer.
+;; - C-c C-x v pops the image link at point into another window fit to
+;;   the window height; with a prefix arg (C-u) it fits to width.
+;;   Inside the image buffer, evil-collection's H / W switch between
+;;   fit-height / fit-width, and q quits.
+
+(declare-function markdown-link-url "markdown-mode")
+(declare-function markdown--get-remote-image "markdown-mode")
+(declare-function url-type "url-parse")
+(declare-function url-generic-parse-url "url-parse")
+(declare-function zetta-image-pop-out-file "image")
+(defvar markdown-max-image-size)
+(defvar markdown-translate-filename-function)
+(defvar markdown-remote-image-protocols)
+(defvar zetta-image-inline-height-fraction)
+
+(defun zetta-markdown--cap-inline-image-size (&rest _)
+  "Recompute `markdown-max-image-size' from the selected frame's size.
+Height is capped at `zetta-image-inline-height-fraction' of the
+frame height, width at the full frame width."
+  (setq markdown-max-image-size
+        (cons (frame-pixel-width)
+              (truncate (* zetta-image-inline-height-fraction
+                           (frame-pixel-height))))))
+
+(defun zetta-markdown--html-img-src ()
+  "Return the src of an HTML <img> tag on the current line, or nil.
+Documents like the system-design-primer README embed images as raw
+HTML blocks, which `markdown-link-url' does not parse."
+  (save-excursion
+    (goto-char (line-beginning-position))
+    (when (re-search-forward
+           "<img[^>]*?[ \t]src=[\"']?\\([^\"' >]+\\)"
+           (line-end-position) t)
+      (match-string-no-properties 1))))
+
+(defun zetta-markdown--image-file-at-point ()
+  "Return a local file for the image link at point, or nil.
+Remote images are downloaded into markdown-mode's image cache.
+Mirrors the path resolution in `markdown-display-inline-images'.
+Recognizes both markdown image links and raw HTML <img> tags."
+  (let ((url (or (markdown-link-url) (zetta-markdown--html-img-src))))
+    (when url
+      (if (file-exists-p url)
+          (expand-file-name url)
+        (let* ((translated (funcall markdown-translate-filename-function url))
+               (scheme (ignore-errors
+                         (downcase (url-type (url-generic-parse-url
+                                              translated)))))
+               ;; Count plain http as remote too (the primer's solution
+               ;; docs use http://i.imgur.com links); fetch via https.
+               (remotep (member scheme
+                                (cons "http" markdown-remote-image-protocols))))
+          (if remotep
+              (markdown--get-remote-image
+               (if (equal scheme "http")
+                   (concat "https" (substring translated (length "http")))
+                 translated))
+            (let ((file (replace-regexp-in-string "?.+\\'" "" url)))
+              (unless (file-exists-p file)
+                (setq file (url-unhex-string file)))
+              (when (file-exists-p file)
+                (expand-file-name file)))))))))
+
+(defun zetta-markdown-pop-out-image (&optional fit-width)
+  "Display the image link at point in another window.
+See `zetta-image-pop-out-file' for the fit behavior; with prefix
+argument FIT-WIDTH, fit to the window width."
+  (interactive "P")
+  (let ((file (zetta-markdown--image-file-at-point)))
+    (unless file
+      (user-error "No image link at point"))
+    (zetta-image-pop-out-file file fit-width)))
+
+;; markdown-mode is installed by elpaca as a dependency of markdown-toc;
+;; configure it once it loads rather than queueing a duplicate order.
+(with-eval-after-load 'markdown-mode
+  (advice-add 'markdown-display-inline-images :before
+              #'zetta-markdown--cap-inline-image-size)
+  (general-define-key
+   :keymaps 'markdown-mode-map
+   "C-c v" #'zetta-markdown-pop-out-image
+   "C-c C-x v" #'zetta-markdown-pop-out-image))
+;;; markdown.el ends here

--- a/modules/lang/markdown.el
+++ b/modules/lang/markdown.el
@@ -119,7 +119,23 @@ Pushes the mark so jumping back works."
 
 ;; markdown-mode is installed by elpaca as a dependency of markdown-toc;
 ;; configure it once it loads rather than queueing a duplicate order.
+(defun zetta-markdown--native-inline-images (orig &rest args)
+  "Create inline images through the native pipeline, not ImageMagick.
+markdown-mode hardcodes (create-image file \\='imagemagick ...) for
+max-size capping whenever IM is available — pre-resampled to logical
+pixels and pixel-doubled on 2x displays, i.e. blurry.  Shadowing the
+availability check makes it fall through to its native :max-width
+branch, which scales at draw time at device resolution."
+  (require 'cl-lib)
+  (cl-letf* ((orig-fn (symbol-function 'image-type-available-p))
+             ((symbol-function 'image-type-available-p)
+              (lambda (type) (and (not (eq type 'imagemagick))
+                                  (funcall orig-fn type)))))
+    (apply orig args)))
+
 (with-eval-after-load 'markdown-mode
+  (advice-add 'markdown-display-inline-images :around
+              #'zetta-markdown--native-inline-images)
   (advice-add 'markdown-display-inline-images :before
               #'zetta-markdown--cap-inline-image-size)
   (advice-add 'markdown--browse-url :around

--- a/modules/lang/markdown.el
+++ b/modules/lang/markdown.el
@@ -76,6 +76,12 @@ argument FIT-WIDTH, fit to the window width."
       (user-error "No image link at point"))
     (zetta-image-pop-out-file file fit-width)))
 
+;; Wrap long lines instead of clipping them, mirroring the org-mode
+;; hook's (toggle-truncate-lines -1).  Covers gfm-mode too (derived).
+(defun zetta-markdown--no-truncate ()
+  (toggle-truncate-lines -1))
+(add-hook 'markdown-mode-hook #'zetta-markdown--no-truncate)
+
 ;; markdown-mode is installed by elpaca as a dependency of markdown-toc;
 ;; configure it once it loads rather than queueing a duplicate order.
 (with-eval-after-load 'markdown-mode

--- a/modules/lang/markdown.el
+++ b/modules/lang/markdown.el
@@ -82,11 +82,48 @@ argument FIT-WIDTH, fit to the window width."
   (toggle-truncate-lines -1))
 (add-hook 'markdown-mode-hook #'zetta-markdown--no-truncate)
 
+;; Follow GitHub-style intra-document anchor links ([text](#anchor)).
+;; For a bare "#fragment" URL, url-path-and-query returns an empty
+;; path, so markdown--browse-url's (> (length file) 0) check silently
+;; does nothing.  Jump to the heading whose GFM slug matches instead.
+(defun zetta-markdown--gfm-slug (text)
+  "GitHub-style anchor slug for heading TEXT.
+Downcase, strip everything but alphanumerics/spaces/hyphens,
+spaces become hyphens."
+  (let* ((s (downcase (string-trim text)))
+         (s (replace-regexp-in-string "[^[:alnum:][:space:]-]" "" s))
+         (s (replace-regexp-in-string "[[:space:]]+" "-" s)))
+    s))
+
+(defun zetta-markdown-goto-anchor (anchor)
+  "Jump to the heading matching ANCHOR (leading # optional).
+Pushes the mark so jumping back works."
+  (let ((target (if (string-prefix-p "#" anchor) (substring anchor 1) anchor))
+        (found nil))
+    (save-excursion
+      (goto-char (point-min))
+      (while (and (not found)
+                  (re-search-forward "^#+[ \t]+\\(.*\\)" nil t))
+        (when (string= target
+                       (zetta-markdown--gfm-slug (match-string-no-properties 1)))
+          (setq found (match-beginning 0)))))
+    (unless found (user-error "No heading matches anchor #%s" target))
+    (push-mark)
+    (goto-char found)))
+
+(defun zetta-markdown--browse-url-anchors (orig url)
+  "Handle in-document #fragment URLs before ORIG sees them."
+  (if (string-prefix-p "#" url)
+      (zetta-markdown-goto-anchor url)
+    (funcall orig url)))
+
 ;; markdown-mode is installed by elpaca as a dependency of markdown-toc;
 ;; configure it once it loads rather than queueing a duplicate order.
 (with-eval-after-load 'markdown-mode
   (advice-add 'markdown-display-inline-images :before
               #'zetta-markdown--cap-inline-image-size)
+  (advice-add 'markdown--browse-url :around
+              #'zetta-markdown--browse-url-anchors)
   (general-define-key
    :keymaps 'markdown-mode-map
    "C-c v" #'zetta-markdown-pop-out-image

--- a/modules/org/org-image.el
+++ b/modules/org/org-image.el
@@ -1,0 +1,65 @@
+;;; org-image.el --- Pop out and cap org inline images -*- lexical-binding: t; -*-
+
+;; Mirrors the markdown image workflow for org documents:
+;; - C-c v pops the image link at point into another window, fit to
+;;   the window (C-u: fit to width; t in the image buffer toggles the
+;;   fit axis).  Handles file:, attachment: and http(s) links.
+;; - Inline previews (org-link-preview, C-c C-x C-v) are capped to
+;;   `zetta-image-inline-height-fraction' of the frame height.
+;; (C-c C-x v stays org-copy-visible; markdown-mode binds C-c v too.)
+
+(declare-function org-element-context "org-element")
+(declare-function org-attach-expand "org-attach")
+(declare-function zetta-image--remote-file "image")
+(declare-function zetta-image-pop-out-file "image")
+(defvar zetta-image-inline-height-fraction)
+
+(defun zetta-org--image-file-at-point ()
+  "Return a local image file for the org link at point, or nil.
+Remote images are downloaded into `zetta-image--remote-cache'."
+  (let ((ctx (org-element-context)))
+    (when (eq (org-element-type ctx) 'link)
+      (let ((type (org-element-property :type ctx))
+            (path (org-element-property :path ctx)))
+        (cond
+         ((equal type "file")
+          (let ((f (expand-file-name path)))
+            (and (file-exists-p f) f)))
+         ((equal type "attachment")
+          (require 'org-attach)
+          (let ((f (ignore-errors (org-attach-expand path))))
+            (and f (file-exists-p f) f)))
+         ((member type '("http" "https"))
+          (zetta-image--remote-file (concat type ":" path))))))))
+
+(defun zetta-org-pop-out-image (&optional fit-width)
+  "Display the org image link at point in another window.
+See `zetta-image-pop-out-file' for the fit behavior; with prefix
+argument FIT-WIDTH, fit to the window width."
+  (interactive "P")
+  (let ((file (zetta-org--image-file-at-point)))
+    (unless file
+      (user-error "No image link at point"))
+    (zetta-image-pop-out-file file fit-width)))
+
+(defun zetta-org--cap-inline-image (image)
+  "Cap inline preview IMAGE to a fraction of the frame size.
+Filter-return advice for `org--create-inline-image'; only adds the
+max constraints when the spec doesn't set them itself."
+  (when (and (consp image) (eq (car image) 'image))
+    (let ((props (cdr image)))
+      (unless (plist-member props :max-height)
+        (nconc image (list :max-height
+                           (truncate (* zetta-image-inline-height-fraction
+                                        (frame-pixel-height))))))
+      (unless (plist-member props :max-width)
+        (nconc image (list :max-width (frame-pixel-width))))))
+  image)
+
+(with-eval-after-load 'org
+  (advice-add 'org--create-inline-image :filter-return
+              #'zetta-org--cap-inline-image)
+  (general-define-key
+   :keymaps 'org-mode-map
+   "C-c v" #'zetta-org-pop-out-image))
+;;; org-image.el ends here

--- a/modules/org/org-remark.el
+++ b/modules/org/org-remark.el
@@ -239,6 +239,23 @@ Gmail moves around), so they make a durable source identity."
 
   (setq org-remark-notes-file-name 'my-org-remark-notes-file-name)
 
+  ;; The first highlight in a new domain hits two prompts: auto-on's
+  ;; load path already visited the (nonexistent) notes file while its
+  ;; parent directory didn't exist, so at highlight time the revisit
+  ;; inside find-file-noselect sees file-writable-p nil → "read-only
+  ;; on disk.  Make buffer read-only, too?", and then save-buffer asks
+  ;; to create the directory.  Create the directory when a highlight
+  ;; is actually MADE — not in the notes-file-name function, which the
+  ;; load path calls for every page render and would litter the synced
+  ;; kb with empty per-domain dirs for pages never highlighted.
+  (defun my-org-remark-ensure-notes-dir (&rest _)
+    "Create the notes file's directory before a highlight is saved."
+    (when-let* ((path (org-remark-notes-get-file-name))
+                (dir (file-name-directory path)))
+      (unless (file-directory-p dir)
+        (make-directory dir t))))
+  (advice-add 'org-remark-highlight-mark :before #'my-org-remark-ensure-notes-dir)
+
   ;; EWW eww-readable integration
   (defun my-advice-eww-show-mode-org-remark (&rest _args)
     (org-remark-auto-on))

--- a/modules/org/org-remark.el
+++ b/modules/org/org-remark.el
@@ -317,12 +317,72 @@ Gmail moves around), so they make a durable source identity."
                        ;; new date every day
                        org-remark-highlight-date ,(my/org-remark-get-date)))
 
+  ;; Semantic pens beyond the generic default.  "question" marks
+  ;; brush-up-on-this-later passages in study guides (faint orange);
+  ;; "important" separates truly-important highlights from the routine
+  ;; ones (light purple).  Both carry the same date-link property as
+  ;; the default pen.
+  (defface zetta-org-remark-question-face
+    '((((background light)) :background "#FFE9D2")
+      (t :background "#4A3A28"))
+    "Faint orange highlight for the org-remark question pen.")
+
+  (defface zetta-org-remark-important-face
+    '((((background light)) :background "#EFE3F8")
+      (t :background "#403354"))
+    "Light purple highlight for the org-remark important pen.")
+
+  (org-remark-create "question"
+                     'zetta-org-remark-question-face
+                     `(CATEGORY "question"
+                       org-remark-highlight-date ,(my/org-remark-get-date)))
+
+  (org-remark-create "important"
+                     'zetta-org-remark-important-face
+                     `(CATEGORY "important"
+                       org-remark-highlight-date ,(my/org-remark-get-date)))
+
+  ;; Re-pen the highlight at point: prompts with the OTHER pens only
+  ;; (upstream org-remark-change includes the current one and offers
+  ;; raw function names).  Typical gestures: promote default →
+  ;; important, downgrade question → default once groked.
+  (defun zetta-org-remark-change-pen ()
+    "Switch the pen of the highlight at point, excluding its current pen."
+    (interactive)
+    (let* ((ov (org-remark-find-dwim))
+           (current (and ov (overlay-get ov 'org-remark-label)))
+           (type (and ov (overlay-get ov 'org-remark-type))))
+      (unless ov (user-error "No highlight at point"))
+      (let* ((label-of (lambda (fn)
+                         (string-remove-prefix "org-remark-mark-"
+                                               (symbol-name fn))))
+             ;; upstream registers sample pens (yellow, red-line) and
+             ;; the label-less base pen; only offer the deliberate ones
+             (noise '("org-remark-mark" "yellow" "red-line"))
+             (candidates
+              (seq-filter
+               (lambda (fn)
+                 (let ((label (funcall label-of fn)))
+                   (and (eql type (function-get fn 'org-remark-type))
+                        (not (string= label current))
+                        (not (member label noise)))))
+               org-remark-available-pens))
+             (table (mapcar (lambda (fn) (cons (funcall label-of fn) fn))
+                            candidates))
+             (choice (completing-read
+                      (format "Change pen (%s → ): " current)
+                      table nil t)))
+        (org-remark-change (cdr (assoc choice table))))))
+
   :bind (("C-c n m" . org-remark-mark-default)
+         ("C-c n q" . org-remark-mark-question)
+         ("C-c n i" . org-remark-mark-important)
          ("C-c n l" . org-remark-mark-line)
          :map org-remark-mode-map
          ("C-c n o" . org-remark-open)
          ("C-c n ]" . org-remark-view-next)
          ("C-c n [" . org-remark-view-prev)
          ("C-c n r" . org-remark-remove)
-         ("C-c n d" . org-remark-delete)))
+         ("C-c n d" . org-remark-delete)
+         ("C-c n c" . zetta-org-remark-change-pen)))
 ;;; org-remark.el ends here

--- a/modules/org/org-remark.el
+++ b/modules/org/org-remark.el
@@ -284,9 +284,21 @@ Gmail moves around), so they make a durable source identity."
   (add-to-list 'brushup-styles
                '(set-face-attribute
                  'org-remark-highlighter nil
-                 :background brushup-bg-2
-                 :underline brushup-bg-4
+                 :background brushup-bg-1
+                 :underline brushup-bg-3
                  ))
+
+  ;; symbol-overlay's overlays sit at priority 90 (set in
+  ;; modules/ui/symbol-overlay.el), while org-remark's carry none —
+  ;; so symbol highlights painted over remark highlights.  The remark
+  ;; highlight should win; 95 outranks symbol-overlay but org-remark
+  ;; has no overlay keymap, so symbol-overlay's keys still work inside
+  ;; a highlight.
+  (defun zetta-org-remark--bump-priority (ov)
+    (when (overlayp ov) (overlay-put ov 'priority 95))
+    ov)
+  (advice-add 'org-remark-highlight-make-overlay :filter-return
+              #'zetta-org-remark--bump-priority)
 
   ;; custom pens
   (defun my/org-remark-get-date ()

--- a/modules/org/org.el
+++ b/modules/org/org.el
@@ -95,6 +95,10 @@ TYPE is a character: ?a alphabetic, ?t timestamp, ?p priority, ?o TODO order."
         zetta-org-log-initial-schedule 'time
         org-outline-path-complete-in-steps nil
         org-refile-allow-creating-parent-nodes 'confirm
+        ;; Files themselves are refile targets (filed as top-level
+        ;; entries) — the flat (todo) files have no headings to file
+        ;; under, and the capture flow is inbox-first + refile-later.
+        org-refile-use-outline-path 'file
         org-refile-targets '((nil :maxlevel . 10)
                              (org-agenda-files :maxlevel . 10))
         org-src-window-setup 'plain
@@ -386,22 +390,31 @@ Set this in ~/.private.el before modules load.")
   ;; %a from a mu4e buffer captures a link back to the message.
   (when (locate-library "mu4e-org")
     (require 'mu4e-org))
+  ;; Two-gesture capture: notes land in the inbox (n, or N with an
+  ;; org backlink to wherever capture was invoked via %a); TODO-ing
+  ;; and routing happen later — C-c C-w in the capture buffer
+  ;; (org-capture-refile) files directly elsewhere when the target is
+  ;; already known.  The per-(todo)-file templates are retired: refile
+  ;; covers routing (org-refile-use-outline-path 'file makes the flat
+  ;; todo files themselves valid targets).  m stays as the mail
+  ;; specialization — the sender/subject prefill has no generic
+  ;; equivalent (%:fromname/%:subject only bind in mail buffers).
   (setq org-capture-templates
-        (append
-         '(("o" "Simple capture"
-            entry
-            (file "~/kb/inbox.org")
-            "* %?\n%a"
-            :prepend t)
-           ;; Mail TODOs land in the email todo file (agenda-visible via
-           ;; the (todo)-file scan), not the general inbox.  CREATED
-           ;; drawer matches the generated todo-file templates.
-           ("m" "Mail (capture message link)"
-            entry
-            (file "~/kb/todo/(todo) email.org")
-            "* TODO %:fromname: %:subject\n:PROPERTIES:\n:CREATED: %U\n:END:\n%a\n%?"
-            :prepend t))
-         (zetta-logseq-generate-capture-templates)))
+        '(("n" "Note"
+           entry
+           (file "~/kb/inbox.org")
+           "* %?\n:PROPERTIES:\n:CREATED: %U\n:END:\n"
+           :prepend t)
+          ("N" "Note (with backlink)"
+           entry
+           (file "~/kb/inbox.org")
+           "* %?\n:PROPERTIES:\n:CREATED: %U\n:END:\n%a\n"
+           :prepend t)
+          ("m" "Mail (capture message link)"
+           entry
+           (file "~/kb/todo/(todo) email.org")
+           "* TODO %:fromname: %:subject\n:PROPERTIES:\n:CREATED: %U\n:END:\n%a\n%?"
+           :prepend t)))
   (zetta-logseq-update-agenda-files))
 
 ;;; Log initial deadline/schedule creation

--- a/modules/org/org.el
+++ b/modules/org/org.el
@@ -393,10 +393,13 @@ Set this in ~/.private.el before modules load.")
             (file "~/kb/inbox.org")
             "* %?\n%a"
             :prepend t)
+           ;; Mail TODOs land in the email todo file (agenda-visible via
+           ;; the (todo)-file scan), not the general inbox.  CREATED
+           ;; drawer matches the generated todo-file templates.
            ("m" "Mail (capture message link)"
             entry
-            (file "~/kb/inbox.org")
-            "* TODO %:fromname: %:subject\n%a\n%?"
+            (file "~/kb/todo/(todo) email.org")
+            "* TODO %:fromname: %:subject\n:PROPERTIES:\n:CREATED: %U\n:END:\n%a\n%?"
             :prepend t))
          (zetta-logseq-generate-capture-templates)))
   (zetta-logseq-update-agenda-files))

--- a/modules/org/org.el
+++ b/modules/org/org.el
@@ -107,17 +107,65 @@ TYPE is a character: ?a alphabetic, ?t timestamp, ?p priority, ?o TODO order."
           ("emacs-lisp" . emacs-lisp) ("shell" . sh) ("sqlite" . sql)
           ("html" . web) ("js" . js2) ("jsx" . rjsx))
         org-table-shrunk-column-indicator "|"
+        ;; 4-letter states (2026-08-08 migration: STARTED→PROG,
+        ;; CANCELLED→NOPE; WAITING/NEXT/OBSOLETE had zero uses).
+        ;; PROG = in progress, WAIT = blocked externally, QUES = open
+        ;; question (pairs with the org-remark question pen), HOLD =
+        ;; paused by choice (backlog skill vocabulary), IDEA =
+        ;; someday/maybe, NOPE = cancelled.  Scheduling stays with
+        ;; org's SCHEDULED timestamps, not a state.
         org-todo-keywords
         '((sequence
            "TODO(t!)"
-           "STARTED(s!)"
-           "WAITING(w!)"
+           "PROG(p!)"
+           "WAIT(w!)"
+           "QUES(q!)"
            "HOLD(h!)"
-           "NEXT(n!)"
+           "IDEA(i!)"
            "|"
            "DONE(d!)"
-           "CANCELLED(c!)"
-           "OBSOLETE(o!)")))
+           "NOPE(n!)")))
+
+  ;; State faces: QUES in the question pen's orange family, IDEA in
+  ;; the important pen's purple family, NOPE struck through; all
+  ;; light/dark aware.  TODO and DONE keep org's stock faces.
+  (defface zetta-org-todo-prog
+    '((((background light)) :foreground "#1F6FB2" :weight bold)
+      (t :foreground "#6FB3E0" :weight bold))
+    "Face for the PROG todo keyword."
+    :group 'org-faces)
+  (defface zetta-org-todo-wait
+    '((((background light)) :foreground "#8A6D3B" :weight bold)
+      (t :foreground "#C9A66B" :weight bold))
+    "Face for the WAIT todo keyword."
+    :group 'org-faces)
+  (defface zetta-org-todo-ques
+    '((((background light)) :foreground "#C25E00" :weight bold)
+      (t :foreground "#E8A45C" :weight bold))
+    "Face for the QUES todo keyword."
+    :group 'org-faces)
+  (defface zetta-org-todo-hold
+    '((((background light)) :foreground "#767676" :weight bold)
+      (t :foreground "#9E9E9E" :weight bold))
+    "Face for the HOLD todo keyword."
+    :group 'org-faces)
+  (defface zetta-org-todo-idea
+    '((((background light)) :foreground "#7B4FA6" :weight bold)
+      (t :foreground "#B08FD6" :weight bold))
+    "Face for the IDEA todo keyword."
+    :group 'org-faces)
+  (defface zetta-org-todo-nope
+    '((((background light)) :foreground "#9A9A9A" :strike-through t)
+      (t :foreground "#7A7A7A" :strike-through t))
+    "Face for the NOPE todo keyword."
+    :group 'org-faces)
+  (setq org-todo-keyword-faces
+        '(("PROG" . zetta-org-todo-prog)
+          ("WAIT" . zetta-org-todo-wait)
+          ("QUES" . zetta-org-todo-ques)
+          ("HOLD" . zetta-org-todo-hold)
+          ("IDEA" . zetta-org-todo-idea)
+          ("NOPE" . zetta-org-todo-nope)))
 
   (defun orgtree-forward-orgtree (&optional arg)
     "Move ARG times to start of a set of the same orgtree characters."

--- a/modules/tools/flamegraph.el
+++ b/modules/tools/flamegraph.el
@@ -1,0 +1,18 @@
+;;; flamegraph.el --- Configure flamegraph -*- lexical-binding: t; -*-
+
+;; Flame graphs for the Emacs profiler, and for folded-stacks files
+;; from external profilers (perf, py-spy, rbspy).
+;;
+;; Workflow: M-x profiler-start … do the slow thing … M-x
+;; profiler-stop, then M-x flamegraph-profiler-report.  In the graph:
+;; RET/mouse-1 zooms into a frame, d describes it (parent, callees,
+;; self-time, annotated source snippet), f jumps to the source, l/r
+;; walk the navigation history.  External profiles come in via
+;; M-x flamegraph-find-profile (for perf, fold with -F +srcline to
+;; get source locations).
+
+(use-package flamegraph
+  :ensure (flamegraph :host github :repo "dgutov/emacs-flamegraph")
+  :commands (flamegraph-profiler-report flamegraph-find-profile))
+
+;;; flamegraph.el ends here

--- a/modules/tools/flamegraph.el
+++ b/modules/tools/flamegraph.el
@@ -11,8 +11,11 @@
 ;; M-x flamegraph-find-profile (for perf, fold with -F +srcline to
 ;; get source locations).
 
-(use-package flamegraph
-  :ensure (flamegraph :host github :repo "dgutov/emacs-flamegraph")
-  :commands (flamegraph-profiler-report flamegraph-find-profile))
+;; Package-Requires (emacs "30.1") — skip entirely on older Emacsen
+;; (the CI matrix includes 29.4, where elpaca would fail the build).
+(when (version<= "30.1" emacs-version)
+  (use-package flamegraph
+    :ensure (flamegraph :host github :repo "dgutov/emacs-flamegraph")
+    :commands (flamegraph-profiler-report flamegraph-find-profile)))
 
 ;;; flamegraph.el ends here

--- a/modules/tools/git-gutter.el
+++ b/modules/tools/git-gutter.el
@@ -18,6 +18,16 @@
   ;; inside a git repo.  A gutter is meaningless for these anyway.
   (setq git-gutter:disabled-modes
         '(image-mode doc-view-mode pdf-view-mode archive-mode tar-mode))
+  ;; The live-update idle timer is global and trusts buffer-local
+  ;; state blindly: async diff sentinels can leave git-gutter:enabled
+  ;; t in buffers where the mode never enabled (no vcs-type), and the
+  ;; timer then errors every tick — "Error running timer
+  ;; 'git-gutter:live-update': (wrong-type-argument arrayp nil)".
+  ;; Only live-update where the mode is actually on and initialized.
+  (defun zetta-git-gutter--live-update-sane-p (&rest _)
+    (and git-gutter-mode git-gutter:vcs-type))
+  (advice-add 'git-gutter:live-update :before-while
+              #'zetta-git-gutter--live-update-sane-p)
 
   ;; add indicator to margin showing the current line number
 

--- a/modules/tools/git-gutter.el
+++ b/modules/tools/git-gutter.el
@@ -11,6 +11,13 @@
   :config
   (setq git-gutter:window-width 2)
   (setq git-gutter:update-interval 2)
+  ;; Binary buffers: git-gutter:live-update writes the buffer to a
+  ;; temp file to diff it, and raw image/pdf bytes can't be utf-8
+  ;; encoded — Emacs pops the select-safe-coding-system warning +
+  ;; minibuffer prompt on every idle tick for any image visited
+  ;; inside a git repo.  A gutter is meaningless for these anyway.
+  (setq git-gutter:disabled-modes
+        '(image-mode doc-view-mode pdf-view-mode archive-mode tar-mode))
 
   ;; add indicator to margin showing the current line number
 

--- a/modules/ui/spacetree.el
+++ b/modules/ui/spacetree.el
@@ -78,17 +78,37 @@ value isn't an integer (`zetta-circle-number' returns nil in those cases)."
 ;; padding is needed here.  Degrades to a no-op if space-tree ever
 ;; drops the wrapper.  Text properties (bold selected space) survive
 ;; the substring operations.
+(defface zetta-space-tree-selected
+  '((t :foreground "#6c4dab" :weight bold))
+  "The selected space at each level of the tab-bar lighter.
+Same purple as `zetta-tab-bar-svg-icon-color' \u2014 color alone marks
+the current space; no apostrophe."
+  :group 'space-tree)
+
 (defun zetta-space-tree--plain-lighter (s)
-  "Remove the brace wrapper and trailing whitespace from lighter string S.
-Ends with a no-break space: the circled glyphs ink wider than their
-reported advance, and without right padding the last one clips at
-the frame edge (the brace used to absorb the overhang).  NBSP
-because it is not XML whitespace, so svg-line's SVG text cannot
-collapse it the way a plain trailing space would be."
-  (concat
-   (string-trim-right
-    (string-remove-suffix "}" (string-remove-prefix "{ " s)))
-   "\u00A0"))
+  "Clean up lighter string S for the svg-line tab bar.
+Removes the brace wrapper and space-tree's apostrophe
+selected-markers; the selected space at every level is instead
+recolored purple (`zetta-space-tree-selected', replacing the bold
+face the package applies).  Ends with a no-break space: the circled
+glyphs ink wider than their reported advance, and without right
+padding the last one clips at the frame edge \u2014 NBSP because it is
+not XML whitespace, so svg-line's SVG text cannot collapse it the
+way a plain trailing space would be."
+  (let* ((s (string-remove-prefix "{ " s))
+         (s (string-remove-suffix "}" s))
+         (s (string-replace "'" "" s))
+         (s (string-trim-right s))
+         (len (length s))
+         (pos 0))
+    (while (< pos len)
+      (let ((face (get-text-property pos 'face s))
+            (next (or (next-single-property-change pos 'face s) len)))
+        (when (or (eq face 'bold)
+                  (and (listp face) (memq 'bold face)))
+          (put-text-property pos next 'face 'zetta-space-tree-selected s))
+        (setq pos next)))
+    (concat s "\u00A0")))
 
 (with-eval-after-load 'space-tree
   (advice-add 'space-tree-modeline-lighter

--- a/modules/ui/spacetree.el
+++ b/modules/ui/spacetree.el
@@ -79,9 +79,16 @@ value isn't an integer (`zetta-circle-number' returns nil in those cases)."
 ;; drops the wrapper.  Text properties (bold selected space) survive
 ;; the substring operations.
 (defun zetta-space-tree--plain-lighter (s)
-  "Remove the brace wrapper and trailing whitespace from lighter string S."
-  (string-trim-right
-   (string-remove-suffix "}" (string-remove-prefix "{ " s))))
+  "Remove the brace wrapper and trailing whitespace from lighter string S.
+Ends with a no-break space: the circled glyphs ink wider than their
+reported advance, and without right padding the last one clips at
+the frame edge (the brace used to absorb the overhang).  NBSP
+because it is not XML whitespace, so svg-line's SVG text cannot
+collapse it the way a plain trailing space would be."
+  (concat
+   (string-trim-right
+    (string-remove-suffix "}" (string-remove-prefix "{ " s)))
+   "\u00A0"))
 
 (with-eval-after-load 'space-tree
   (advice-add 'space-tree-modeline-lighter

--- a/modules/ui/spacetree.el
+++ b/modules/ui/spacetree.el
@@ -113,3 +113,28 @@ way a plain trailing space would be."
 (with-eval-after-load 'space-tree
   (advice-add 'space-tree-modeline-lighter
               :filter-return #'zetta-space-tree--plain-lighter))
+
+;; svg-line strips text properties when flattening tab-bar segments
+;; (svg-line--item->string → substring-no-properties), so the purple
+;; face above never reaches the SVG.  Color has to travel through
+;; svg-line's segment DSL instead: emit the lighter as (:svg-segs …)
+;; with the selected pieces as (:svg-seg TXT :color purple) runs and
+;; the rest as plain text.  This replaces the bare
+;; space-tree-modeline-lighter entry in the tab-bar format
+;; (tab-bar-svg.el).
+(defun zetta-tab-bar-space-tree ()
+  "Space-tree lighter as svg-line segments, selected spaces in purple."
+  (let* ((s (space-tree-modeline-lighter))  ; advised: cleaned + faced
+         (len (length s))
+         (pos 0)
+         (items nil))
+    (while (< pos len)
+      (let* ((face (get-text-property pos 'face s))
+             (next (or (next-single-property-change pos 'face s) len))
+             (txt (substring-no-properties s pos next)))
+        (push (if (eq face 'zetta-space-tree-selected)
+                  (list :svg-seg txt :color "#6c4dab")
+                txt)
+              items)
+        (setq pos next)))
+    (cons :svg-segs (nreverse items))))

--- a/modules/ui/spacetree.el
+++ b/modules/ui/spacetree.el
@@ -69,72 +69,27 @@ value isn't an integer (`zetta-circle-number' returns nil in those cases)."
 (with-eval-after-load 'space-tree
   (advice-add 'space-tree--modeline-string-for-level
               :around #'zetta-space-tree--circle-numbers))
-
-;; Strip the lighter's hardcoded "{ … }" wrapper and trailing space:
-;; the braces plus each label's own trailing space (and the circled
-;; glyphs' side bearings) made the whitespace around the numbers
-;; uneven in the svg-line tab bar.  The icon gap comes from the
-;; zetta-insert-space preceding the lighter in tab-bar-svg.el, so no
-;; padding is needed here.  Degrades to a no-op if space-tree ever
-;; drops the wrapper.  Text properties (bold selected space) survive
-;; the substring operations.
-(defface zetta-space-tree-selected
-  '((t :foreground "#6c4dab" :weight bold))
-  "The selected space at each level of the tab-bar lighter.
-Same purple as `zetta-tab-bar-svg-icon-color' \u2014 color alone marks
-the current space; no apostrophe."
-  :group 'space-tree)
-
+;; The svg-line tab bar renders this lighter through
+;; `zetta-tab-bar-svg--workspace' (line-utils.el), which splits it
+;; into per-token segments, detects each level's selected space by
+;; space-tree's trailing apostrophe, DROPS the apostrophe itself, and
+;; colors that token with `zetta-tab-bar-svg-active-space-color' (the
+;; masthead purple).  So this advice must NOT touch the apostrophes —
+;; they are the selection signal.  It only:
+;;   1. strips the hardcoded "{ … }" wrapper (the bracket clutter),
+;;   2. appends " " + NBSP, which survives the workspace splitter as
+;;      a standalone trailing padding token: the circled glyphs ink
+;;      wider than their reported advance, and without a final
+;;      padding segment the last one clips at the frame edge (the
+;;      brace used to absorb the overhang).  NBSP because it is not
+;;      XML whitespace, so svg-line's SVG text cannot collapse it.
 (defun zetta-space-tree--plain-lighter (s)
-  "Clean up lighter string S for the svg-line tab bar.
-Removes the brace wrapper and space-tree's apostrophe
-selected-markers; the selected space at every level is instead
-recolored purple (`zetta-space-tree-selected', replacing the bold
-face the package applies).  Ends with a no-break space: the circled
-glyphs ink wider than their reported advance, and without right
-padding the last one clips at the frame edge \u2014 NBSP because it is
-not XML whitespace, so svg-line's SVG text cannot collapse it the
-way a plain trailing space would be."
-  (let* ((s (string-remove-prefix "{ " s))
-         (s (string-remove-suffix "}" s))
-         (s (string-replace "'" "" s))
-         (s (string-trim-right s))
-         (len (length s))
-         (pos 0))
-    (while (< pos len)
-      (let ((face (get-text-property pos 'face s))
-            (next (or (next-single-property-change pos 'face s) len)))
-        (when (or (eq face 'bold)
-                  (and (listp face) (memq 'bold face)))
-          (put-text-property pos next 'face 'zetta-space-tree-selected s))
-        (setq pos next)))
-    (concat s "\u00A0")))
+  "Strip the brace wrapper from lighter S; keep apostrophes, add padding."
+  (concat
+   (string-trim-right
+    (string-remove-suffix "}" (string-remove-prefix "{ " s)))
+   " \u00A0"))
 
 (with-eval-after-load 'space-tree
   (advice-add 'space-tree-modeline-lighter
               :filter-return #'zetta-space-tree--plain-lighter))
-
-;; svg-line strips text properties when flattening tab-bar segments
-;; (svg-line--item->string → substring-no-properties), so the purple
-;; face above never reaches the SVG.  Color has to travel through
-;; svg-line's segment DSL instead: emit the lighter as (:svg-segs …)
-;; with the selected pieces as (:svg-seg TXT :color purple) runs and
-;; the rest as plain text.  This replaces the bare
-;; space-tree-modeline-lighter entry in the tab-bar format
-;; (tab-bar-svg.el).
-(defun zetta-tab-bar-space-tree ()
-  "Space-tree lighter as svg-line segments, selected spaces in purple."
-  (let* ((s (space-tree-modeline-lighter))  ; advised: cleaned + faced
-         (len (length s))
-         (pos 0)
-         (items nil))
-    (while (< pos len)
-      (let* ((face (get-text-property pos 'face s))
-             (next (or (next-single-property-change pos 'face s) len))
-             (txt (substring-no-properties s pos next)))
-        (push (if (eq face 'zetta-space-tree-selected)
-                  (list :svg-seg txt :color "#6c4dab")
-                txt)
-              items)
-        (setq pos next)))
-    (cons :svg-segs (nreverse items))))

--- a/modules/ui/spacetree.el
+++ b/modules/ui/spacetree.el
@@ -69,3 +69,20 @@ value isn't an integer (`zetta-circle-number' returns nil in those cases)."
 (with-eval-after-load 'space-tree
   (advice-add 'space-tree--modeline-string-for-level
               :around #'zetta-space-tree--circle-numbers))
+
+;; Strip the lighter's hardcoded "{ … }" wrapper and trailing space:
+;; the braces plus each label's own trailing space (and the circled
+;; glyphs' side bearings) made the whitespace around the numbers
+;; uneven in the svg-line tab bar.  The icon gap comes from the
+;; zetta-insert-space preceding the lighter in tab-bar-svg.el, so no
+;; padding is needed here.  Degrades to a no-op if space-tree ever
+;; drops the wrapper.  Text properties (bold selected space) survive
+;; the substring operations.
+(defun zetta-space-tree--plain-lighter (s)
+  "Remove the brace wrapper and trailing whitespace from lighter string S."
+  (string-trim-right
+   (string-remove-suffix "}" (string-remove-prefix "{ " s))))
+
+(with-eval-after-load 'space-tree
+  (advice-add 'space-tree-modeline-lighter
+              :filter-return #'zetta-space-tree--plain-lighter))

--- a/modules/ui/symbol-overlay.el
+++ b/modules/ui/symbol-overlay.el
@@ -47,9 +47,19 @@
 
   (global-set-key (kbd "s-.") 'symbol-overlay-transient)
 
+  ;; The auto-highlight face's stock #f0f0f0 is indistinguishable from
+  ;; the org-remark default highlighter (brushup-bg-1) — use the
+  ;; half-step between pure background and bg-1: visibly lighter than
+  ;; a remark highlight, still detectable, theme-adaptive.
+  (add-to-list 'brushup-styles
+               '(set-face-attribute
+                 'symbol-overlay-default-face nil
+                 :background brushup-bg-1_0))
+  (when (fboundp 'brushup) (brushup))
+
   ;; modes
   :hook ((sql-mode python-ts-mode emacs-lisp-mode yaml-mode
                    jsonian-mode json-mode web-mode shell-command-mode sh-mode grep-mode
-                   lark-mode makefile-mode helpful-mode org-mode terraform-mode) .
+                   lark-mode makefile-mode helpful-mode org-mode terraform-mode eww-mode) .
                    symbol-overlay-mode))
 ;;; symbol-overlay.el ends here

--- a/modules/ui/tab-bar-svg.el
+++ b/modules/ui/tab-bar-svg.el
@@ -205,7 +205,10 @@ The sunrise/sunset flank and the date/moon-phase widget were removed."
           recursion-indicator--string tab-bar-format-global
           internal-echo-keystrokes-prefix
           zetta-insert-space zetta-current-prefix zetta-insert-space
-          space-tree-modeline-lighter
+          ;; svg-line segment wrapper (spacetree.el) — colors the
+          ;; selected spaces purple; text properties don't survive
+          ;; svg-line's flattening, so the bare lighter can't.
+          zetta-tab-bar-space-tree
           )))
 
 (add-to-list 'brushup-styles

--- a/modules/ui/tab-bar-svg.el
+++ b/modules/ui/tab-bar-svg.el
@@ -205,10 +205,7 @@ The sunrise/sunset flank and the date/moon-phase widget were removed."
           recursion-indicator--string tab-bar-format-global
           internal-echo-keystrokes-prefix
           zetta-insert-space zetta-current-prefix zetta-insert-space
-          ;; svg-line segment wrapper (spacetree.el) — colors the
-          ;; selected spaces purple; text properties don't survive
-          ;; svg-line's flattening, so the bare lighter can't.
-          zetta-tab-bar-space-tree
+          space-tree-modeline-lighter
           )))
 
 (add-to-list 'brushup-styles

--- a/source/op-secrets.env.tpl
+++ b/source/op-secrets.env.tpl
@@ -4,7 +4,13 @@ SPOTIFY_REFRESH_TOKEN={{ op://Dev/Spotify/refresh-token }}
 WALLABAG_PASSWORD={{ op://Dev/Wallabag/password }}
 WALLABAG_CLIENT_ID={{ op://Dev/Wallabag/client-id }}
 WALLABAG_CLIENT_SECRET={{ op://Dev/Wallabag/client-secret }}
-MINIFLUX_PASSWORD={{ op://Dev/Miniflux/password }}
+# Two Dev items share the Miniflux name (2026-08-03), so it is
+# ambiguous and would fail the whole inject — reference by item ID.
+# khjv... = original (fever password), dzoj... = api-key item.
+# Collapse back to name-based refs once consolidated.  NB: op inject
+# resolves op-scheme URIs even inside comments; never quote one here.
+MINIFLUX_PASSWORD={{ op://Dev/khjv4m35sqe66tvssor3ldvx4m/password }}
+MINIFLUX_API_KEY={{ op://Dev/dzojnnugzyp4tiiqpjel4hz2ym/api-key }}
 POSTGRESQL_LOCAL_PASSWORD={{ op://Dev/PostgreSQL-Local/password }}
 REDDIT_CLIENT_ID={{ op://Dev/Reddit/client-id }}
 REDDIT_CLIENT_SECRET={{ op://Dev/Reddit/client-secret }}

--- a/source/op-secrets.env.tpl
+++ b/source/op-secrets.env.tpl
@@ -7,6 +7,7 @@ WALLABAG_CLIENT_SECRET={{ op://Dev/Wallabag/client-secret }}
 MINIFLUX_PASSWORD={{ op://Dev/Miniflux/password }}
 POSTGRESQL_LOCAL_PASSWORD={{ op://Dev/PostgreSQL-Local/password }}
 REDDIT_CLIENT_ID={{ op://Dev/Reddit/client-id }}
+REDDIT_CLIENT_SECRET={{ op://Dev/Reddit/client-secret }}
 REDDIT_REFRESH_TOKEN={{ op://Dev/Reddit/refresh-token }}
 REDDIT_ACCESS_TOKEN={{ op://Dev/Reddit/access-token }}
 PUBMED_API_KEY={{ op://Dev/PubMed/api-key }}


### PR DESCRIPTION
A week of daily-driver improvements, verified live in-session throughout.

## Mail (nano-mu4e / org-msg)
- Keybindings: headers `r` = mark-read (normal + visual region, working around the region-marking incompatibility under nano's multi-line boxes), `RET` views the message (was triggering the sender's from: search button), view `r` = reply, `e` prompts for attachment save dir, compose `C-RET` sends (keeping `C-c C-c` for org)
- Thread fork glyphs (├/└) restored in the headers view
- Preview pipeline: charset fallback utf-8, unreadable-path-safe (mark-execute race), message-id-keyed persistent cache + libxml extraction — 29s renders down to ~1s cold / 0.05s warm
- Brushup `:brushup` keyword ordering fix (faces reverted to defaults every fresh startup)

## Reddit (md4rd / reddigg)
- All reads routed through oauth.reddit.com with auto-refreshing tokens (Reddit 403-blocks the unauthenticated endpoints md4rd/reddigg use); token requests authenticate with the web-app client secret
- 100-post listings, tab-line in md4rd buffers, plain-text tree glyphs, live-update guard for half-initialized buffers, org backlinks from listing/comments
- reddigg added as a parallel trial (same OAuth layer via its single fetch choke point)

## Feeds (elfeed / miniflux)
- elfeed.org is now the single source of truth: `zetta-elfeed-miniflux-sync` diffs org feeds against Miniflux's REST API and pushes additions (C-u = dry run)
- `gc` opens reddit comments from the search listing
- org-link store backend for elfeed entries (portable https links; elfeed-link's filter-storing :store disabled)

## Capture & org
- Inbox-first capture: `n`/`N` (note / note+backlink) → kb inbox, refile-later via C-c C-w with files as targets; per-todo-file templates retired
- %a backlink backends for elfeed, md4rd, and mastodon (boost-aware)
- 4-letter todo states (TODO PROG WAIT QUES HOLD IDEA | DONE NOPE) with faces; STARTED/CANCELLED migrated across kb and chiply.dev
- org-remark: question/important pens + pen switcher (C-c n q/i/c), lighter highlighter gray, highlights win over symbol-overlay, notes dirs auto-created

## Reading & images
- Retina-sharp images: ImageMagick pipeline inhibited (image-mode + markdown-mode's hardcoded IM path), always-interpolate scaling
- Clean image buffers: no line numbers / hl-line stripe / cursor bar
- Markdown: HTML `<img>` pop-out support, GitHub-anchor link following, truncate-lines off
- git-gutter disabled in binary modes (coding-system prompt storm on images in repos)
- eww: org-remark notes dir creation, per-dir read-only immutable sources with writable annotations

## UI
- space-tree tab-bar lighter: brace wrapper stripped, NBSP overhang padding, selected-space purple via the existing workspace cluster
- symbol-overlay half-step gray, distinguishable from remark highlights

## Misc
- flamegraph + bluesky + reddigg modules (lockfile pins), auth-source wildcard fix for the 1Password backend, Miniflux/Reddit secret template entries